### PR TITLE
Added support for new V1 routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+.env

--- a/port/cli/blueprint.go
+++ b/port/cli/blueprint.go
@@ -8,11 +8,11 @@ import (
 
 func (c *PortClient) ReadBlueprint(ctx context.Context, id string) (*Blueprint, error) {
 	pb := &PortBody{}
-	url := "v0.1/blueprints/{identifier}"
+	url := "v1/blueprints/{identifier}"
 	resp, err := c.Client.R().
 		SetContext(ctx).
 		SetHeader("Accept", "application/json").
-		SetQueryParam("exclude_mirror_properties", "true").
+		SetQueryParam("exclude_calculated_properties", "true").
 		SetResult(pb).
 		SetPathParam("identifier", id).
 		Get(url)
@@ -26,7 +26,7 @@ func (c *PortClient) ReadBlueprint(ctx context.Context, id string) (*Blueprint, 
 }
 
 func (c *PortClient) CreateBlueprint(ctx context.Context, b *Blueprint) (*Blueprint, error) {
-	url := "v0.1/blueprints"
+	url := "v1/blueprints"
 	resp, err := c.Client.R().
 		SetBody(b).
 		SetContext(ctx).
@@ -46,7 +46,7 @@ func (c *PortClient) CreateBlueprint(ctx context.Context, b *Blueprint) (*Bluepr
 }
 
 func (c *PortClient) UpdateBlueprint(ctx context.Context, b *Blueprint, id string) (*Blueprint, error) {
-	url := "v0.1/blueprints/{identifier}"
+	url := "v1/blueprints/{identifier}"
 	resp, err := c.Client.R().
 		SetBody(b).
 		SetContext(ctx).
@@ -67,7 +67,7 @@ func (c *PortClient) UpdateBlueprint(ctx context.Context, b *Blueprint, id strin
 }
 
 func (c *PortClient) DeleteBlueprint(ctx context.Context, id string) error {
-	url := "v0.1/blueprints/{identifier}"
+	url := "v1/blueprints/{identifier}"
 	resp, err := c.Client.R().
 		SetContext(ctx).
 		SetHeader("Accept", "application/json").

--- a/port/cli/client.go
+++ b/port/cli/client.go
@@ -42,7 +42,7 @@ func New(baseURL string, opts ...Option) (*PortClient, error) {
 }
 
 func (c *PortClient) Authenticate(ctx context.Context, clientID, clientSecret string) (string, error) {
-	url := "v0.1/auth/access_token"
+	url := "v1/auth/access_token"
 	resp, err := c.Client.R().
 		SetContext(ctx).
 		SetQueryParam("client_id", clientID).

--- a/port/cli/entity.go
+++ b/port/cli/entity.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 )
 
-func (c *PortClient) ReadEntity(ctx context.Context, id string) (*Entity, error) {
-	url := "v0.1/entities/{identifier}"
+func (c *PortClient) ReadEntity(ctx context.Context, id string, blueprint string) (*Entity, error) {
+	url := "v1/blueprints/{blueprint}/entities/{identifier}"
 	resp, err := c.Client.R().
 		SetHeader("Accept", "application/json").
-		SetQueryParam("exclude_mirror_properties", "true").
+		SetQueryParam("exclude_calculated_properties", "true").
+		SetPathParam(("blueprint"), blueprint).
 		SetPathParam("identifier", id).
 		Get(url)
 	if err != nil {
@@ -25,10 +26,11 @@ func (c *PortClient) ReadEntity(ctx context.Context, id string) (*Entity, error)
 }
 
 func (c *PortClient) CreateEntity(ctx context.Context, e *Entity) (*Entity, error) {
-	url := "v0.1/entities"
+	url := "v1/blueprints/{blueprint}/entities"
 	pb := &PortBody{}
 	resp, err := c.Client.R().
 		SetBody(e).
+		SetPathParam(("blueprint"), e.Blueprint).
 		SetQueryParam("upsert", "true").
 		SetResult(&pb).
 		Post(url)
@@ -41,11 +43,12 @@ func (c *PortClient) CreateEntity(ctx context.Context, e *Entity) (*Entity, erro
 	return &pb.Entity, nil
 }
 
-func (c *PortClient) DeleteEntity(ctx context.Context, id string) error {
-	url := "v0.1/entities/{identifier}"
+func (c *PortClient) DeleteEntity(ctx context.Context, id string, blueprint string) error {
+	url := "v1/blueprints/{blueprint}/entities/{identifier}"
 	pb := &PortBody{}
 	resp, err := c.Client.R().
 		SetHeader("Accept", "application/json").
+		SetPathParam("blueprint", blueprint).
 		SetPathParam("identifier", id).
 		SetResult(pb).
 		Delete(url)

--- a/port/cli/permission.go
+++ b/port/cli/permission.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (c *PortClient) CreatePermissions(ctx context.Context, clientID string, scopes ...string) error {
-	url := "v0.1/apps/{app_id}/permissions"
+	url := "v1/apps/{app_id}/permissions"
 	resp, err := c.Client.R().
 		SetContext(ctx).
 		SetHeader("Accept", "application/json").

--- a/port/cli/relation.go
+++ b/port/cli/relation.go
@@ -6,7 +6,7 @@ import (
 )
 
 func (c *PortClient) CreateRelation(ctx context.Context, bpID string, r *Relation) (string, error) {
-	url := "v0.1/blueprints/{identifier}/relations"
+	url := "v1/blueprints/{identifier}/relations"
 	result := map[string]interface{}{}
 	resp, err := c.Client.R().
 		SetBody(r).
@@ -24,7 +24,7 @@ func (c *PortClient) CreateRelation(ctx context.Context, bpID string, r *Relatio
 }
 
 func (c *PortClient) ReadRelations(ctx context.Context, blueprintID string) ([]*Relation, error) {
-	url := "v0.1/relations"
+	url := "v1/relations"
 	result := map[string]interface{}{}
 	resp, err := c.Client.R().
 		SetContext(ctx).

--- a/port/resource_port_entity.go
+++ b/port/resource_port_entity.go
@@ -111,7 +111,7 @@ func newEntityResource() *schema.Resource {
 func deleteEntity(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := m.(*cli.PortClient)
-	err := c.DeleteEntity(ctx, d.Id())
+	err := c.DeleteEntity(ctx, d.Id(), d.Get("blueprint").(string))
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -245,7 +245,7 @@ func createEntity(ctx context.Context, d *schema.ResourceData, m interface{}) di
 func readEntity(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var diags diag.Diagnostics
 	c := m.(*cli.PortClient)
-	e, err := c.ReadEntity(ctx, d.Id())
+	e, err := c.ReadEntity(ctx, d.Id(), d.Get("blueprint").(string))
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
As part of routes matuarity of Port.i, this PR adjusts the terraform provider to support V1 routes in Port.

## Changes
### Entity

Query string
exclude_mirror_properties -> exclude_calculated_properties

Routes changed to v1 instead of v0.1 
Identifier changed to be scoped by blueprint instead of global identifier

### Blueprint
Changed to use v1 rotues
