### PR TITLE
PORT-7217-bug-terraform-errors-when-trying-to-conditionally-set-variable-properties

### DIFF
--- a/port/action/model.go
+++ b/port/action/model.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
 )
 
 type WebhookMethodModel struct {
@@ -68,6 +69,33 @@ type StringPropModel struct {
 	Enum        types.List   `tfsdk:"enum"`
 	EnumJqQuery types.String `tfsdk:"enum_jq_query"`
 	Encryption  types.String `tfsdk:"encryption"`
+}
+
+// StringPropValidationModel is a model used for the validation of StringPropModel resources
+type StringPropValidationModel struct {
+	Title    string
+	Required *bool
+}
+
+func (e *StringPropValidationModel) FromTerraform5Value(val tftypes.Value) error {
+	v := map[string]tftypes.Value{}
+
+	err := val.As(&v)
+	if err != nil {
+		return err
+	}
+
+	err = v["title"].As(&e.Title)
+	if err != nil {
+		return err
+	}
+
+	err = v["required"].As(&e.Required)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 type NumberPropModel struct {
@@ -193,22 +221,22 @@ type ActionModel struct {
 }
 
 type ActionValidationModel struct {
-	ID                          types.String         `tfsdk:"id"`
-	Identifier                  types.String         `tfsdk:"identifier"`
-	Blueprint                   types.String         `tfsdk:"blueprint"`
-	Title                       types.String         `tfsdk:"title"`
-	Icon                        types.String         `tfsdk:"icon"`
-	Description                 types.String         `tfsdk:"description"`
-	RequiredApproval            types.Bool           `tfsdk:"required_approval"`
-	Trigger                     types.String         `tfsdk:"trigger"`
-	KafkaMethod                 types.Object         `tfsdk:"kafka_method"`
-	WebhookMethod               types.Object         `tfsdk:"webhook_method"`
-	GithubMethod                types.Object         `tfsdk:"github_method"`
-	AzureMethod                 types.Object         `tfsdk:"azure_method"`
-	GitlabMethod                types.Object         `tfsdk:"gitlab_method"`
-	UserProperties              *UserPropertiesModel `tfsdk:"user_properties"`
-	ApprovalWebhookNotification types.Object         `tfsdk:"approval_webhook_notification"`
-	ApprovalEmailNotification   types.Object         `tfsdk:"approval_email_notification"`
-	OrderProperties             types.List           `tfsdk:"order_properties"`
-	RequiredJqQuery             types.String         `tfsdk:"required_jq_query"`
+	ID                          types.String `tfsdk:"id"`
+	Identifier                  types.String `tfsdk:"identifier"`
+	Blueprint                   types.String `tfsdk:"blueprint"`
+	Title                       types.String `tfsdk:"title"`
+	Icon                        types.String `tfsdk:"icon"`
+	Description                 types.String `tfsdk:"description"`
+	RequiredApproval            types.Bool   `tfsdk:"required_approval"`
+	Trigger                     types.String `tfsdk:"trigger"`
+	KafkaMethod                 types.Object `tfsdk:"kafka_method"`
+	WebhookMethod               types.Object `tfsdk:"webhook_method"`
+	GithubMethod                types.Object `tfsdk:"github_method"`
+	AzureMethod                 types.Object `tfsdk:"azure_method"`
+	GitlabMethod                types.Object `tfsdk:"gitlab_method"`
+	UserProperties              types.Object `tfsdk:"user_properties"`
+	ApprovalWebhookNotification types.Object `tfsdk:"approval_webhook_notification"`
+	ApprovalEmailNotification   types.Object `tfsdk:"approval_email_notification"`
+	OrderProperties             types.List   `tfsdk:"order_properties"`
+	RequiredJqQuery             types.String `tfsdk:"required_jq_query"`
 }

--- a/port/action/model.go
+++ b/port/action/model.go
@@ -98,6 +98,114 @@ func (e *StringPropValidationModel) FromTerraform5Value(val tftypes.Value) error
 	return nil
 }
 
+// NumberPropValidationModel is a model used for the validation of StringPropModel resources
+type NumberPropValidationModel struct {
+	Title    string
+	Required *bool
+}
+
+func (e *NumberPropValidationModel) FromTerraform5Value(val tftypes.Value) error {
+	v := map[string]tftypes.Value{}
+
+	err := val.As(&v)
+	if err != nil {
+		return err
+	}
+
+	err = v["title"].As(&e.Title)
+	if err != nil {
+		return err
+	}
+
+	err = v["required"].As(&e.Required)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// BooleanPropValidationModel is a model used for the validation of StringPropModel resources
+type BooleanPropValidationModel struct {
+	Title    string
+	Required *bool
+}
+
+func (e *BooleanPropValidationModel) FromTerraform5Value(val tftypes.Value) error {
+	v := map[string]tftypes.Value{}
+
+	err := val.As(&v)
+	if err != nil {
+		return err
+	}
+
+	err = v["title"].As(&e.Title)
+	if err != nil {
+		return err
+	}
+
+	err = v["required"].As(&e.Required)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ObjectPropValidationModel is a model used for the validation of StringPropModel resources
+type ObjectPropValidationModel struct {
+	Title    string
+	Required *bool
+}
+
+func (e *ObjectPropValidationModel) FromTerraform5Value(val tftypes.Value) error {
+	v := map[string]tftypes.Value{}
+
+	err := val.As(&v)
+	if err != nil {
+		return err
+	}
+
+	err = v["title"].As(&e.Title)
+	if err != nil {
+		return err
+	}
+
+	err = v["required"].As(&e.Required)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ArrayPropValidationModel is a model used for the validation of StringPropModel resources
+type ArrayPropValidationModel struct {
+	Title    string
+	Required *bool
+}
+
+func (e *ArrayPropValidationModel) FromTerraform5Value(val tftypes.Value) error {
+	v := map[string]tftypes.Value{}
+
+	err := val.As(&v)
+	if err != nil {
+		return err
+	}
+
+	err = v["title"].As(&e.Title)
+	if err != nil {
+		return err
+	}
+
+	err = v["required"].As(&e.Required)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 type NumberPropModel struct {
 	Title          types.String  `tfsdk:"title"`
 	Icon           types.String  `tfsdk:"icon"`
@@ -220,6 +328,7 @@ type ActionModel struct {
 	RequiredJqQuery             types.String                      `tfsdk:"required_jq_query"`
 }
 
+// ActionValidationModel is a model used for the validation of ActionModel resources
 type ActionValidationModel struct {
 	ID                          types.String `tfsdk:"id"`
 	Identifier                  types.String `tfsdk:"identifier"`

--- a/port/action/model.go
+++ b/port/action/model.go
@@ -191,3 +191,24 @@ type ActionModel struct {
 	OrderProperties             types.List                        `tfsdk:"order_properties"`
 	RequiredJqQuery             types.String                      `tfsdk:"required_jq_query"`
 }
+
+type ActionValidationModel struct {
+	ID                          types.String         `tfsdk:"id"`
+	Identifier                  types.String         `tfsdk:"identifier"`
+	Blueprint                   types.String         `tfsdk:"blueprint"`
+	Title                       types.String         `tfsdk:"title"`
+	Icon                        types.String         `tfsdk:"icon"`
+	Description                 types.String         `tfsdk:"description"`
+	RequiredApproval            types.Bool           `tfsdk:"required_approval"`
+	Trigger                     types.String         `tfsdk:"trigger"`
+	KafkaMethod                 types.Object         `tfsdk:"kafka_method"`
+	WebhookMethod               types.Object         `tfsdk:"webhook_method"`
+	GithubMethod                types.Object         `tfsdk:"github_method"`
+	AzureMethod                 types.Object         `tfsdk:"azure_method"`
+	GitlabMethod                types.Object         `tfsdk:"gitlab_method"`
+	UserProperties              *UserPropertiesModel `tfsdk:"user_properties"`
+	ApprovalWebhookNotification types.Object         `tfsdk:"approval_webhook_notification"`
+	ApprovalEmailNotification   types.Object         `tfsdk:"approval_email_notification"`
+	OrderProperties             types.List           `tfsdk:"order_properties"`
+	RequiredJqQuery             types.String         `tfsdk:"required_jq_query"`
+}

--- a/port/action/schema.go
+++ b/port/action/schema.go
@@ -661,7 +661,7 @@ func (r *ActionResource) ValidateConfig(ctx context.Context, req resource.Valida
 }
 
 func validateUserInputRequiredNotSetToFalse(ctx context.Context, state *ActionValidationModel, resp *resource.ValidateConfigResponse) {
-	// go over all the properties and check if required is set to false, is its false, raise an error that false is not
+	// go over all the properties and check if required is set to false, it is false, raise an error that false is not
 	// supported anymore
 	const errorString = "required is set to false, this is not supported anymore, if you don't want to make the stringProp required, remove the required stringProp"
 
@@ -709,6 +709,142 @@ func validateUserInputRequiredNotSetToFalse(ctx context.Context, state *ActionVa
 			for _, stringProp := range stringPropValidationsObjects {
 				if stringProp.Required != nil && !*stringProp.Required {
 					resp.Diagnostics.AddError(errorString, fmt.Sprint(`Error in User Property: `, stringProp.Title, ` in action: `, state.Identifier))
+				}
+			}
+		}
+
+		var numberProperties, _ = userProperties["number_props"]
+
+		if numberProperties != nil {
+			var val, err = numberProperties.ToTerraformValue(ctx)
+			if err != nil {
+				return
+			}
+
+			v := map[string]tftypes.Value{}
+
+			err = val.As(&v)
+			if err != nil {
+				return
+			}
+
+			numberPropValidationsObjects := make(map[string]NumberPropValidationModel, len(v))
+			for key := range v {
+				var val NumberPropValidationModel
+				err = v[key].As(&val)
+
+				if err != nil {
+					return
+				}
+
+				numberPropValidationsObjects[key] = val
+			}
+
+			for _, numberProp := range numberPropValidationsObjects {
+				if numberProp.Required != nil && !*numberProp.Required {
+					resp.Diagnostics.AddError(errorString, fmt.Sprint(`Error in User Property: `, numberProp.Title, ` in action: `, state.Identifier))
+				}
+			}
+		}
+
+		var booleanProperties, _ = userProperties["boolean_props"]
+
+		if booleanProperties != nil {
+			var val, err = booleanProperties.ToTerraformValue(ctx)
+			if err != nil {
+				return
+			}
+
+			v := map[string]tftypes.Value{}
+
+			err = val.As(&v)
+			if err != nil {
+				return
+			}
+
+			booleanPropValidationsObjects := make(map[string]BooleanPropValidationModel, len(v))
+			for key := range v {
+				var val BooleanPropValidationModel
+				err = v[key].As(&val)
+
+				if err != nil {
+					return
+				}
+
+				booleanPropValidationsObjects[key] = val
+			}
+
+			for _, booleanProp := range booleanPropValidationsObjects {
+				if booleanProp.Required != nil && !*booleanProp.Required {
+					resp.Diagnostics.AddError(errorString, fmt.Sprint(`Error in User Property: `, booleanProp.Title, ` in action: `, state.Identifier))
+				}
+			}
+		}
+
+		var objectProperties, _ = userProperties["object_props"]
+
+		if objectProperties != nil {
+			var val, err = objectProperties.ToTerraformValue(ctx)
+			if err != nil {
+				return
+			}
+
+			v := map[string]tftypes.Value{}
+
+			err = val.As(&v)
+			if err != nil {
+				return
+			}
+
+			objectPropValidationsObjects := make(map[string]ObjectPropValidationModel, len(v))
+			for key := range v {
+				var val ObjectPropValidationModel
+				err = v[key].As(&val)
+
+				if err != nil {
+					return
+				}
+
+				objectPropValidationsObjects[key] = val
+			}
+
+			for _, objectProp := range objectPropValidationsObjects {
+				if objectProp.Required != nil && !*objectProp.Required {
+					resp.Diagnostics.AddError(errorString, fmt.Sprint(`Error in User Property: `, objectProp.Title, ` in action: `, state.Identifier))
+				}
+			}
+		}
+
+		var arrayProperties, _ = userProperties["array_props"]
+
+		if arrayProperties != nil {
+			var val, err = arrayProperties.ToTerraformValue(ctx)
+			if err != nil {
+				return
+			}
+
+			v := map[string]tftypes.Value{}
+
+			err = val.As(&v)
+			if err != nil {
+				return
+			}
+
+			arrayPropValidationsObjects := make(map[string]ArrayPropValidationModel, len(v))
+			for key := range v {
+				var val ArrayPropValidationModel
+				err = v[key].As(&val)
+
+				if err != nil {
+					return
+				}
+
+				arrayPropValidationsObjects[key] = val
+			}
+
+			for _, arrayProp := range arrayPropValidationsObjects {
+				if arrayProp.Required != nil && !*arrayProp.Required {
+					resp.Diagnostics.AddError(errorString, fmt.Sprint(`Error in User Property: `, arrayProp.Title, ` in action: `, state.Identifier))
 				}
 			}
 		}

--- a/port/action/schema.go
+++ b/port/action/schema.go
@@ -3,6 +3,7 @@ package action
 import (
 	"context"
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
@@ -646,7 +647,7 @@ func (r *ActionResource) Schema(ctx context.Context, req resource.SchemaRequest,
 }
 
 func (r *ActionResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
-	var state *ActionModel
+	var state *ActionValidationModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
 
@@ -657,7 +658,7 @@ func (r *ActionResource) ValidateConfig(ctx context.Context, req resource.Valida
 	validateUserInputRequiredNotSetToFalse(state, resp)
 }
 
-func validateUserInputRequiredNotSetToFalse(state *ActionModel, resp *resource.ValidateConfigResponse) {
+func validateUserInputRequiredNotSetToFalse(state *ActionValidationModel, resp *resource.ValidateConfigResponse) {
 	// go over all the properties and check if required is set to false, is its false, raise an error that false is not
 	// supported anymore
 	const errorString = "required is set to false, this is not supported anymore, if you don't want to make the stringProp required, remove the required stringProp"


### PR DESCRIPTION
# Description

What - there was a problem with the automatic type conversion of validations in some cases
How - fixed by adding a new type specifically made for the action validations, and a somewhat manual conversion of the user data to that type

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)