### PR TITLE
PORT-5213-replace-fernet-with-aes256-gcm-in-terraform

### DIFF
--- a/port/action/resource_test.go
+++ b/port/action/resource_test.go
@@ -816,14 +816,14 @@ func TestAccPortActionEncryption(t *testing.T) {
 				"encryptedStringProp" = {
 					"title" = "Encrypted string"
 					"required" = true
-					"encryption" = "fernet"
+					"encryption" = "aes256-gcm"
 				}
 			}
 			"object_props" = {
 				"encryptedObjectProp" = {
 					"title" = "Encrypted object"
 					"required" = true
-					"encryption" = "fernet"
+					"encryption" = "aes256-gcm"
 				}
 			}
 		}
@@ -845,10 +845,10 @@ func TestAccPortActionEncryption(t *testing.T) {
 					resource.TestCheckResourceAttr("port_action.action1", "webhook_method.url", "https://getport.io"),
 					resource.TestCheckResourceAttr("port_action.action1", "user_properties.string_props.encryptedStringProp.title", "Encrypted string"),
 					resource.TestCheckResourceAttr("port_action.action1", "user_properties.string_props.encryptedStringProp.required", "true"),
-					resource.TestCheckResourceAttr("port_action.action1", "user_properties.string_props.encryptedStringProp.encryption", "fernet"),
+					resource.TestCheckResourceAttr("port_action.action1", "user_properties.string_props.encryptedStringProp.encryption", "aes256-gcm"),
 					resource.TestCheckResourceAttr("port_action.action1", "user_properties.object_props.encryptedObjectProp.title", "Encrypted object"),
 					resource.TestCheckResourceAttr("port_action.action1", "user_properties.object_props.encryptedObjectProp.required", "true"),
-					resource.TestCheckResourceAttr("port_action.action1", "user_properties.object_props.encryptedObjectProp.encryption", "fernet"),
+					resource.TestCheckResourceAttr("port_action.action1", "user_properties.object_props.encryptedObjectProp.encryption", "aes256-gcm"),
 				),
 			},
 		},

--- a/port/action/schema.go
+++ b/port/action/schema.go
@@ -320,7 +320,7 @@ func StringPropertySchema() schema.Attribute {
 			MarkdownDescription: "The algorithm to encrypt the property with",
 			Optional:            true,
 			Validators: []validator.String{
-				stringvalidator.OneOf("fernet"),
+				stringvalidator.OneOf("aes256-gcm"),
 			},
 		},
 	}
@@ -426,7 +426,7 @@ func ObjectPropertySchema() schema.Attribute {
 			MarkdownDescription: "The algorithm to encrypt the property with",
 			Optional:            true,
 			Validators: []validator.String{
-				stringvalidator.OneOf("fernet"),
+				stringvalidator.OneOf("aes256-gcm"),
 			},
 		},
 	}


### PR DESCRIPTION
Replace the older (and deprecated by port) fernet encryption algorithm with the newly supported aes256-gcm.