### PR TITLE
Port 1843 terraform provider support multiple types of default of a property

### DIFF
--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -57,6 +57,7 @@ Required:
 Optional:
 
 - `blueprint` (String) When selecting format 'entity', the identifier of the target blueprint
+- `default_items` (List of String) The list of default items, in case the type of this property is a list
 - `default` (String) A default value for this property in case an entity is created without explicitly providing a value.
 - `description` (String) A description of the property. This value is visible to users when hovering on the info icon in the UI. It provides detailed information about the use of a specific property.
 - `enum` (List of String) A list of allowed values for the property

--- a/docs/resources/blueprint.md
+++ b/docs/resources/blueprint.md
@@ -50,6 +50,7 @@ Required:
 
 Optional:
 
+- `default_items` (List of String) The list of default items, in case the type of this property is a list
 - `default` (String) The default value of the property
 - `description` (String) The description of the property
 - `enum` (List of String) A list of allowed values for the property

--- a/port/cli/models.go
+++ b/port/cli/models.go
@@ -32,7 +32,7 @@ type (
 		Type        string            `json:"type,omitempty"`
 		Title       string            `json:"title,omitempty"`
 		Identifier  string            `json:"identifier,omitempty"`
-		Default     string            `json:"default,omitempty"`
+		Default     interface{}       `json:"default,omitempty"`
 		Icon        string            `json:"icon,omitempty"`
 		Format      string            `json:"format,omitempty"`
 		Description string            `json:"description,omitempty"`

--- a/port/resource_port_action.go
+++ b/port/resource_port_action.go
@@ -2,6 +2,9 @@ package port
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -73,6 +76,14 @@ func newActionResource() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "A default value for this property in case an entity is created without explicitly providing a value.",
+						},
+						"default_items": {
+							Type:        schema.TypeList,
+							Optional:    true,
+							Description: "The list of items, in case the type of default property is a list",
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
 						},
 						"format": {
 							Type:        schema.TypeString,
@@ -170,7 +181,6 @@ func writeActionFieldsToResource(d *schema.ResourceData, action *cli.Action) {
 		p["title"] = v.Title
 		p["type"] = v.Type
 		p["description"] = v.Description
-		p["default"] = v.Default
 		p["format"] = v.Format
 		p["pattern"] = v.Pattern
 		p["blueprint"] = v.Blueprint
@@ -180,6 +190,25 @@ func writeActionFieldsToResource(d *schema.ResourceData, action *cli.Action) {
 		} else {
 			p["required"] = false
 		}
+		switch t := v.Default.(type) {
+		case map[string]interface{}:
+			js, _ := json.Marshal(&t)
+			p["default"] = string(js)
+		case []interface{}:
+			p["default_items"] = t
+		case float64:
+			p["default"] = strconv.FormatFloat(t, 'f', -1, 64)
+		case int:
+			p["default"] = strconv.Itoa(t)
+		case string:
+			p["default"] = t
+		case bool:
+			p["default"] = "false"
+			if t {
+				p["default"] = "true"
+			}
+		}
+
 		properties.Add(p)
 	}
 	d.Set("user_properties", &properties)
@@ -220,8 +249,20 @@ func actionResourceToBody(d *schema.ResourceData) (*cli.Action, error) {
 		if d, ok := p["description"]; ok && d != "" {
 			propFields.Description = d.(string)
 		}
-		if d, ok := p["default"]; ok && d != "" {
-			propFields.Default = d.(string)
+		switch propFields.Type {
+		case "string", "number", "boolean":
+			propFields.Default = p["default"]
+		case "array":
+			propFields.Default = p["default_items"]
+		case "object":
+			obj := make(map[string]interface{})
+			err := json.Unmarshal([]byte(p["default"].(string)), &obj)
+			if err != nil {
+				return nil, err
+			}
+			propFields.Default = obj
+		default:
+			return nil, fmt.Errorf("unsupported type %s", propFields.Type)
 		}
 		if f, ok := p["format"]; ok && f != "" {
 			propFields.Format = f.(string)

--- a/port/resource_port_action.go
+++ b/port/resource_port_action.go
@@ -253,11 +253,11 @@ func actionResourceToBody(d *schema.ResourceData) (*cli.Action, error) {
 		switch propFields.Type {
 		case "string", "number", "boolean":
 			if d, ok := p["default"]; ok && d != "" {
-				propFields.Default = d.(interface{})
+				propFields.Default = d
 			}
 		case "array":
 			if d, ok := p["default_items"]; ok && d != "" {
-				propFields.Default = d.(interface{})
+				propFields.Default = d
 			}
 		case "object":
 			if d, ok := p["default"]; ok && d != "" {

--- a/port/resource_port_action.go
+++ b/port/resource_port_action.go
@@ -251,22 +251,38 @@ func actionResourceToBody(d *schema.ResourceData) (*cli.Action, error) {
 			propFields.Description = d.(string)
 		}
 		switch propFields.Type {
-		case "string", "number", "boolean":
-			if d, ok := p["default"]; ok && d != "" {
-				propFields.Default = d
+		case "string":
+			if d, ok := p["default"]; ok && d.(string) != "" {
+				propFields.Default = d.(string)
 			}
-		case "array":
-			if d, ok := p["default_items"]; ok && d != "" {
-				propFields.Default = d
-			}
-		case "object":
-			if d, ok := p["default"]; ok && d != "" {
-				obj := make(map[string]interface{})
-				err := json.Unmarshal([]byte(d.(string)), &obj)
+		case "number":
+			if d, ok := p["default"]; ok && d.(string) != "" {
+				defaultNum, err := strconv.ParseInt(d.(string), 10, 0)
 				if err != nil {
 					return nil, err
 				}
-				propFields.Default = obj
+				propFields.Default = defaultNum
+			}
+		case "boolean":
+			if d, ok := p["default"]; ok && d.(string) != "" {
+				defaultBool, err := strconv.ParseBool(d.(string))
+				if err != nil {
+					return nil, err
+				}
+				propFields.Default = defaultBool
+			}
+		case "array":
+			if d, ok := p["default_items"]; ok && d != nil {
+				propFields.Default = d
+			}
+		case "object":
+			if d, ok := p["default"]; ok && d.(string) != "" {
+				defaultObj := make(map[string]interface{})
+				err := json.Unmarshal([]byte(d.(string)), &defaultObj)
+				if err != nil {
+					return nil, err
+				}
+				propFields.Default = defaultObj
 			}
 		}
 		if f, ok := p["format"]; ok && f != "" {

--- a/port/resource_port_action_test.go
+++ b/port/resource_port_action_test.go
@@ -35,6 +35,13 @@ func TestAccPortAction(t *testing.T) {
 			identifier = "clear_cache"
 			type = "boolean"
 			title = "Clear cache"
+			default = "true"
+		}
+		user_properties {
+			identifier = "services"
+			type = "array"
+			title = "Services"
+			default_items = ["api", "frontend"]
 		}
 	}
 `, identifier, actionIdentifier)
@@ -87,10 +94,13 @@ func TestAccPortAction(t *testing.T) {
 					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "blueprint_identifier", identifier),
 					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "invocation_method.0.type", "KAFKA"),
 					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "trigger", "DAY-2"),
-					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.#", "1"),
-					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.0.identifier", "clear_cache"),
-					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.0.type", "boolean"),
-					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.0.title", "Clear cache"),
+					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.#", "2"),
+					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.0.default_items.0", "api"),
+					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.0.default_items.#", "2"),
+					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.1.identifier", "clear_cache"),
+					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.1.type", "boolean"),
+					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.1.title", "Clear cache"),
+					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.1.default", "true"),
 				),
 			},
 			{

--- a/port/resource_port_action_test.go
+++ b/port/resource_port_action_test.go
@@ -32,16 +32,34 @@ func TestAccPortAction(t *testing.T) {
 			type = "KAFKA"
 		}
 		user_properties {
+			identifier = "reason"
+			type = "string"
+			title = "Reason"
+			default = "test"
+		}
+		user_properties {
+			identifier = "delay"
+			type = "number"
+			title = "Delay"
+			default = 3
+		}
+		user_properties {
 			identifier = "clear_cache"
 			type = "boolean"
 			title = "Clear cache"
-			default = "true"
+			default = true
 		}
 		user_properties {
 			identifier = "services"
 			type = "array"
 			title = "Services"
 			default_items = ["api", "frontend"]
+		}
+		user_properties {
+			identifier = "config"
+			type = "object"
+			title = "Config"
+			default = jsonencode({"when":"immediate"})
 		}
 	}
 `, identifier, actionIdentifier)
@@ -94,13 +112,16 @@ func TestAccPortAction(t *testing.T) {
 					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "blueprint_identifier", identifier),
 					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "invocation_method.0.type", "KAFKA"),
 					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "trigger", "DAY-2"),
-					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.#", "2"),
+					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.#", "5"),
 					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.0.default_items.0", "api"),
 					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.0.default_items.#", "2"),
-					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.1.identifier", "clear_cache"),
-					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.1.type", "boolean"),
-					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.1.title", "Clear cache"),
-					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.1.default", "true"),
+					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.1.default", "3"),
+					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.2.default", "test"),
+					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.3.identifier", "clear_cache"),
+					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.3.type", "boolean"),
+					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.3.title", "Clear cache"),
+					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.3.default", "true"),
+					resource.TestCheckResourceAttr("port-labs_action.restart_microservice", "user_properties.4.default", "{\"when\":\"immediate\"}"),
 				),
 			},
 			{

--- a/port/resource_port_blueprint.go
+++ b/port/resource_port_blueprint.go
@@ -389,11 +389,11 @@ func blueprintResourceToBody(d *schema.ResourceData) (*cli.Blueprint, error) {
 		switch propFields.Type {
 		case "string", "number", "boolean":
 			if d, ok := p["default"]; ok && d != "" {
-				propFields.Default = d.(interface{})
+				propFields.Default = d
 			}
 		case "array":
 			if d, ok := p["default_items"]; ok && d != "" {
-				propFields.Default = d.(interface{})
+				propFields.Default = d
 			}
 		case "object":
 			if d, ok := p["default"]; ok && d != "" {

--- a/port/resource_port_blueprint.go
+++ b/port/resource_port_blueprint.go
@@ -3,7 +3,6 @@ package port
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -303,22 +302,24 @@ func writeBlueprintFieldsToResource(d *schema.ResourceData, b *cli.Blueprint) {
 		} else {
 			p["required"] = false
 		}
-		switch t := v.Default.(type) {
-		case map[string]interface{}:
-			js, _ := json.Marshal(&t)
-			p["default"] = string(js)
-		case []interface{}:
-			p["default_items"] = t
-		case float64:
-			p["default"] = strconv.FormatFloat(t, 'f', -1, 64)
-		case int:
-			p["default"] = strconv.Itoa(t)
-		case string:
-			p["default"] = t
-		case bool:
-			p["default"] = "false"
-			if t {
-				p["default"] = "true"
+		if v.Default != nil {
+			switch t := v.Default.(type) {
+			case map[string]interface{}:
+				js, _ := json.Marshal(&t)
+				p["default"] = string(js)
+			case []interface{}:
+				p["default_items"] = t
+			case float64:
+				p["default"] = strconv.FormatFloat(t, 'f', -1, 64)
+			case int:
+				p["default"] = strconv.Itoa(t)
+			case string:
+				p["default"] = t
+			case bool:
+				p["default"] = "false"
+				if t {
+					p["default"] = "true"
+				}
 			}
 		}
 
@@ -387,18 +388,22 @@ func blueprintResourceToBody(d *schema.ResourceData) (*cli.Blueprint, error) {
 		}
 		switch propFields.Type {
 		case "string", "number", "boolean":
-			propFields.Default = p["default"]
-		case "array":
-			propFields.Default = p["default_items"]
-		case "object":
-			obj := make(map[string]interface{})
-			err := json.Unmarshal([]byte(p["default"].(string)), &obj)
-			if err != nil {
-				return nil, err
+			if d, ok := p["default"]; ok && d != "" {
+				propFields.Default = d.(interface{})
 			}
-			propFields.Default = obj
-		default:
-			return nil, fmt.Errorf("unsupported type %s", propFields.Type)
+		case "array":
+			if d, ok := p["default_items"]; ok && d != "" {
+				propFields.Default = d.(interface{})
+			}
+		case "object":
+			if d, ok := p["default"]; ok && d != "" {
+				obj := make(map[string]interface{})
+				err := json.Unmarshal([]byte(d.(string)), &obj)
+				if err != nil {
+					return nil, err
+				}
+				propFields.Default = obj
+			}
 		}
 		if f, ok := p["format"]; ok && f != "" {
 			propFields.Format = f.(string)

--- a/port/resource_port_blueprint.go
+++ b/port/resource_port_blueprint.go
@@ -387,22 +387,38 @@ func blueprintResourceToBody(d *schema.ResourceData) (*cli.Blueprint, error) {
 			propFields.Description = d.(string)
 		}
 		switch propFields.Type {
-		case "string", "number", "boolean":
-			if d, ok := p["default"]; ok && d != "" {
-				propFields.Default = d
+		case "string":
+			if d, ok := p["default"]; ok && d.(string) != "" {
+				propFields.Default = d.(string)
 			}
-		case "array":
-			if d, ok := p["default_items"]; ok && d != "" {
-				propFields.Default = d
-			}
-		case "object":
-			if d, ok := p["default"]; ok && d != "" {
-				obj := make(map[string]interface{})
-				err := json.Unmarshal([]byte(d.(string)), &obj)
+		case "number":
+			if d, ok := p["default"]; ok && d.(string) != "" {
+				defaultNum, err := strconv.ParseInt(d.(string), 10, 0)
 				if err != nil {
 					return nil, err
 				}
-				propFields.Default = obj
+				propFields.Default = defaultNum
+			}
+		case "boolean":
+			if d, ok := p["default"]; ok && d.(string) != "" {
+				defaultBool, err := strconv.ParseBool(d.(string))
+				if err != nil {
+					return nil, err
+				}
+				propFields.Default = defaultBool
+			}
+		case "array":
+			if d, ok := p["default_items"]; ok && d != nil {
+				propFields.Default = d
+			}
+		case "object":
+			if d, ok := p["default"]; ok && d.(string) != "" {
+				defaultObj := make(map[string]interface{})
+				err := json.Unmarshal([]byte(d.(string)), &defaultObj)
+				if err != nil {
+					return nil, err
+				}
+				propFields.Default = defaultObj
 			}
 		}
 		if f, ok := p["format"]; ok && f != "" {

--- a/port/resource_port_blueprint_test.go
+++ b/port/resource_port_blueprint_test.go
@@ -28,21 +28,25 @@ func TestAccPortBlueprint(t *testing.T) {
 			identifier = "bool"
 			type = "boolean"
 			title = "boolean"
+			default = "true"
 		}
 		properties {
 			identifier = "number"
 			type = "number"
 			title = "number"
+			default = "1"
 		}
 		properties {
 			identifier = "obj"
 			type = "object"
 			title = "object"
+			default = jsonencode({"a":"b"})
 		}
 		properties {
 			identifier = "array"
 			type = "array"
 			title = "array"
+			default_items = [1, 2, 3]
 		}
 		properties {
 			identifier = "text"
@@ -54,6 +58,7 @@ func TestAccPortBlueprint(t *testing.T) {
 				a = "red"
 				b = "blue"
 			}
+			default = "a"
 		}
 	}
 `, identifier)
@@ -65,9 +70,15 @@ func TestAccPortBlueprint(t *testing.T) {
 			{
 				Config: testAccActionConfigCreate,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("port-labs_blueprint.microservice", "properties.0.identifier", "text"),
-					resource.TestCheckResourceAttr("port-labs_blueprint.microservice", "properties.0.enum.0", "a"),
-					resource.TestCheckResourceAttr("port-labs_blueprint.microservice", "properties.0.enum_colors.a", "red"),
+					resource.TestCheckResourceAttr("port-labs_blueprint.microservice", "properties.0.default_items.0", "1"),
+					resource.TestCheckResourceAttr("port-labs_blueprint.microservice", "properties.0.default_items.#", "3"),
+					resource.TestCheckResourceAttr("port-labs_blueprint.microservice", "properties.1.default", "1"),
+					resource.TestCheckResourceAttr("port-labs_blueprint.microservice", "properties.2.identifier", "text"),
+					resource.TestCheckResourceAttr("port-labs_blueprint.microservice", "properties.2.enum.0", "a"),
+					resource.TestCheckResourceAttr("port-labs_blueprint.microservice", "properties.2.enum_colors.a", "red"),
+					resource.TestCheckResourceAttr("port-labs_blueprint.microservice", "properties.2.default", "a"),
+					resource.TestCheckResourceAttr("port-labs_blueprint.microservice", "properties.3.default", "true"),
+					resource.TestCheckResourceAttr("port-labs_blueprint.microservice", "properties.4.default", "{\"a\":\"b\"}"),
 				),
 			},
 		},

--- a/port/resource_port_blueprint_test.go
+++ b/port/resource_port_blueprint_test.go
@@ -28,13 +28,13 @@ func TestAccPortBlueprint(t *testing.T) {
 			identifier = "bool"
 			type = "boolean"
 			title = "boolean"
-			default = "true"
+			default = true
 		}
 		properties {
 			identifier = "number"
 			type = "number"
 			title = "number"
-			default = "1"
+			default = 1
 		}
 		properties {
 			identifier = "obj"


### PR DESCRIPTION
Add support for multiple types (including `array`) of default of a Blueprint property and Action user property.