### PR TITLE
Fix page permissions import

### DIFF
--- a/port/page-permissions/model.go
+++ b/port/page-permissions/model.go
@@ -9,7 +9,7 @@ type ReadPagePermissionsModel struct {
 }
 
 type PagePermissionsModel struct {
-	ID             types.String             `tfsdk:"id"`
-	PageIdentifier types.String             `tfsdk:"page_identifier"`
-	Read           ReadPagePermissionsModel `tfsdk:"read"`
+	ID             types.String              `tfsdk:"id"`
+	PageIdentifier types.String              `tfsdk:"page_identifier"`
+	Read           *ReadPagePermissionsModel `tfsdk:"read"`
 }

--- a/port/page-permissions/refreshPagePermissionsToState.go
+++ b/port/page-permissions/refreshPagePermissionsToState.go
@@ -8,7 +8,7 @@ import (
 func refreshPagePermissionsState(state *PagePermissionsModel, a *cli.PagePermissions, pageId string) error {
 	state.ID = types.StringValue(pageId)
 	state.PageIdentifier = types.StringValue(pageId)
-	state.Read = ReadPagePermissionsModel{}
+	state.Read = &ReadPagePermissionsModel{}
 
 	state.Read.Users = make([]types.String, len(a.Read.Users))
 	for i, u := range a.Read.Users {

--- a/port/page-permissions/resource_test.go
+++ b/port/page-permissions/resource_test.go
@@ -147,3 +147,40 @@ func TestAccPortPagePermissionsUpdateWithUsers(t *testing.T) {
 		},
 	})
 }
+
+func TestAccPortPagePermissionsImport(t *testing.T) {
+	pageIdentifier := utils.GenID()
+	err := os.Setenv("PORT_BETA_FEATURES_ENABLED", "true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var testAccPortPageResourceBasic = createPage(pageIdentifier)
+
+	var testAccBasePagePermissionsConfigUpdate = `
+
+	resource "port_page_permissions" "microservice_permissions" {
+		page_identifier = port_page.microservice_dashboard_page.identifier
+		read = {
+			"roles": [
+				"Member",
+			],
+			"users": [],
+			"teams": []
+			}
+	}`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPortPageResourceBasic + testAccBasePagePermissionsConfigUpdate,
+			},
+			{
+				ResourceName:      "port_page_permissions.microservice_permissions",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}


### PR DESCRIPTION
# Description

What - Fix page permissions import
Why - Import didn't work due to wrong initialization of the model object
How - Changed reference to a pointer to allow passing null when using import

Fixes the following 
```
➜  import-action terraform plan -generate-config-out page-permission-state.tf
port_page_permissions.gitlabIssues: Preparing import... [id=gitlabIssues]
port_page_permissions.gitlabIssues: Refreshing state... [id=gitlabIssues]

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: Value Conversion Error
│
│ An unexpected error was encountered trying to build a value. This is always an error in the provider. Please report the
│ following to the provider developer:
│
│ Received null value, however the target type cannot handle null values. Use the corresponding `types` package type, a pointer
│ type or a custom type that handles null values.
│
│ Path: read
│ Target Type: page_permissions.ReadPagePermissionsModel
│ Suggested `types` Type: basetypes.ObjectValue
│ Suggested Pointer Type: *page_permissions.ReadPagePermissionsModel
╵
```

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)