### PR TITLE
fixed incorrect title for microservices blueprint in examples

### DIFF
--- a/examples/resources/port_blueprint/main.tf
+++ b/examples/resources/port_blueprint/main.tf
@@ -38,7 +38,7 @@ resource "port_blueprint" "vm" {
 }
 
 resource "port_blueprint" "microservice" {
-  title      = "VM"
+  title      = "Microservice"
   icon       = "GPU"
   identifier = "hedwig-microservice"
   properties = {


### PR DESCRIPTION
# Description

What - The title of the microservice blueprint in the examples section was set to "VM" instead of microservice creating confusion when the terraform apply is run as there is already a VM blueprint
Why - change the title for the microservice blueprint to "Microservice" to make the example more logical
How - N/A

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)