### PR TITLE
[Entity] Handle undefined array type as string  

### DIFF
--- a/port/entity/refreshEntityToState.go
+++ b/port/entity/refreshEntityToState.go
@@ -25,7 +25,8 @@ func refreshArrayEntityState(ctx context.Context, state *EntityModel, arrayPrope
 	for k, t := range arrayProperties {
 
 		switch blueprint.Schema.Properties[k].Items["type"] {
-		case "string":
+		// array without items type is array of string by default
+		case "string", nil:
 			if t != nil {
 				for _, item := range t {
 					stringItem := item.(string)
@@ -80,7 +81,6 @@ func refreshArrayEntityState(ctx context.Context, state *EntityModel, arrayPrope
 				mapObjectItems[k] = nil
 			}
 			state.Properties.ArrayProps.ObjectItems, _ = types.MapValueFrom(ctx, types.ListType{ElemType: types.StringType}, mapObjectItems)
-
 		}
 	}
 }

--- a/port/entity/resource_test.go
+++ b/port/entity/resource_test.go
@@ -769,5 +769,60 @@ func TestAccPortEntityUpdateBlueprintIdentifier(t *testing.T) {
 			},
 		},
 	})
+}
 
+func TestAccPortEntityWithDefaultArrayProp(t *testing.T) {
+	identifier := utils.GenID()
+	entityIdentifier := utils.GenID()
+	var testAccActionConfigCreate = fmt.Sprintf(`
+	resource "port_blueprint" "microservice" {
+		title = "TF Provider Test BP0"
+		icon = "Terraform"
+		identifier = "%s"
+		properties = {
+			"array_props" = {
+				"myArrayIdentifier" =  {
+					"title" = "My Array Identifier"
+				}
+			}
+		}	
+	}
+	resource "port_entity" "microservice" {
+		title = "TF Provider Test Entity0"	
+		blueprint = port_blueprint.microservice.identifier	
+		identifier = "%s"	
+		properties = {	
+			array_props = {
+				string_items = {
+					"myArrayIdentifier" =  ["My Array Value", "My Array Value2"]
+				}
+			}
+		}
+	}`, identifier, entityIdentifier)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + testAccActionConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_entity.microservice", "title", "TF Provider Test Entity0"),
+					resource.TestCheckResourceAttr("port_entity.microservice", "blueprint", identifier),
+					resource.TestCheckResourceAttr("port_entity.microservice", "properties.array_props.string_items.myArrayIdentifier.0", "My Array Value"),
+					resource.TestCheckResourceAttr("port_entity.microservice", "properties.array_props.string_items.myArrayIdentifier.1", "My Array Value2"),
+				),
+			},
+			{
+				Config: acctest.ProviderConfig + testAccActionConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_entity.microservice", "title", "TF Provider Test Entity0"),
+					resource.TestCheckResourceAttr("port_entity.microservice", "blueprint", identifier),
+					resource.TestCheckResourceAttr("port_entity.microservice", "properties.array_props.string_items.myArrayIdentifier.0", "My Array Value"),
+					resource.TestCheckResourceAttr("port_entity.microservice", "properties.array_props.string_items.myArrayIdentifier.1", "My Array Value2"),
+				),
+			},
+		},
+	})
 }


### PR DESCRIPTION
# Description

What - Currently the blueprint resource only supports array of type string, without specifying the actual type, which makes it return from the backend without `items.type`. This caused a bug with the entity state of string arrays where we didn't handle that kind of array type of "undefined". 
Why -
How -

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)