### PR TITLE
Add custom scorecard levels

### DIFF
--- a/docs/resources/port_scorecard.md
+++ b/docs/resources/port_scorecard.md
@@ -38,11 +38,25 @@ description: |-
     identifier = "Readiness"
     title      = "Readiness"
     blueprint  = portblueprint.microservice.identifier
-    rules      = [
+    levels     = [
+      {
+        title = "Not Ready"
+        color = "red"
+      },
+      {
+        title = "Partially Ready",
+        color = "yellow"
+      },
+      {
+        title = "Ready",
+        color = "green"
+      }
+    ]
+    rules = [
       {
         identifier = "hasOwner"
         title      = "Has Owner"
-        level      = "Gold"
+        level      = "Ready"
         query      = {
           combinator = "and"
           conditions = [
@@ -61,7 +75,7 @@ description: |-
       {
         identifier = "hasUrl"
         title      = "Has URL"
-        level      = "Silver"
+        level      = "Partially Ready"
         query      = {
           combinator = "and"
           conditions = [
@@ -75,7 +89,7 @@ description: |-
       {
         identifier = "checkSumIfRequired"
         title      = "Check Sum If Required"
-        level      = "Bronze"
+        level      = "Partially Ready"
         query      = {
           combinator = "or"
           conditions = [
@@ -144,11 +158,25 @@ resource "port_scorecard" "readiness" {
   identifier = "Readiness"
   title      = "Readiness"
   blueprint  = port_blueprint.microservice.identifier
-  rules      = [
+  levels = [
+    {
+      title = "Not Ready"
+      color = "red"
+    },
+    {
+      title = "Partially Ready",
+      color = "yellow"
+    },
+    {
+      title = "Ready",
+      color = "green"
+    }
+  ]
+  rules = [
     {
       identifier = "hasOwner"
       title      = "Has Owner"
-      level      = "Gold"
+      level      = "Ready"
       query      = {
         combinator = "and"
         conditions = [
@@ -167,7 +195,7 @@ resource "port_scorecard" "readiness" {
     {
       identifier = "hasUrl"
       title      = "Has URL"
-      level      = "Silver"
+      level      = "Partially Ready"
       query      = {
         combinator = "and"
         conditions = [
@@ -181,7 +209,7 @@ resource "port_scorecard" "readiness" {
     {
       identifier = "checkSumIfRequired"
       title      = "Check Sum If Required"
-      level      = "Bronze"
+      level      = "Partially Ready"
       query      = {
         combinator = "or"
         conditions = [
@@ -218,6 +246,10 @@ resource "port_scorecard" "readiness" {
 - `rules` (Attributes List) The rules of the scorecard (see [below for nested schema](#nestedatt--rules))
 - `title` (String) The title of the scorecard
 
+### Optional
+
+- `levels` (Attributes List) The levels of the scorecard. This overrides the default levels (Basic, Bronze, Silver, Gold) if provided (see [below for nested schema](#nestedatt--levels))
+
 ### Read-Only
 
 - `created_at` (String) The creation date of the scorecard
@@ -243,3 +275,13 @@ Required:
 
 - `combinator` (String) The combinator of the query
 - `conditions` (List of String) The conditions of the query. Each condition object should be encoded to a string
+
+
+
+<a id="nestedatt--levels"></a>
+### Nested Schema for `levels`
+
+Required:
+
+- `color` (String) The color of the level
+- `title` (String) The title of the level

--- a/docs/resources/port_scorecard.md
+++ b/docs/resources/port_scorecard.md
@@ -7,7 +7,7 @@ description: |-
   This resource allows you to manage a scorecard.
   See the Port documentation https://docs.getport.io/promote-scorecards/ for more information about scorecards.
   Example Usage
-  Create a parent blueprint with a child blueprint and an aggregation property to count the parent kids:
+  This will create a blueprint with a Scorecard measuring the readiness of a microservice.
   ```hcl
   resource "portblueprint" "microservice" {
     title      = "microservice"
@@ -38,25 +38,11 @@ description: |-
     identifier = "Readiness"
     title      = "Readiness"
     blueprint  = portblueprint.microservice.identifier
-    levels     = [
-      {
-        title = "Not Ready"
-        color = "red"
-      },
-      {
-        title = "Partially Ready",
-        color = "yellow"
-      },
-      {
-        title = "Ready",
-        color = "green"
-      }
-    ]
-    rules = [
+    rules      = [
       {
         identifier = "hasOwner"
         title      = "Has Owner"
-        level      = "Ready"
+        level      = "Gold"
         query      = {
           combinator = "and"
           conditions = [
@@ -75,7 +61,7 @@ description: |-
       {
         identifier = "hasUrl"
         title      = "Has URL"
-        level      = "Partially Ready"
+        level      = "Silver"
         query      = {
           combinator = "and"
           conditions = [
@@ -89,8 +75,113 @@ description: |-
       {
         identifier = "checkSumIfRequired"
         title      = "Check Sum If Required"
-        level      = "Partially Ready"
+        level      = "Bronze"
         query      = {
+          combinator = "or"
+          conditions = [
+            jsonencode({
+              property = "required"
+              operator : "="
+              value : false
+            }),
+            jsonencode({
+              property = "sum"
+              operator : ">"
+              value : 2
+            })
+          ]
+        }
+      }
+    ]
+    dependson = [
+      portblueprint.microservice
+    ]
+  }
+  Example Usage with Levels
+  This will override the default levels (Basic, Bronze, Silver, Gold) with the provided levels: Not Ready, Partially Ready, Ready.
+  ```hcl
+  resource "portblueprint" "microservice" {
+    title      = "microservice"
+    icon       = "Terraform"
+    identifier = "microservice"
+    properties = {
+      stringprops = {
+        "author" = {
+          title = "Author"
+        }
+        "url" = {
+          title = "URL"
+        }
+      }
+      booleanprops = {
+        "required" = {
+          type = "boolean"
+        }
+      }
+      numberprops = {
+        "sum" = {
+          type = "number"
+        }
+      }
+    }
+  }
+  resource "portscorecard" "readiness" {
+    identifier = "Readiness"
+    title      = "Readiness"
+    blueprint  = portblueprint.microservice.identifier
+    levels = [
+      {
+        color = "red"
+        title = "No Ready"
+      },
+      {
+        color = "yellow"
+        title = "Partially Ready"
+      },
+      {
+        color = "green"
+        title = "Ready"
+      }
+    ]
+    rules = [
+      {
+        identifier = "hasOwner"
+        title      = "Has Owner"
+        level      = "Ready"
+        query = {
+          combinator = "and"
+          conditions = [
+            jsonencode({
+              property = "$team"
+              operator = "isNotEmpty"
+            }),
+            jsonencode({
+              property = "author",
+              operator : "=",
+              value : "myValue"
+            })
+          ]
+        }
+      },
+      {
+        identifier = "hasUrl"
+        title      = "Has URL"
+        level      = "Partially Ready"
+        query = {
+          combinator = "and"
+          conditions = [
+            jsonencode({
+              property = "url"
+              operator = "isNotEmpty"
+            })
+          ]
+        }
+      },
+      {
+        identifier = "checkSumIfRequired"
+        title      = "Check Sum If Required"
+        level      = "Partially Ready"
+        query = {
           combinator = "or"
           conditions = [
             jsonencode({
@@ -124,7 +215,106 @@ See the [Port documentation](https://docs.getport.io/promote-scorecards/) for mo
 
 ## Example Usage
 
-Create a parent blueprint with a child blueprint and an aggregation property to count the parent kids:
+This will create a blueprint with a Scorecard measuring the readiness of a microservice.
+
+```hcl
+
+resource "port_blueprint" "microservice" {
+  title      = "microservice"
+  icon       = "Terraform"
+  identifier = "microservice"
+  properties = {
+    string_props = {
+      "author" = {
+        title = "Author"
+      }
+      "url" = {
+        title = "URL"
+      }
+    }
+    boolean_props = {
+      "required" = {
+        type = "boolean"
+      }
+    }
+    number_props = {
+      "sum" = {
+        type = "number"
+      }
+    }
+  }
+}
+
+resource "port_scorecard" "readiness" {
+  identifier = "Readiness"
+  title      = "Readiness"
+  blueprint  = port_blueprint.microservice.identifier
+  rules      = [
+    {
+      identifier = "hasOwner"
+      title      = "Has Owner"
+      level      = "Gold"
+      query      = {
+        combinator = "and"
+        conditions = [
+          jsonencode({
+            property = "$team"
+            operator = "isNotEmpty"
+          }),
+          jsonencode({
+            property = "author",
+            operator : "=",
+            value : "myValue"
+          })
+        ]
+      }
+    },
+    {
+      identifier = "hasUrl"
+      title      = "Has URL"
+      level      = "Silver"
+      query      = {
+        combinator = "and"
+        conditions = [
+          jsonencode({
+            property = "url"
+            operator = "isNotEmpty"
+          })
+        ]
+      }
+    },
+    {
+      identifier = "checkSumIfRequired"
+      title      = "Check Sum If Required"
+      level      = "Bronze"
+      query      = {
+        combinator = "or"
+        conditions = [
+          jsonencode({
+            property = "required"
+            operator : "="
+            value : false
+          }),
+          jsonencode({
+            property = "sum"
+            operator : ">"
+            value : 2
+          })
+        ]
+      }
+    }
+  ]
+  depends_on = [
+    port_blueprint.microservice
+  ]
+}
+
+
+
+## Example Usage with Levels
+
+This will override the default levels (Basic, Bronze, Silver, Gold) with the provided levels: Not Ready, Partially Ready, Ready.
+
 
 ```hcl
 
@@ -160,16 +350,16 @@ resource "port_scorecard" "readiness" {
   blueprint  = port_blueprint.microservice.identifier
   levels = [
     {
-      title = "Not Ready"
       color = "red"
+      title = "No Ready"
     },
     {
-      title = "Partially Ready",
       color = "yellow"
+      title = "Partially Ready"
     },
     {
-      title = "Ready",
       color = "green"
+      title = "Ready"
     }
   ]
   rules = [
@@ -177,7 +367,7 @@ resource "port_scorecard" "readiness" {
       identifier = "hasOwner"
       title      = "Has Owner"
       level      = "Ready"
-      query      = {
+      query = {
         combinator = "and"
         conditions = [
           jsonencode({
@@ -196,7 +386,7 @@ resource "port_scorecard" "readiness" {
       identifier = "hasUrl"
       title      = "Has URL"
       level      = "Partially Ready"
-      query      = {
+      query = {
         combinator = "and"
         conditions = [
           jsonencode({
@@ -210,7 +400,7 @@ resource "port_scorecard" "readiness" {
       identifier = "checkSumIfRequired"
       title      = "Check Sum If Required"
       level      = "Partially Ready"
-      query      = {
+      query = {
         combinator = "or"
         conditions = [
           jsonencode({

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -26,15 +26,9 @@ type (
 		Level      string `json:"level"`
 	}
 
-	ScorecardLevelModel struct {
-		Title string `json:"title"`
-		Color string `json:"color"`
-	}
-
 	ScorecardModel struct {
-		Rules  []ScorecardRulesModel `json:"rules"`
-		Levels []ScorecardLevelModel `json:"levels"`
-		Level  string                `json:"level"`
+		Rules []ScorecardRulesModel `json:"rules"`
+		Level string                `json:"level"`
 	}
 
 	Entity struct {

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -21,14 +21,20 @@ type (
 	}
 
 	ScorecardRulesModel struct {
-		Identifier string `tfsdk:"identifier"`
-		Status     string `tfsdk:"status"`
-		Level      string `tfsdk:"level"`
+		Identifier string `json:"identifier"`
+		Status     string `json:"status"`
+		Level      string `json:"level"`
+	}
+
+	ScorecardLevelModel struct {
+		Title string `json:"title"`
+		Color string `json:"color"`
 	}
 
 	ScorecardModel struct {
-		Rules []ScorecardRulesModel `tfsdk:"rules"`
-		Level string                `tfsdk:"level"`
+		Rules  []ScorecardRulesModel `json:"rules"`
+		Levels []ScorecardLevelModel `json:"levels"`
+		Level  string                `json:"level"`
 	}
 
 	Entity struct {
@@ -326,10 +332,11 @@ type (
 
 	Scorecard struct {
 		Meta
-		Identifier string `json:"identifier,omitempty"`
-		Title      string `json:"title,omitempty"`
-		Blueprint  string `json:"blueprint,omitempty"`
-		Rules      []Rule `json:"rules,omitempty"`
+		Identifier string  `json:"identifier,omitempty"`
+		Title      string  `json:"title,omitempty"`
+		Blueprint  string  `json:"blueprint,omitempty"`
+		Levels     []Level `json:"levels,omitempty"`
+		Rules      []Rule  `json:"rules,omitempty"`
 	}
 
 	Rule struct {
@@ -339,6 +346,10 @@ type (
 		Query      Query  `json:"query,omitempty"`
 	}
 
+	Level struct {
+		Title string `json:"title,omitempty"`
+		Color string `json:"color,omitempty"`
+	}
 	Query struct {
 		Combinator string `json:"combinator,omitempty"`
 		Conditions []any  `json:"conditions,omitempty"`

--- a/port/scorecard/model.go
+++ b/port/scorecard/model.go
@@ -26,7 +26,7 @@ type ScorecardModel struct {
 	Identifier types.String `tfsdk:"identifier"`
 	Blueprint  types.String `tfsdk:"blueprint"`
 	Title      types.String `tfsdk:"title"`
-	Levels      []Level `tfsdk:"levels"`
+	Levels     []Level      `tfsdk:"levels"`
 	Rules      []Rule       `tfsdk:"rules"`
 	CreatedAt  types.String `tfsdk:"created_at"`
 	CreatedBy  types.String `tfsdk:"created_by"`

--- a/port/scorecard/model.go
+++ b/port/scorecard/model.go
@@ -16,11 +16,17 @@ type Rule struct {
 	Query      *Query       `tfsdk:"query"`
 }
 
+type Level struct {
+	Title types.String `tfsdk:"title"`
+	Color types.String `tfsdk:"color"`
+}
+
 type ScorecardModel struct {
 	ID         types.String `tfsdk:"id"`
 	Identifier types.String `tfsdk:"identifier"`
 	Blueprint  types.String `tfsdk:"blueprint"`
 	Title      types.String `tfsdk:"title"`
+	Levels      []Level `tfsdk:"levels"`
 	Rules      []Rule       `tfsdk:"rules"`
 	CreatedAt  types.String `tfsdk:"created_at"`
 	CreatedBy  types.String `tfsdk:"created_by"`

--- a/port/scorecard/refreshScorecardState.go
+++ b/port/scorecard/refreshScorecardState.go
@@ -53,7 +53,7 @@ func DefaultCliLevels() []cli.Level {
 	}
 }
 
-func refreshScorecardState(ctx context.Context, state *ScorecardModel, s *cli.Scorecard, blueprintIdentifier string, includeLevels ...bool) {
+func refreshScorecardState(ctx context.Context, state *ScorecardModel, s *cli.Scorecard, blueprintIdentifier string) {
 	state.ID = types.StringValue(fmt.Sprintf("%s:%s", blueprintIdentifier, s.Identifier))
 	state.Identifier = types.StringValue(s.Identifier)
 	state.Blueprint = types.StringValue(blueprintIdentifier)
@@ -86,7 +86,7 @@ func refreshScorecardState(ctx context.Context, state *ScorecardModel, s *cli.Sc
 	}
 
 	state.Rules = stateRules
-	if len(includeLevels) > 0 && includeLevels[0] || (shouldRefreshLevels(state.Levels, s.Levels)) {
+	if shouldRefreshLevels(state.Levels, s.Levels) {
 		state.Levels = fromCliLevelsToTerraformLevels(s.Levels)
 	}
 }

--- a/port/scorecard/refreshScorecardState.go
+++ b/port/scorecard/refreshScorecardState.go
@@ -11,15 +11,23 @@ import (
 )
 
 func shouldRefreshLevels(stateLevels []Level, cliLevels []cli.Level) bool {
-	// If the TF state has no levels and the Port existing levels are the default levels, we don't need to refresh the TF state
+	// When you create a scorecard in Port, the scorecard gets created with default levels. 
+	// If your scorecard doesn't have the "levels" attribute, it means the scorecard is created with default levels behind the scenes.
+	//
+	// If the TF state has no levels and the Port existing levels are the default levels, This means both are considered 
+	// to have default levels, And so we don't need to update them.
 	if len(stateLevels) == 0 && reflect.DeepEqual(cliLevels, DefaultCliLevels()) {
 		return false
 	}
-	// If the TF state has levels / TF state doesn't have levels and the Port existing levels are not the default ones
-	// We have to make sure our Terraform state aligns with the Port existing levels
+	// If the TF state has defined levels, we have to make sure that Port's existing levels are the same as the TF state levels.
+	// also,
+	// If TF state doesn't have levels and the Port existing levels are not the default ones,
+	// this means we have to make sure that Port's defined levels are the default levels, 
+	// as the state without levels is considered to have default levels.
 	if len(stateLevels) > 0 || (len(stateLevels) == 0 && !reflect.DeepEqual(cliLevels, DefaultCliLevels())) {
 		return true
 	}
+
 	return false
 }
 

--- a/port/scorecard/refreshScorecardState.go
+++ b/port/scorecard/refreshScorecardState.go
@@ -14,13 +14,8 @@ func shouldRefreshLevels(stateLevels []Level, cliLevels []cli.Level) bool {
 	if len(stateLevels) == 0 && reflect.DeepEqual(cliLevels, DefaultCliLevels()) {
 		return false
 	}
-	if len(stateLevels) > 0 && len(stateLevels) != len(cliLevels) {
+	if len(stateLevels) > 0 || (len(stateLevels) == 0 && !reflect.DeepEqual(cliLevels, DefaultCliLevels())) {
 		return true
-	}
-	for i, stateLevel := range stateLevels {
-		if stateLevel.Color != types.StringValue(cliLevels[i].Color) || stateLevel.Title != types.StringValue(cliLevels[i].Title) {
-			return true
-		}
 	}
 	return false
 }

--- a/port/scorecard/refreshScorecardState.go
+++ b/port/scorecard/refreshScorecardState.go
@@ -11,9 +11,12 @@ import (
 )
 
 func shouldRefreshLevels(stateLevels []Level, cliLevels []cli.Level) bool {
+	// If the TF state has no levels and the Port existing levels are the default levels, we don't need to refresh the TF state
 	if len(stateLevels) == 0 && reflect.DeepEqual(cliLevels, DefaultCliLevels()) {
 		return false
 	}
+	// If the TF state has levels / TF state doesn't have levels and the Port existing levels are not the default ones
+	// We have to make sure our Terraform state aligns with the Port existing levels
 	if len(stateLevels) > 0 || (len(stateLevels) == 0 && !reflect.DeepEqual(cliLevels, DefaultCliLevels())) {
 		return true
 	}

--- a/port/scorecard/resource.go
+++ b/port/scorecard/resource.go
@@ -53,8 +53,8 @@ func (r *ScorecardResource) Read(ctx context.Context, req resource.ReadRequest, 
 		resp.Diagnostics.AddError("failed to read scorecard", err.Error())
 		return
 	}
-
-	refreshScorecardState(ctx, state, s, blueprintIdentifier)
+	shouldRefreshLevels := len(state.Levels) > 0 || len(s.Levels) > 0
+	refreshScorecardState(ctx, state, s, blueprintIdentifier, shouldRefreshLevels)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/port/scorecard/resource.go
+++ b/port/scorecard/resource.go
@@ -2,12 +2,10 @@ package scorecard
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
 )
 
@@ -81,18 +79,10 @@ func (r *ScorecardResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	writeScorecardComputedFieldsToState(state, sp)
+	shouldRefreshLevels := len(state.Levels) > 0
+	refreshScorecardState(ctx, state, sp, state.Blueprint.ValueString(), shouldRefreshLevels)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-}
-
-func writeScorecardComputedFieldsToState(state *ScorecardModel, wp *cli.Scorecard) {
-	state.ID = types.StringValue(fmt.Sprintf("%s:%s", wp.Blueprint, wp.Identifier))
-	state.Identifier = types.StringValue(wp.Identifier)
-	state.CreatedAt = types.StringValue(wp.CreatedAt.String())
-	state.CreatedBy = types.StringValue(wp.CreatedBy)
-	state.UpdatedAt = types.StringValue(wp.UpdatedAt.String())
-	state.UpdatedBy = types.StringValue(wp.UpdatedBy)
 }
 
 func (r *ScorecardResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
@@ -125,7 +115,7 @@ func (r *ScorecardResource) Update(ctx context.Context, req resource.UpdateReque
 		return
 	}
 
-	writeScorecardComputedFieldsToState(state, sp)
+	refreshScorecardState(ctx, state, sp, state.Blueprint.ValueString())
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/port/scorecard/resource.go
+++ b/port/scorecard/resource.go
@@ -53,7 +53,7 @@ func (r *ScorecardResource) Read(ctx context.Context, req resource.ReadRequest, 
 		resp.Diagnostics.AddError("failed to read scorecard", err.Error())
 		return
 	}
-	shouldRefreshLevels := len(state.Levels) > 0 || len(s.Levels) > 0
+	shouldRefreshLevels := shouldRefreshLevels(state.Levels, s.Levels)
 	refreshScorecardState(ctx, state, s, blueprintIdentifier, shouldRefreshLevels)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -79,7 +79,7 @@ func (r *ScorecardResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	shouldRefreshLevels := len(state.Levels) > 0
+	shouldRefreshLevels := shouldRefreshLevels(state.Levels, sp.Levels)
 	refreshScorecardState(ctx, state, sp, state.Blueprint.ValueString(), shouldRefreshLevels)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
@@ -114,8 +114,8 @@ func (r *ScorecardResource) Update(ctx context.Context, req resource.UpdateReque
 		resp.Diagnostics.AddError("failed to update the scorecard", err.Error())
 		return
 	}
-
-	refreshScorecardState(ctx, state, sp, state.Blueprint.ValueString())
+	shouldRefreshLevels := shouldRefreshLevels(state.Levels, sp.Levels)
+	refreshScorecardState(ctx, state, sp, state.Blueprint.ValueString(), shouldRefreshLevels)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/port/scorecard/resource.go
+++ b/port/scorecard/resource.go
@@ -53,8 +53,7 @@ func (r *ScorecardResource) Read(ctx context.Context, req resource.ReadRequest, 
 		resp.Diagnostics.AddError("failed to read scorecard", err.Error())
 		return
 	}
-	shouldRefreshLevels := shouldRefreshLevels(state.Levels, s.Levels)
-	refreshScorecardState(ctx, state, s, blueprintIdentifier, shouldRefreshLevels)
+	refreshScorecardState(ctx, state, s, blueprintIdentifier)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -79,8 +78,7 @@ func (r *ScorecardResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	shouldRefreshLevels := shouldRefreshLevels(state.Levels, sp.Levels)
-	refreshScorecardState(ctx, state, sp, state.Blueprint.ValueString(), shouldRefreshLevels)
+	refreshScorecardState(ctx, state, sp, state.Blueprint.ValueString())
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -114,8 +112,8 @@ func (r *ScorecardResource) Update(ctx context.Context, req resource.UpdateReque
 		resp.Diagnostics.AddError("failed to update the scorecard", err.Error())
 		return
 	}
-	shouldRefreshLevels := shouldRefreshLevels(state.Levels, sp.Levels)
-	refreshScorecardState(ctx, state, sp, state.Blueprint.ValueString(), shouldRefreshLevels)
+	
+	refreshScorecardState(ctx, state, sp, state.Blueprint.ValueString())
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/port/scorecard/schema.go
+++ b/port/scorecard/schema.go
@@ -13,6 +13,19 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 )
 
+func LevelSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"color": schema.StringAttribute{
+			MarkdownDescription: "The color of the level",
+			Required:            true,
+		},
+		"title": schema.StringAttribute{
+			MarkdownDescription: "The title of the level",
+			Required:            true,
+		},
+	}
+}
+
 func RuleSchema() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"identifier": schema.StringAttribute{
@@ -70,6 +83,13 @@ func ScorecardSchema() map[string]schema.Attribute {
 			MarkdownDescription: "The title of the scorecard",
 			Required:            true,
 		},
+		"levels": schema.ListNestedAttribute{
+			MarkdownDescription: "The Levels of the scorecard",
+			Optional:            true,
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: LevelSchema(),
+			},
+		}, 
 		"rules": schema.ListNestedAttribute{
 			MarkdownDescription: "The rules of the scorecard",
 			Required:            true,

--- a/port/scorecard/schema.go
+++ b/port/scorecard/schema.go
@@ -39,9 +39,6 @@ func RuleSchema() map[string]schema.Attribute {
 		"level": schema.StringAttribute{
 			MarkdownDescription: "The level of the rule",
 			Required:            true,
-			Validators: []validator.String{
-				stringvalidator.OneOf("Bronze", "Silver", "Gold"),
-			},
 		},
 		"query": schema.SingleNestedAttribute{
 			MarkdownDescription: "The query of the rule",

--- a/port/scorecard/schema.go
+++ b/port/scorecard/schema.go
@@ -81,12 +81,12 @@ func ScorecardSchema() map[string]schema.Attribute {
 			Required:            true,
 		},
 		"levels": schema.ListNestedAttribute{
-			MarkdownDescription: "The Levels of the scorecard",
+			MarkdownDescription: "The levels of the scorecard. This overrides the default levels (Basic, Bronze, Silver, Gold) if provided",
 			Optional:            true,
 			NestedObject: schema.NestedAttributeObject{
 				Attributes: LevelSchema(),
 			},
-		}, 
+		},
 		"rules": schema.ListNestedAttribute{
 			MarkdownDescription: "The rules of the scorecard",
 			Required:            true,
@@ -170,12 +170,26 @@ resource "port_scorecard" "readiness" {
   identifier = "Readiness"
   title      = "Readiness"
   blueprint  = port_blueprint.microservice.identifier
-  rules      = [
+  levels = [
+    {
+      title = "Not Ready"
+      color = "red"
+    },
+    {
+      title = "Partially Ready",
+      color = "yellow"
+    },
+    {
+      title = "Ready",
+      color = "green"
+    }
+  ]
+  rules = [
     {
       identifier = "hasOwner"
       title      = "Has Owner"
-      level      = "Gold"
-      query      = {
+      level      = "Ready"
+      query = {
         combinator = "and"
         conditions = [
           jsonencode({
@@ -193,8 +207,8 @@ resource "port_scorecard" "readiness" {
     {
       identifier = "hasUrl"
       title      = "Has URL"
-      level      = "Silver"
-      query      = {
+      level      = "Partially Ready"
+      query = {
         combinator = "and"
         conditions = [
           jsonencode({
@@ -207,8 +221,8 @@ resource "port_scorecard" "readiness" {
     {
       identifier = "checkSumIfRequired"
       title      = "Check Sum If Required"
-      level      = "Bronze"
-      query      = {
+      level      = "Partially Ready"
+      query = {
         combinator = "or"
         conditions = [
           jsonencode({

--- a/port/scorecard/scorecardResourceToPortBody.go
+++ b/port/scorecard/scorecardResourceToPortBody.go
@@ -6,6 +6,18 @@ import (
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
 )
 
+func fromTerraformLevelsToCliLevels(tfLevels []Level) []cli.Level {
+	var levels []cli.Level
+	for _, stateLevel := range tfLevels {
+		level := &cli.Level{
+			Color: stateLevel.Color.ValueString(),
+			Title: stateLevel.Title.ValueString(),
+		}
+		levels = append(levels, *level)
+	}
+	return levels
+}
+
 func scorecardResourceToPortBody(ctx context.Context, state *ScorecardModel) (*cli.Scorecard, error) {
 	s := &cli.Scorecard{
 		Identifier: state.Identifier.ValueString(),
@@ -42,6 +54,10 @@ func scorecardResourceToPortBody(ctx context.Context, state *ScorecardModel) (*c
 	}
 
 	s.Rules = rules
+
+	if len(state.Levels) > 0 {
+		s.Levels = fromTerraformLevelsToCliLevels(state.Levels)
+	}
 
 	return s, nil
 }


### PR DESCRIPTION
# Description

What - Added levels to scorecards
Why - To enable custom management of the scorecard levels
How - Add to schema + add state handling to where levels is provided by the terraform resource or not 

## Type of change

Please leave one option from the following and delete the rest:

- [ ] New feature (non-breaking change which adds functionality)