### PR TITLE
Support Force delete blueprint

### DIFF
--- a/docs/resources/port_action.md
+++ b/docs/resources/port_action.md
@@ -429,5 +429,3 @@ Optional:
 - `agent` (Boolean) Use the agent to invoke the action
 - `method` (String) The HTTP method to invoke the action
 - `synchronized` (Boolean) Synchronize the action
-
-

--- a/docs/resources/port_action_permissions.md
+++ b/docs/resources/port_action_permissions.md
@@ -222,5 +222,3 @@ Optional:
 - `roles` (List of String) The roles with execution permission
 - `teams` (List of String) The teams with execution permission
 - `users` (List of String) The users with execution permission
-
-

--- a/docs/resources/port_aggregation_properties.md
+++ b/docs/resources/port_aggregation_properties.md
@@ -645,5 +645,3 @@ Optional:
 
 - `average_of` (String) The time periods to calculate the average of, e.g. hour, day, week, month
 - `measure_time_by` (String) The property name on which to calculate the the time periods, e.g. $createdAt, $updated_at or any other date property
-
-

--- a/docs/resources/port_blueprint.md
+++ b/docs/resources/port_blueprint.md
@@ -98,9 +98,9 @@ description: |-
   }
   ```
   Force Deleting a Blueprint
-  There could be cases where a blueprint will be managed by Terraform, but entities will get created from other sources such as the PORT UI or different integrations.
-  In this case, when trying to delete the blueprint, Terraform will fail because it will try to delete the entities that were created outside of Terraform.
-  To overcome this behavior, you can set the environment variable PORT_FORCE_DELETE_ENTITIES to true.
+  There could be cases where a blueprint will be managed by Terraform, but entities will get created from other sources (e.g. Port UI, API or other supported integrations).
+  In this case, when trying to delete the blueprint, Terraform will fail because it will try to delete the blueprint without deleting the entities first as they are not managed by Terraform.
+  To overcome this behavior, you can set the environment variable PORT_FORCE_DELETE_ENTITIES=true.
   This will trigger a migration that will delete all the entities in the blueprint and then delete the blueprint itself.
 ---
 
@@ -219,10 +219,10 @@ resource "port_blueprint" "microservice" {
 
 ## Force Deleting a Blueprint
 
-There could be cases where a blueprint will be managed by Terraform, but entities will get created from other sources such as the PORT UI or different integrations.
-In this case, when trying to delete the blueprint, Terraform will fail because it will try to delete the entities that were created outside of Terraform.
+There could be cases where a blueprint will be managed by Terraform, but entities will get created from other sources (e.g. Port UI, API or other supported integrations).
+In this case, when trying to delete the blueprint, Terraform will fail because it will try to delete the blueprint without deleting the entities first as they are not managed by Terraform.
 
-To overcome this behavior, you can set the environment variable `PORT_FORCE_DELETE_ENTITIES` to `true`. 
+To overcome this behavior, you can set the environment variable `PORT_FORCE_DELETE_ENTITIES=true`. 
 This will trigger a migration that will delete all the entities in the blueprint and then delete the blueprint itself.
 
 

--- a/docs/resources/port_blueprint.md
+++ b/docs/resources/port_blueprint.md
@@ -100,8 +100,27 @@ description: |-
   Force Deleting a Blueprint
   There could be cases where a blueprint will be managed by Terraform, but entities will get created from other sources (e.g. Port UI, API or other supported integrations).
   In this case, when trying to delete the blueprint, Terraform will fail because it will try to delete the blueprint without deleting the entities first as they are not managed by Terraform.
-  To overcome this behavior, you can set the environment variable PORT_FORCE_DELETE_ENTITIES=true.
-  This will trigger a migration that will delete all the entities in the blueprint and then delete the blueprint itself.
+  To overcome this behavior, you can set the argument force_delete_entities=true.
+  On the blueprint destroy it will trigger a migration that will delete all the entities in the blueprint and then delete the blueprint itself.
+  ```hcl
+  resource "portblueprint" "microservice" {
+    title      = "Microservice"
+    icon       = "Microservice"
+    identifier = "microservice"
+    properties = {
+      stringprops = {
+        "domain" = {
+          title = "Domain"
+        }
+        "slack-channel" = {
+          title  = "Slack Channel"
+          format = "url"
+        }
+      }
+    }
+    forcedeleteentities = false
+  }
+  ```
 ---
 
 # port_blueprint (Resource)
@@ -222,8 +241,29 @@ resource "port_blueprint" "microservice" {
 There could be cases where a blueprint will be managed by Terraform, but entities will get created from other sources (e.g. Port UI, API or other supported integrations).
 In this case, when trying to delete the blueprint, Terraform will fail because it will try to delete the blueprint without deleting the entities first as they are not managed by Terraform.
 
-To overcome this behavior, you can set the environment variable `PORT_FORCE_DELETE_ENTITIES=true`. 
-This will trigger a migration that will delete all the entities in the blueprint and then delete the blueprint itself.
+To overcome this behavior, you can set the argument `force_delete_entities=true`. 
+On the blueprint destroy it will trigger a migration that will delete all the entities in the blueprint and then delete the blueprint itself.
+
+```hcl
+resource "port_blueprint" "microservice" {
+  title      = "Microservice"
+  icon       = "Microservice"
+  identifier = "microservice"
+  properties = {
+    string_props = {
+      "domain" = {
+        title = "Domain"
+      }
+      "slack-channel" = {
+        title  = "Slack Channel"
+        format = "url"
+      }
+    }
+  }
+  force_delete_entities = false
+}
+
+```
 
 
 
@@ -239,6 +279,7 @@ This will trigger a migration that will delete all the entities in the blueprint
 
 - `calculation_properties` (Attributes Map) The calculation properties of the blueprint (see [below for nested schema](#nestedatt--calculation_properties))
 - `description` (String) The description of the blueprint
+- `force_delete_entities` (Boolean) If set to true, the blueprint will be deleted with all its entities, even if they are not managed by Terraform
 - `icon` (String) The icon of the blueprint
 - `kafka_changelog_destination` (Object) The changelog destination of the blueprint (see [below for nested schema](#nestedatt--kafka_changelog_destination))
 - `mirror_properties` (Attributes Map) The mirror properties of the blueprint (see [below for nested schema](#nestedatt--mirror_properties))

--- a/docs/resources/port_blueprint.md
+++ b/docs/resources/port_blueprint.md
@@ -97,6 +97,11 @@ description: |-
     }
   }
   ```
+  Force Deleting a Blueprint
+  There could be cases where a blueprint will be managed by Terraform, but entities will get created from other sources such as the PORT UI or different integrations.
+  In this case, when trying to delete the blueprint, Terraform will fail because it will try to delete the entities that were created outside of Terraform.
+  To overcome this behavior, you can set the environment variable PORT_FORCE_DELETE_ENTITIES to true.
+  This will trigger a migration that will delete all the entities in the blueprint and then delete the blueprint itself.
 ---
 
 # port_blueprint (Resource)
@@ -211,6 +216,14 @@ resource "port_blueprint" "microservice" {
 }
 
 ```
+
+## Force Deleting a Blueprint
+
+There could be cases where a blueprint will be managed by Terraform, but entities will get created from other sources such as the PORT UI or different integrations.
+In this case, when trying to delete the blueprint, Terraform will fail because it will try to delete the entities that were created outside of Terraform.
+
+To overcome this behavior, you can set the environment variable `PORT_FORCE_DELETE_ENTITIES` to `true`. 
+This will trigger a migration that will delete all the entities in the blueprint and then delete the blueprint itself.
 
 
 
@@ -444,5 +457,3 @@ Required:
 Optional:
 
 - `agent` (Boolean) The agent of the webhook changelog destination
-
-

--- a/docs/resources/port_entity.md
+++ b/docs/resources/port_entity.md
@@ -67,5 +67,3 @@ Optional:
 
 - `many_relations` (Map of List of String) The many relation of the entity
 - `single_relations` (Map of String) The single relation of the entity
-
-

--- a/docs/resources/port_scorecard.md
+++ b/docs/resources/port_scorecard.md
@@ -10,90 +10,92 @@ description: |-
   Create a parent blueprint with a child blueprint and an aggregation property to count the parent kids:
   ```hcl
   resource "portblueprint" "microservice" {
-      title = "microservice"
-      icon = "Terraform"
-      identifier = "microservice"
-      properties = {
-          stringprops = {
-              "author" = {
-                  title = "Author"
-              }
-              "url" = {
-                  title = "URL"
-              }
-          }
-          booleanprops = {
-              "required" = {
-                  type = "boolean"
-              }
-          }
-          numberprops = {
-              "sum" = {
-                  type = "number"
-              }
-          }
+    title      = "microservice"
+    icon       = "Terraform"
+    identifier = "microservice"
+    properties = {
+      stringprops = {
+        "author" = {
+          title = "Author"
+        }
+        "url" = {
+          title = "URL"
+        }
       }
+      booleanprops = {
+        "required" = {
+          type = "boolean"
+        }
+      }
+      numberprops = {
+        "sum" = {
+          type = "number"
+        }
+      }
+    }
   }
   resource "portscorecard" "readiness" {
-      identifier = "Readiness"
-      title      = "Readiness"
-      blueprint  = portblueprint.microservice.identifier
-      rules = [
-          {
-              identifier = "hasOwner"
-              title      = "Has Owner"
-              level      = "Gold"
-              query = {
-                  combinator = "and"
-                  conditions = [
-                      jsonencode({
-                          property = "$team"
-                          operator = "isNotEmpty"
-                      }),
-                      jsonencode({
-                          property = "author",
-                          operator : "=",
-                          value : "myValue"
-                      })
-                  ]
-              }
-          },
-          {
-              identifier = "hasUrl"
-              title      = "Has URL"
-              level      = "Silver"
-              query = {
-                combinator = "and"
-                conditions = [jsonencode({
-                  property = "url"
-                  operator = "isNotEmpty"
-                })]
-              }
-          },
-          {
-              identifier = "checkSumIfRequired"
-              title      = "Check Sum If Required"
-              level      = "Bronze"
-              query = {
-                  combinator = "or"
-                  conditions = [
-                      jsonencode({
-                          property = "required"
-                          operator : "="
-                          value : false
-                      }),
-                      jsonencode({
-                          property = "sum"
-                          operator : ">"
-                          value : 2
-                      })
-                  ]
-              }
-          }
-      ]
-      dependson = [
-        portblueprint.microservice
-      ]
+    identifier = "Readiness"
+    title      = "Readiness"
+    blueprint  = portblueprint.microservice.identifier
+    rules      = [
+      {
+        identifier = "hasOwner"
+        title      = "Has Owner"
+        level      = "Gold"
+        query      = {
+          combinator = "and"
+          conditions = [
+            jsonencode({
+              property = "$team"
+              operator = "isNotEmpty"
+            }),
+            jsonencode({
+              property = "author",
+              operator : "=",
+              value : "myValue"
+            })
+          ]
+        }
+      },
+      {
+        identifier = "hasUrl"
+        title      = "Has URL"
+        level      = "Silver"
+        query      = {
+          combinator = "and"
+          conditions = [
+            jsonencode({
+              property = "url"
+              operator = "isNotEmpty"
+            })
+          ]
+        }
+      },
+      {
+        identifier = "checkSumIfRequired"
+        title      = "Check Sum If Required"
+        level      = "Bronze"
+        query      = {
+          combinator = "or"
+          conditions = [
+            jsonencode({
+              property = "required"
+              operator : "="
+              value : false
+            }),
+            jsonencode({
+              property = "sum"
+              operator : ">"
+              value : 2
+            })
+          ]
+        }
+      }
+    ]
+    dependson = [
+      portblueprint.microservice
+    ]
   }
   ```
 ---
@@ -113,91 +115,93 @@ Create a parent blueprint with a child blueprint and an aggregation property to 
 ```hcl
 
 resource "port_blueprint" "microservice" {
-	title = "microservice"
-	icon = "Terraform"
-	identifier = "microservice"
-	properties = {
-		string_props = {
-			"author" = {
-				title = "Author"
-			}
-			"url" = {
-				title = "URL"
-			}
-		}
-		boolean_props = {
-			"required" = {
-				type = "boolean"
-			}
-		}
-		number_props = {
-			"sum" = {
-				type = "number"
-			}
-		}
-	}
+  title      = "microservice"
+  icon       = "Terraform"
+  identifier = "microservice"
+  properties = {
+    string_props = {
+      "author" = {
+        title = "Author"
+      }
+      "url" = {
+        title = "URL"
+      }
+    }
+    boolean_props = {
+      "required" = {
+        type = "boolean"
+      }
+    }
+    number_props = {
+      "sum" = {
+        type = "number"
+      }
+    }
+  }
 }
 
 resource "port_scorecard" "readiness" {
-	identifier = "Readiness"
-	title      = "Readiness"
-	blueprint  = port_blueprint.microservice.identifier
-	rules = [
-		{
-			identifier = "hasOwner"
-			title      = "Has Owner"
-			level      = "Gold"
-			query = {
-				combinator = "and"
-				conditions = [
-					jsonencode({
-						property = "$team"
-						operator = "isNotEmpty"
-					}),
-					jsonencode({
-						property = "author",
-						operator : "=",
-						value : "myValue"
-					})
-				]
-			}
-		},
-		{
-			identifier = "hasUrl"
-			title      = "Has URL"
-			level      = "Silver"
-			query = {
-			  combinator = "and"
-			  conditions = [jsonencode({
-				property = "url"
-				operator = "isNotEmpty"
-			  })]
-			}
-		},
-		{
-			identifier = "checkSumIfRequired"
-			title      = "Check Sum If Required"
-			level      = "Bronze"
-			query = {
-				combinator = "or"
-				conditions = [
-					jsonencode({
-						property = "required"
-						operator : "="
-						value : false
-					}),
-					jsonencode({
-						property = "sum"
-						operator : ">"
-						value : 2
-					})
-				]
-			}
-		}
-	]
-	depends_on = [
-	  port_blueprint.microservice
-	]
+  identifier = "Readiness"
+  title      = "Readiness"
+  blueprint  = port_blueprint.microservice.identifier
+  rules      = [
+    {
+      identifier = "hasOwner"
+      title      = "Has Owner"
+      level      = "Gold"
+      query      = {
+        combinator = "and"
+        conditions = [
+          jsonencode({
+            property = "$team"
+            operator = "isNotEmpty"
+          }),
+          jsonencode({
+            property = "author",
+            operator : "=",
+            value : "myValue"
+          })
+        ]
+      }
+    },
+    {
+      identifier = "hasUrl"
+      title      = "Has URL"
+      level      = "Silver"
+      query      = {
+        combinator = "and"
+        conditions = [
+          jsonencode({
+            property = "url"
+            operator = "isNotEmpty"
+          })
+        ]
+      }
+    },
+    {
+      identifier = "checkSumIfRequired"
+      title      = "Check Sum If Required"
+      level      = "Bronze"
+      query      = {
+        combinator = "or"
+        conditions = [
+          jsonencode({
+            property = "required"
+            operator : "="
+            value : false
+          }),
+          jsonencode({
+            property = "sum"
+            operator : ">"
+            value : 2
+          })
+        ]
+      }
+    }
+  ]
+  depends_on = [
+    port_blueprint.microservice
+  ]
 }
 
 ```

--- a/docs/resources/port_scorecard.md
+++ b/docs/resources/port_scorecard.md
@@ -3,12 +3,204 @@
 page_title: "port_scorecard Resource - terraform-provider-port-labs"
 subcategory: ""
 description: |-
-  scorecard resource
+  Scorecard
+  This resource allows you to manage a scorecard.
+  See the Port documentation https://docs.getport.io/promote-scorecards/ for more information about scorecards.
+  Example Usage
+  Create a parent blueprint with a child blueprint and an aggregation property to count the parent kids:
+  ```hcl
+  resource "portblueprint" "microservice" {
+      title = "microservice"
+      icon = "Terraform"
+      identifier = "microservice"
+      properties = {
+          stringprops = {
+              "author" = {
+                  title = "Author"
+              }
+              "url" = {
+                  title = "URL"
+              }
+          }
+          booleanprops = {
+              "required" = {
+                  type = "boolean"
+              }
+          }
+          numberprops = {
+              "sum" = {
+                  type = "number"
+              }
+          }
+      }
+  }
+  resource "portscorecard" "readiness" {
+      identifier = "Readiness"
+      title      = "Readiness"
+      blueprint  = portblueprint.microservice.identifier
+      rules = [
+          {
+              identifier = "hasOwner"
+              title      = "Has Owner"
+              level      = "Gold"
+              query = {
+                  combinator = "and"
+                  conditions = [
+                      jsonencode({
+                          property = "$team"
+                          operator = "isNotEmpty"
+                      }),
+                      jsonencode({
+                          property = "author",
+                          operator : "=",
+                          value : "myValue"
+                      })
+                  ]
+              }
+          },
+          {
+              identifier = "hasUrl"
+              title      = "Has URL"
+              level      = "Silver"
+              query = {
+                combinator = "and"
+                conditions = [jsonencode({
+                  property = "url"
+                  operator = "isNotEmpty"
+                })]
+              }
+          },
+          {
+              identifier = "checkSumIfRequired"
+              title      = "Check Sum If Required"
+              level      = "Bronze"
+              query = {
+                  combinator = "or"
+                  conditions = [
+                      jsonencode({
+                          property = "required"
+                          operator : "="
+                          value : false
+                      }),
+                      jsonencode({
+                          property = "sum"
+                          operator : ">"
+                          value : 2
+                      })
+                  ]
+              }
+          }
+      ]
+      dependson = [
+        portblueprint.microservice
+      ]
+  }
+  ```
 ---
 
 # port_scorecard (Resource)
 
-scorecard resource
+# Scorecard
+
+This resource allows you to manage a scorecard.
+
+See the [Port documentation](https://docs.getport.io/promote-scorecards/) for more information about scorecards.
+
+## Example Usage
+
+Create a parent blueprint with a child blueprint and an aggregation property to count the parent kids:
+
+```hcl
+
+resource "port_blueprint" "microservice" {
+	title = "microservice"
+	icon = "Terraform"
+	identifier = "microservice"
+	properties = {
+		string_props = {
+			"author" = {
+				title = "Author"
+			}
+			"url" = {
+				title = "URL"
+			}
+		}
+		boolean_props = {
+			"required" = {
+				type = "boolean"
+			}
+		}
+		number_props = {
+			"sum" = {
+				type = "number"
+			}
+		}
+	}
+}
+
+resource "port_scorecard" "readiness" {
+	identifier = "Readiness"
+	title      = "Readiness"
+	blueprint  = port_blueprint.microservice.identifier
+	rules = [
+		{
+			identifier = "hasOwner"
+			title      = "Has Owner"
+			level      = "Gold"
+			query = {
+				combinator = "and"
+				conditions = [
+					jsonencode({
+						property = "$team"
+						operator = "isNotEmpty"
+					}),
+					jsonencode({
+						property = "author",
+						operator : "=",
+						value : "myValue"
+					})
+				]
+			}
+		},
+		{
+			identifier = "hasUrl"
+			title      = "Has URL"
+			level      = "Silver"
+			query = {
+			  combinator = "and"
+			  conditions = [jsonencode({
+				property = "url"
+				operator = "isNotEmpty"
+			  })]
+			}
+		},
+		{
+			identifier = "checkSumIfRequired"
+			title      = "Check Sum If Required"
+			level      = "Bronze"
+			query = {
+				combinator = "or"
+				conditions = [
+					jsonencode({
+						property = "required"
+						operator : "="
+						value : false
+					}),
+					jsonencode({
+						property = "sum"
+						operator : ">"
+						value : 2
+					})
+				]
+			}
+		}
+	]
+	depends_on = [
+	  port_blueprint.microservice
+	]
+}
+
+```
 
 
 
@@ -47,5 +239,3 @@ Required:
 
 - `combinator` (String) The combinator of the query
 - `conditions` (List of String) The conditions of the query. Each condition object should be encoded to a string
-
-

--- a/docs/resources/port_team.md
+++ b/docs/resources/port_team.md
@@ -30,5 +30,3 @@ Team resource
 - `id` (String) The ID of this resource.
 - `provider_name` (String) The provider of the team
 - `updated_at` (String) The last update date of the team
-
-

--- a/docs/resources/port_webhook.md
+++ b/docs/resources/port_webhook.md
@@ -75,5 +75,3 @@ Optional:
 - `signature_algorithm` (String) The signature algorithm of the webhook
 - `signature_header_name` (String) The signature header name of the webhook
 - `signature_prefix` (String) The signature prefix of the webhook
-
-

--- a/internal/cli/blueprint.go
+++ b/internal/cli/blueprint.go
@@ -86,3 +86,26 @@ func (c *PortClient) DeleteBlueprint(ctx context.Context, id string) error {
 	}
 	return nil
 }
+
+func (c *PortClient) DeleteBlueprintWithAllEntities(ctx context.Context, id string) (*string, error) {
+	url := "v1/blueprints/{identifier}/all-entities?delete_blueprint=true"
+	resp, err := c.Client.R().
+		SetContext(ctx).
+		SetHeader("Accept", "application/json").
+		SetPathParam("identifier", id).
+		Delete(url)
+	if err != nil {
+		return nil, err
+	}
+	var pb PortBody
+	err = json.Unmarshal(resp.Body(), &pb)
+	if err != nil {
+		return nil, err
+	}
+	if !pb.OK {
+		return nil, fmt.Errorf("failed to trigger blueprint deletion with all entities, got: %s", resp.Body())
+	}
+
+	return &pb.MigrationId, nil
+
+}

--- a/internal/cli/migrations.go
+++ b/internal/cli/migrations.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+)
+
+func (c *PortClient) GetMigration(ctx context.Context, id string) (*Migration, error) {
+	pb := &PortBody{}
+	url := "v1/migrations/{identifier}"
+	resp, err := c.Client.R().
+		SetContext(ctx).
+		SetHeader("Accept", "application/json").
+		SetResult(pb).
+		SetPathParam("identifier", id).
+		Get(url)
+	if err != nil {
+		return nil, err
+	}
+	if !pb.OK {
+		return nil, fmt.Errorf("failed to read migration, got: %s", resp.Body())
+	}
+	return &pb.Migration, nil
+}

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -295,6 +295,19 @@ type (
 		Users       []string   `json:"users,omitempty"`
 		Provider    string     `json:"provider,omitempty"`
 	}
+
+	Migration struct {
+		Meta
+		Id              string `json:"id,omitempty"`
+		Actor           string `json:"actor,omitempty"`
+		SourceBlueprint string `json:"sourceBlueprint,omitempty"`
+		Mapping         any    `json:"mapping,omitempty"`
+		Status          string `json:"status,omitempty"`
+		DeleteBlueprint bool   `json:"deleteBlueprint,omitempty"`
+		DeleteEntities  bool   `json:"deleteEntities,omitempty"`
+		FailureCount    int    `json:"failureCount,omitempty"`
+		SuccessCount    int    `json:"successCount,omitempty"`
+	}
 )
 
 type PortBody struct {
@@ -306,6 +319,8 @@ type PortBody struct {
 	Integration       Webhook           `json:"integration"`
 	Scorecard         Scorecard         `json:"Scorecard"`
 	Team              Team              `json:"team"`
+	MigrationId       string            `json:"migrationId"`
+	Migration         Migration         `json:"migration"`
 }
 
 type TeamUserBody struct {

--- a/internal/consts/migrations.go
+++ b/internal/consts/migrations.go
@@ -1,0 +1,15 @@
+package consts
+
+const (
+	Failure             = "FAILURE"
+	Cancelled           = "CANCELLED"
+	Completed           = "COMPLETED"
+	Running             = "RUNNING"
+	Pending             = "PENDING"
+	Initializing        = "INITIALIZING"
+	PendingCancellation = "PENDING_CANCELLATION"
+)
+
+func IsTerminalStatus(status string) bool {
+	return status == Failure || status == Cancelled || status == Completed
+}

--- a/port/blueprint/model.go
+++ b/port/blueprint/model.go
@@ -173,4 +173,5 @@ type BlueprintModel struct {
 	Relations                   map[string]RelationModel            `tfsdk:"relations"`
 	MirrorProperties            map[string]MirrorPropertyModel      `tfsdk:"mirror_properties"`
 	CalculationProperties       map[string]CalculationPropertyModel `tfsdk:"calculation_properties"`
+	ForceDeleteEntities         types.Bool                          `tfsdk:"force_delete_entities"`
 }

--- a/port/blueprint/resource.go
+++ b/port/blueprint/resource.go
@@ -78,6 +78,10 @@ func refreshBlueprintState(ctx context.Context, bm *BlueprintModel, b *cli.Bluep
 	bm.Icon = flex.GoStringToFramework(b.Icon)
 	bm.Description = flex.GoStringToFramework(b.Description)
 
+	if bm.ForceDeleteEntities.IsNull() {
+		bm.ForceDeleteEntities = types.BoolValue(false)
+	}
+
 	if b.ChangelogDestination != nil {
 		if b.ChangelogDestination.Type == consts.Kafka {
 			bm.KafkaChangelogDestination, _ = types.ObjectValue(nil, nil)
@@ -151,6 +155,10 @@ func writeBlueprintComputedFieldsToState(state *BlueprintModel, bp *cli.Blueprin
 	state.CreatedBy = types.StringValue(bp.CreatedBy)
 	state.UpdatedAt = types.StringValue(bp.UpdatedAt.String())
 	state.UpdatedBy = types.StringValue(bp.UpdatedBy)
+
+	if state.ForceDeleteEntities.IsNull() {
+		state.ForceDeleteEntities = types.BoolValue(false)
+	}
 }
 
 func (r *BlueprintResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/port/blueprint/schema.go
+++ b/port/blueprint/schema.go
@@ -568,4 +568,14 @@ resource "port_blueprint" "microservice" {
   }
 }
 
-` + "```" + ``
+` + "```" + `
+
+## Force Deleting a Blueprint
+
+There could be cases where a blueprint will be managed by Terraform, but entities will get created from other sources (e.g. Port UI, API or other supported integrations).
+In this case, when trying to delete the blueprint, Terraform will fail because it will try to delete the blueprint without deleting the entities first as they are not managed by Terraform.
+
+To overcome this behavior, you can set the environment variable ` + "`PORT_FORCE_DELETE_ENTITIES=true`" + `. 
+This will trigger a migration that will delete all the entities in the blueprint and then delete the blueprint itself.
+
+`

--- a/port/blueprint/schema.go
+++ b/port/blueprint/schema.go
@@ -447,6 +447,12 @@ func BlueprintSchema() map[string]schema.Attribute {
 				},
 			},
 		},
+		"force_delete_entities": schema.BoolAttribute{
+			MarkdownDescription: "If set to true, the blueprint will be deleted with all its entities, even if they are not managed by Terraform",
+			Optional:            true,
+			Computed:            true,
+			Default:             booldefault.StaticBool(false),
+		},
 	}
 }
 
@@ -575,7 +581,28 @@ resource "port_blueprint" "microservice" {
 There could be cases where a blueprint will be managed by Terraform, but entities will get created from other sources (e.g. Port UI, API or other supported integrations).
 In this case, when trying to delete the blueprint, Terraform will fail because it will try to delete the blueprint without deleting the entities first as they are not managed by Terraform.
 
-To overcome this behavior, you can set the environment variable ` + "`PORT_FORCE_DELETE_ENTITIES=true`" + `. 
-This will trigger a migration that will delete all the entities in the blueprint and then delete the blueprint itself.
+To overcome this behavior, you can set the argument ` + "`force_delete_entities=true`" + `. 
+On the blueprint destroy it will trigger a migration that will delete all the entities in the blueprint and then delete the blueprint itself.
+
+` + "```hcl" + `
+resource "port_blueprint" "microservice" {
+  title      = "Microservice"
+  icon       = "Microservice"
+  identifier = "microservice"
+  properties = {
+    string_props = {
+      "domain" = {
+        title = "Domain"
+      }
+      "slack-channel" = {
+        title  = "Slack Channel"
+        format = "url"
+      }
+    }
+  }
+  force_delete_entities = false
+}
+
+` + "```" + `
 
 `

--- a/port/blueprint/schema.go
+++ b/port/blueprint/schema.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -452,6 +453,9 @@ func BlueprintSchema() map[string]schema.Attribute {
 			Optional:            true,
 			Computed:            true,
 			Default:             booldefault.StaticBool(false),
+			PlanModifiers: []planmodifier.Bool{
+				boolplanmodifier.UseStateForUnknown(),
+			},
 		},
 	}
 }

--- a/port/blueprint/schema.go
+++ b/port/blueprint/schema.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -453,9 +452,6 @@ func BlueprintSchema() map[string]schema.Attribute {
 			Optional:            true,
 			Computed:            true,
 			Default:             booldefault.StaticBool(false),
-			PlanModifiers: []planmodifier.Bool{
-				boolplanmodifier.UseStateForUnknown(),
-			},
 		},
 	}
 }

--- a/port/scorecard/schema.go
+++ b/port/scorecard/schema.go
@@ -124,91 +124,93 @@ Create a parent blueprint with a child blueprint and an aggregation property to 
 ` + "```hcl" + `
 
 resource "port_blueprint" "microservice" {
-	title = "microservice"
-	icon = "Terraform"
-	identifier = "microservice"
-	properties = {
-		string_props = {
-			"author" = {
-				title = "Author"
-			}
-			"url" = {
-				title = "URL"
-			}
-		}
-		boolean_props = {
-			"required" = {
-				type = "boolean"
-			}
-		}
-		number_props = {
-			"sum" = {
-				type = "number"
-			}
-		}
-	}
+  title      = "microservice"
+  icon       = "Terraform"
+  identifier = "microservice"
+  properties = {
+    string_props = {
+      "author" = {
+        title = "Author"
+      }
+      "url" = {
+        title = "URL"
+      }
+    }
+    boolean_props = {
+      "required" = {
+        type = "boolean"
+      }
+    }
+    number_props = {
+      "sum" = {
+        type = "number"
+      }
+    }
+  }
 }
 
 resource "port_scorecard" "readiness" {
-	identifier = "Readiness"
-	title      = "Readiness"
-	blueprint  = port_blueprint.microservice.identifier
-	rules = [
-		{
-			identifier = "hasOwner"
-			title      = "Has Owner"
-			level      = "Gold"
-			query = {
-				combinator = "and"
-				conditions = [
-					jsonencode({
-						property = "$team"
-						operator = "isNotEmpty"
-					}),
-					jsonencode({
-						property = "author",
-						operator : "=",
-						value : "myValue"
-					})
-				]
-			}
-		},
-		{
-			identifier = "hasUrl"
-			title      = "Has URL"
-			level      = "Silver"
-			query = {
-			  combinator = "and"
-			  conditions = [jsonencode({
-				property = "url"
-				operator = "isNotEmpty"
-			  })]
-			}
-		},
-		{
-			identifier = "checkSumIfRequired"
-			title      = "Check Sum If Required"
-			level      = "Bronze"
-			query = {
-				combinator = "or"
-				conditions = [
-					jsonencode({
-						property = "required"
-						operator : "="
-						value : false
-					}),
-					jsonencode({
-						property = "sum"
-						operator : ">"
-						value : 2
-					})
-				]
-			}
-		}
-	]
-	depends_on = [
-	  port_blueprint.microservice
-	]
+  identifier = "Readiness"
+  title      = "Readiness"
+  blueprint  = port_blueprint.microservice.identifier
+  rules      = [
+    {
+      identifier = "hasOwner"
+      title      = "Has Owner"
+      level      = "Gold"
+      query      = {
+        combinator = "and"
+        conditions = [
+          jsonencode({
+            property = "$team"
+            operator = "isNotEmpty"
+          }),
+          jsonencode({
+            property = "author",
+            operator : "=",
+            value : "myValue"
+          })
+        ]
+      }
+    },
+    {
+      identifier = "hasUrl"
+      title      = "Has URL"
+      level      = "Silver"
+      query      = {
+        combinator = "and"
+        conditions = [
+          jsonencode({
+            property = "url"
+            operator = "isNotEmpty"
+          })
+        ]
+      }
+    },
+    {
+      identifier = "checkSumIfRequired"
+      title      = "Check Sum If Required"
+      level      = "Bronze"
+      query      = {
+        combinator = "or"
+        conditions = [
+          jsonencode({
+            property = "required"
+            operator : "="
+            value : false
+          }),
+          jsonencode({
+            property = "sum"
+            operator : ">"
+            value : 2
+          })
+        ]
+      }
+    }
+  ]
+  depends_on = [
+    port_blueprint.microservice
+  ]
 }
 
 ` + "```"


### PR DESCRIPTION
# Description

Fixes - #61 

What - Added support to force delete blueprints
Why - If terraform only manages the blueprint, but entities are ingested from different sources, the destroying of the blueprint will fail as there are entities left in the blueprint.
How - Introduced a new flag to indicate whether to delete the blueprint `PORT_FORCE_DELETE_ENTITIES=true`

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)