### PR TITLE
fix: bug terraform cannot create entity without a relation even though the relation is not required

### DIFF
--- a/port/entity/model.go
+++ b/port/entity/model.go
@@ -20,7 +20,7 @@ type EntityPropertiesModel struct {
 }
 
 type RelationModel struct {
-	SingleRelation map[string]string   `tfsdk:"single_relations"`
+	SingleRelation map[string]*string  `tfsdk:"single_relations"`
 	ManyRelations  map[string][]string `tfsdk:"many_relations"`
 }
 

--- a/port/entity/refreshEntityToState.go
+++ b/port/entity/refreshEntityToState.go
@@ -147,7 +147,7 @@ func refreshPropertiesEntityState(ctx context.Context, state *EntityModel, e *cl
 
 func refreshRelationsEntityState(ctx context.Context, state *EntityModel, e *cli.Entity) {
 	relations := &RelationModel{
-		SingleRelation: make(map[string]string),
+		SingleRelation: make(map[string]*string),
 		ManyRelations:  make(map[string][]string),
 	}
 
@@ -160,7 +160,7 @@ func refreshRelationsEntityState(ctx context.Context, state *EntityModel, e *cli
 
 		case string:
 			if len(v) != 0 {
-				relations.SingleRelation[identifier] = v
+				relations.SingleRelation[identifier] = &v
 			}
 		}
 	}

--- a/port/entity/resource_test.go
+++ b/port/entity/resource_test.go
@@ -398,6 +398,75 @@ func TestAccPortEntityWithManyRelation(t *testing.T) {
 	})
 }
 
+func TestAccPortEntityWithEmptyRelation(t *testing.T) {
+	identifier := utils.GenID()
+	identifier2 := utils.GenID()
+	var testAccActionConfigCreate = fmt.Sprintf(`
+	resource "port_blueprint" "microservice" {
+		title = "TF Provider Test BP0"
+		icon = "Terraform"
+		identifier = "%s"
+		properties = {
+			"string_props" = {
+				"myStringIdentifier" =  {
+					"title" = "My String Identifier"
+				}
+			}
+		}
+		relations = {
+			"tfRelation" = {
+				"title" = "Test Relation"
+				"target" = port_blueprint.microservice2.identifier
+			}
+		}	
+	}
+	resource "port_blueprint" "microservice2" {
+		title = "TF Provider Test BP1"
+		icon = "Terraform"
+		identifier = "%s"
+		properties = {
+			"string_props" = {
+				"myStringIdentifier2" =  {
+					"title" = "My String Identifier2"
+				}
+			}
+		}
+	}
+
+	resource "port_entity" "microservice" {
+		title = "TF Provider Test Entity0"
+		blueprint = port_blueprint.microservice.identifier
+		properties = {
+			"string_props" = {
+				"myStringIdentifier" =  "My String Value"
+			}
+		}
+		relations = {
+			single_relations = {
+				"tfRelation" = null
+			}
+		}
+	}
+	`, identifier, identifier2)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + testAccActionConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_entity.microservice", "title", "TF Provider Test Entity0"),
+					resource.TestCheckResourceAttr("port_entity.microservice", "blueprint", identifier),
+					resource.TestCheckResourceAttr("port_entity.microservice", "properties.string_props.myStringIdentifier", "My String Value"),
+					resource.TestCheckNoResourceAttr("port_entity.microservice", "relations.single_relations.tfRelation"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccPortEntityImport(t *testing.T) {
 	blueprintIdentifier := utils.GenID()
 	entityIdentifier := utils.GenID()


### PR DESCRIPTION


# Description

What - Support null relation in single_relation in entities. (it is already supported in many_relations)
Why - Terraform support null values when wanting to send empty attributes. Port can configure relations as non-required. there was no support for a case when an entity didn't have a relation that was defined in the blueprint as non-required.
How - changed the model.go to support string and null (using *)

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)