### PR TITLE
Add option to not create catalog page on blueprint creation

### DIFF
--- a/docs/resources/port_blueprint.md
+++ b/docs/resources/port_blueprint.md
@@ -278,6 +278,7 @@ resource "port_blueprint" "microservice" {
 ### Optional
 
 - `calculation_properties` (Attributes Map) The calculation properties of the blueprint (see [below for nested schema](#nestedatt--calculation_properties))
+- `create_catalog_page` (Boolean) This flag is only relevant for blueprint creation, by default if not set, a catalog page will be created for the blueprint
 - `description` (String) The description of the blueprint
 - `force_delete_entities` (Boolean) If set to true, the blueprint will be deleted with all its entities, even if they are not managed by Terraform
 - `icon` (String) The icon of the blueprint

--- a/internal/cli/blueprint.go
+++ b/internal/cli/blueprint.go
@@ -25,12 +25,15 @@ func (c *PortClient) ReadBlueprint(ctx context.Context, id string) (*Blueprint, 
 	return &pb.Blueprint, resp.StatusCode(), nil
 }
 
-func (c *PortClient) CreateBlueprint(ctx context.Context, b *Blueprint) (*Blueprint, error) {
+func (c *PortClient) CreateBlueprint(ctx context.Context, b *Blueprint, createCatalogPage *bool) (*Blueprint, error) {
 	url := "v1/blueprints"
-	resp, err := c.Client.R().
+	request := c.Client.R().
 		SetBody(b).
-		SetContext(ctx).
-		Post(url)
+		SetContext(ctx)
+	if createCatalogPage != nil {
+		request.SetQueryParam("create_catalog_page", fmt.Sprintf("%t", *createCatalogPage))
+	}
+	resp, err := request.Post(url)
 	if err != nil {
 		return nil, err
 	}

--- a/port/blueprint/model.go
+++ b/port/blueprint/model.go
@@ -174,4 +174,5 @@ type BlueprintModel struct {
 	MirrorProperties            map[string]MirrorPropertyModel      `tfsdk:"mirror_properties"`
 	CalculationProperties       map[string]CalculationPropertyModel `tfsdk:"calculation_properties"`
 	ForceDeleteEntities         types.Bool                          `tfsdk:"force_delete_entities"`
+	CreateCatalogPage           types.Bool                          `tfsdk:"create_catalog_page"`
 }

--- a/port/blueprint/resource.go
+++ b/port/blueprint/resource.go
@@ -72,6 +72,11 @@ func refreshBlueprintState(ctx context.Context, bm *BlueprintModel, b *cli.Bluep
 	bm.UpdatedAt = types.StringValue(b.UpdatedAt.String())
 	bm.UpdatedBy = types.StringValue(b.UpdatedBy)
 
+	if bm.CreateCatalogPage.IsNull() {
+		// backwards compatibility, if the field is not set, we assume that the user wants to create a catalog page
+		bm.CreateCatalogPage = types.BoolValue(true)
+	}
+
 	bm.Title = types.StringValue(b.Title)
 	bm.Icon = flex.GoStringToFramework(b.Icon)
 	bm.Description = flex.GoStringToFramework(b.Description)
@@ -130,12 +135,14 @@ func (r *BlueprintResource) Create(ctx context.Context, req resource.CreateReque
 
 	b, err := blueprintResourceToPortRequest(ctx, state)
 
+	createCatalogPage := state.CreateCatalogPage.ValueBoolPointer()
+
 	if err != nil {
 		resp.Diagnostics.AddError("failed to create blueprint", err.Error())
 		return
 	}
 
-	bp, err := r.portClient.CreateBlueprint(ctx, b)
+	bp, err := r.portClient.CreateBlueprint(ctx, b, createCatalogPage)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to create blueprint", err.Error())
 		return
@@ -177,9 +184,9 @@ func (r *BlueprintResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	var bp *cli.Blueprint
-
+	createCatalogPage := state.CreateCatalogPage.ValueBoolPointer()
 	if previousState.Identifier.IsNull() {
-		bp, err = r.portClient.CreateBlueprint(ctx, b)
+		bp, err = r.portClient.CreateBlueprint(ctx, b, createCatalogPage)
 		if err != nil {
 			resp.Diagnostics.AddError("failed to create blueprint", err.Error())
 			return

--- a/port/blueprint/resource_test.go
+++ b/port/blueprint/resource_test.go
@@ -769,7 +769,7 @@ func TestAccPortDestroyDeleteAllEntities(t *testing.T) {
 		Relations:             map[string]cli.Relation{},
 	}
 
-	_, err = portClient.CreateBlueprint(ctx, blueprint)
+	_, err = portClient.CreateBlueprint(ctx, blueprint, nil)
 
 	if err != nil {
 		t.Fatalf("Failed to create blueprint: %s", err.Error())

--- a/port/blueprint/schema.go
+++ b/port/blueprint/schema.go
@@ -454,6 +454,12 @@ func BlueprintSchema() map[string]schema.Attribute {
 			Computed:            true,
 			Default:             booldefault.StaticBool(false),
 		},
+		"create_catalog_page": schema.BoolAttribute{
+			MarkdownDescription: "This flag is only relevant for blueprint creation, by default if not set, a catalog page will be created for the blueprint",
+			Optional:            true,
+			Computed:            true,
+			Default:             booldefault.StaticBool(true),
+		},
 	}
 }
 


### PR DESCRIPTION
# Description

What - Currently by default we create catalog page for any blueprint creation, for use cases such as maintaining all the blueprints and pages through IaC.
Why - this can cause state discrepancies and therefor we want to add option skip that on creation
How - introduced `create_catalog_page` flag to blueprint resource

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)