### PR TITLE
Fix upsert entity invocation

### DIFF
--- a/port/action/actionStateToPortBody.go
+++ b/port/action/actionStateToPortBody.go
@@ -332,8 +332,14 @@ func invocationMethodToBody(ctx context.Context, data *ActionModel) (*cli.Invoca
 				Identifier: data.UpsertEntityMethod.Mapping.Identifier.ValueStringPointer(),
 				Title:      data.UpsertEntityMethod.Title.ValueStringPointer(),
 				Icon:       data.UpsertEntityMethod.Mapping.Icon.ValueStringPointer(),
-				Properties: *properties,
-				Relations:  *relations,
+			}
+
+			if properties != nil {
+				mapping.Properties = *properties
+			}
+
+			if relations != nil {
+				mapping.Relations = *relations
 			}
 		}
 

--- a/port/action/refreshActionState.go
+++ b/port/action/refreshActionState.go
@@ -126,7 +126,7 @@ func writeInvocationMethodToResource(ctx context.Context, a *cli.Action, state *
 				Relations:  relations,
 				Icon:       flex.GoStringToFramework(a.InvocationMethod.Mapping.Icon),
 				Teams:      teams,
-				Identifier: types.StringValue(*a.InvocationMethod.Mapping.Identifier),
+				Identifier: types.StringPointerValue(a.InvocationMethod.Mapping.Identifier),
 			},
 		}
 	}

--- a/port/action/resource_test.go
+++ b/port/action/resource_test.go
@@ -2024,3 +2024,46 @@ func TestAccPortActionConditionalTrigger(t *testing.T) {
 		},
 	})
 }
+
+func TestAccPortActionUpsertEntityWithoutMappingIdentifier(t *testing.T) {
+	identifier := utils.GenID()
+	actionIdentifier := utils.GenID()
+	var testAccActionConfigCreate = testAccCreateBlueprintConfig(identifier) + fmt.Sprintf(`
+	resource "port_action" "create_microservice" {
+		title = "TF Provider Test"
+		identifier = "%s"
+		icon = "Terraform"
+		self_service_trigger = {
+			operation = "DAY-2"
+			blueprint_identifier = port_blueprint.microservice.identifier
+		}
+		upsert_entity_method = {
+			title = "Test Entity"
+			blueprint_identifier = port_blueprint.microservice.identifier
+			mapping = {
+				properties = jsonencode({"text": "test"})
+			}
+		}
+	}`, actionIdentifier)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + testAccActionConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_action.create_microservice", "title", "TF Provider Test"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "identifier", actionIdentifier),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "icon", "Terraform"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.blueprint_identifier", identifier),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.operation", "DAY-2"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "upsert_entity_method.title", "Test Entity"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "upsert_entity_method.blueprint_identifier", identifier),
+					resource.TestCheckNoResourceAttr("port_action.create_microservice", "upsert_entity_method.mapping.identifier"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "upsert_entity_method.mapping.properties", "{\"text\":\"test\"}"),
+				),
+			},
+		},
+	})
+}

--- a/port/action/schema.go
+++ b/port/action/schema.go
@@ -368,7 +368,7 @@ func ActionSchema() map[string]schema.Attribute {
 					Attributes: map[string]schema.Attribute{
 						"identifier": schema.StringAttribute{
 							MarkdownDescription: "Required when selecting type Upsert Entity. The entity identifier for the upsert",
-							Required:            true,
+							Optional:            true,
 						},
 						"teams": schema.ListAttribute{
 							MarkdownDescription: "The teams the entity belongs to",


### PR DESCRIPTION
# Description

What - Fix upsert entity invocation
Why - Cannot use it without identifier
How - mark identifier optional and fix access to it

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)