### PR TITLE
Compatibility with new default empty url in schema

### DIFF
--- a/docs/resources/port_action.md
+++ b/docs/resources/port_action.md
@@ -652,6 +652,17 @@ Optional:
 Required:
 
 - `blueprint_identifier` (String) Required when selecting type Upsert Entity. The blueprint identifier of the entity for the upsert
+
+Optional:
+
+- `mapping` (Attributes) Upsert Entity invocation method (see [below for nested schema](#nestedatt--upsert_entity_method--mapping))
+- `title` (String) The title of the entity
+
+<a id="nestedatt--upsert_entity_method--mapping"></a>
+### Nested Schema for `upsert_entity_method.mapping`
+
+Required:
+
 - `identifier` (String) Required when selecting type Upsert Entity. The entity identifier for the upsert
 
 Optional:
@@ -660,7 +671,7 @@ Optional:
 - `properties` (String) The properties of the entity (key-value object encoded to a string)
 - `relations` (String) The relations of the entity (key-value object encoded to a string)
 - `teams` (List of String) The teams the entity belongs to
-- `title` (String) The title of the entity
+
 
 
 <a id="nestedatt--webhook_method"></a>

--- a/docs/resources/port_integration.md
+++ b/docs/resources/port_integration.md
@@ -4,6 +4,7 @@ page_title: "port_integration Resource - terraform-provider-port-labs"
 subcategory: ""
 description: |-
   Integration resource
+  NOTE: This resource manages existing integration and integration mappings, not for creating new integrations.
   Docs about integration and be found here https://docs.getport.io/integrations-index/.
   ```hcl
   resource "portintegration" "mycustomintegration" {
@@ -42,6 +43,8 @@ description: |-
 # port_integration (Resource)
 
 # Integration resource
+
+**NOTE:** This resource manages existing integration and integration mappings, not for creating new integrations.
 
 Docs about integration and be found [here](https://docs.getport.io/integrations-index/).
 

--- a/docs/resources/port_page.md
+++ b/docs/resources/port_page.md
@@ -5,6 +5,7 @@ subcategory: ""
 description: |-
   Page resource
   Docs about the different page types can be found here https://docs.getport.io/customize-pages-dashboards-and-plugins/page/catalog-page.
+  Docs about the different widget types can be found here https://docs.getport.io/customize-pages-dashboards-and-plugins/dashboards/#widget-type-identifiers-terraform.
   ~> WARNING
   The page resource is currently in beta and is subject to change in future versions.
   Use it by setting the Environment Variable PORT_BETA_FEATURES_ENABLED=true.
@@ -215,6 +216,8 @@ description: |-
 # Page resource
 
 Docs about the different page types can be found [here](https://docs.getport.io/customize-pages-dashboards-and-plugins/page/catalog-page).
+
+Docs about the different widget types can be found [here](https://docs.getport.io/customize-pages-dashboards-and-plugins/dashboards/#widget-type-identifiers-terraform).
 
 ~> **WARNING**
 The page resource is currently in beta and is subject to change in future versions.

--- a/port/integration/refreshIntegrationToState.go
+++ b/port/integration/refreshIntegrationToState.go
@@ -25,11 +25,13 @@ func refreshIntegrationState(state *IntegrationModel, a *cli.Integration, integr
 		if a.ChangelogDestination.Type == consts.Kafka {
 			state.KafkaChangelogDestination, _ = types.ObjectValue(nil, nil)
 		} else {
-			state.WebhookChangelogDestination = &WebhookChangelogDestinationModel{
-				Url: types.StringValue(a.ChangelogDestination.Url),
-			}
-			if a.ChangelogDestination.Agent != nil {
-				state.WebhookChangelogDestination.Agent = types.BoolValue(*a.ChangelogDestination.Agent)
+			if a.ChangelogDestination.Url != "" {
+				state.WebhookChangelogDestination = &WebhookChangelogDestinationModel{
+					Url: types.StringValue(a.ChangelogDestination.Url),
+				}
+				if a.ChangelogDestination.Agent != nil {
+					state.WebhookChangelogDestination.Agent = types.BoolValue(*a.ChangelogDestination.Agent)
+				}
 			}
 		}
 	}

--- a/port/integration/resource.go
+++ b/port/integration/resource.go
@@ -33,6 +33,10 @@ func (r *IntegrationResource) Configure(ctx context.Context, req resource.Config
 
 func (r *IntegrationResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.Append(resp.State.SetAttribute(
+		ctx, path.Root("installation_id"), req.ID,
+	)...)
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(
 		ctx, path.Root("id"), req.ID,
 	)...)
 }

--- a/port/integration/resource_test.go
+++ b/port/integration/resource_test.go
@@ -85,22 +85,22 @@ func createIntegrationWithWebHook(
 	}`, installationId, installationAppType)
 }
 
-func TestAccPortIntegrationBasic(t *testing.T) {
+func TestPortIntegrationBasic(t *testing.T) {
 	integrationIdentifier := utils.GenID()
 	err := os.Setenv("PORT_BETA_FEATURES_ENABLED", "true")
 	if err != nil {
 		t.Fatal(err)
 	}
-	var testAccPortIntegrationResourceBasic = createIntegration(integrationIdentifier)
+	var testPortIntegrationResourceBasic = createIntegration(integrationIdentifier)
 
-	var testAccBaseIntegrationPermissionsConfigUpdate = strings.Replace(testAccPortIntegrationResourceBasic, "1.33.7", "1.33.8", -1)
+	var testAccBaseIntegrationPermissionsConfigUpdate = strings.Replace(testPortIntegrationResourceBasic, "1.33.7", "1.33.8", -1)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPortIntegrationResourceBasic,
+				Config: testPortIntegrationResourceBasic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("port_integration.kafkush", "installation_id", integrationIdentifier),
 					resource.TestCheckResourceAttr("port_integration.kafkush", "title", "ZOMG"),
@@ -121,20 +121,20 @@ func TestAccPortIntegrationBasic(t *testing.T) {
 	})
 }
 
-func TestAccPortIntegrationWithWebhook(t *testing.T) {
+func TestPortIntegrationWithWebhook(t *testing.T) {
 	integrationIdentifier := utils.GenID()
 	err := os.Setenv("PORT_BETA_FEATURES_ENABLED", "true")
 	if err != nil {
 		t.Fatal(err)
 	}
-	var testAccPortIntegrationResourceBasic = createIntegrationWithWebHook(integrationIdentifier, "KAFKA")
+	var testPortIntegrationResourceBasic = createIntegrationWithWebHook(integrationIdentifier, "KAFKA")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccPortIntegrationResourceBasic,
+				Config: testPortIntegrationResourceBasic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("port_integration.kafkush", "installation_id", integrationIdentifier),
 					resource.TestCheckResourceAttr("port_integration.kafkush", "title", "ZOMG"),
@@ -144,6 +144,30 @@ func TestAccPortIntegrationWithWebhook(t *testing.T) {
 					resource.TestCheckResourceAttr("port_integration.kafkush", "webhook_changelog_destination.url", "https://google.com"),
 					resource.TestCheckResourceAttr("port_integration.kafkush", "webhook_changelog_destination.agent", "true"),
 				),
+			},
+		},
+	})
+}
+
+func TestPortIntegrationImport(t *testing.T) {
+	integrationIdentifier := utils.GenID()
+	var testPortIntegrationResourceBasic = createIntegrationWithWebHook(integrationIdentifier, "KAFKA")
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + testPortIntegrationResourceBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_integration.kafkush", "installation_app_type", "KAFKA"),
+					resource.TestCheckResourceAttr("port_integration.kafkush", "installation_id", integrationIdentifier),
+				),
+			},
+			{
+				ResourceName:      "port_integration.kafkush",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     integrationIdentifier,
 			},
 		},
 	})

--- a/port/integration/schema.go
+++ b/port/integration/schema.go
@@ -62,6 +62,8 @@ var IntegrationResourceMarkdownDescription = `
 
 # Integration resource
 
+**NOTE:** This resource manages existing integration and integration mappings, not for creating new integrations.
+
 Docs about integration and be found [here](https://docs.getport.io/integrations-index/).
 
 

--- a/port/page/schema.go
+++ b/port/page/schema.go
@@ -118,6 +118,8 @@ var PageResourceMarkdownDescription = `
 
 Docs about the different page types can be found [here](https://docs.getport.io/customize-pages-dashboards-and-plugins/page/catalog-page).
 
+Docs about the different widget types can be found [here](https://docs.getport.io/customize-pages-dashboards-and-plugins/dashboards/#widget-type-identifiers-terraform).
+
 ~> **WARNING**
 The page resource is currently in beta and is subject to change in future versions.
 Use it by setting the Environment Variable ` + "`PORT_BETA_FEATURES_ENABLED=true`" + `.


### PR DESCRIPTION
For webhooks/integrations, if no change destination as defined when
creating the integration, it now returns a change destination with an
empty string as url as oppose to no change destination

# Description

What - Update integrations port body parser
Why - Since the schema was changed, which wasn't defined to

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
