### PR TITLE
Port 9649 bug terraform does not support multiple approvals

### DIFF
--- a/docs/data-sources/port_search.md
+++ b/docs/data-sources/port_search.md
@@ -225,3 +225,5 @@ Read-Only:
 - `identifier` (String)
 - `level` (String)
 - `status` (String)
+
+

--- a/docs/resources/port_action.md
+++ b/docs/resources/port_action.md
@@ -304,7 +304,7 @@ resource "port_action" "create_microservice" {
 - `icon` (String) Icon
 - `kafka_method` (Attributes) Kafka invocation method (see [below for nested schema](#nestedatt--kafka_method))
 - `publish` (Boolean) Publish action
-- `required_approval` (Boolean) Require approval before invoking the action
+- `required_approval` (String) Require approval before invoking the action
 - `self_service_trigger` (Attributes) Self service trigger for the action (see [below for nested schema](#nestedatt--self_service_trigger))
 - `title` (String) Title
 - `upsert_entity_method` (Attributes) Upsert Entity invocation method (see [below for nested schema](#nestedatt--upsert_entity_method))
@@ -661,13 +661,10 @@ Optional:
 <a id="nestedatt--upsert_entity_method--mapping"></a>
 ### Nested Schema for `upsert_entity_method.mapping`
 
-Required:
-
-- `identifier` (String) Required when selecting type Upsert Entity. The entity identifier for the upsert
-
 Optional:
 
 - `icon` (String) The icon of the entity
+- `identifier` (String) Required when selecting type Upsert Entity. The entity identifier for the upsert
 - `properties` (String) The properties of the entity (key-value object encoded to a string)
 - `relations` (String) The relations of the entity (key-value object encoded to a string)
 - `teams` (List of String) The teams the entity belongs to
@@ -688,3 +685,5 @@ Optional:
 - `headers` (Map of String) The HTTP headers for invoking the action. They should be encoded as a key-value object to a string using [jsonencode](https://developer.hashicorp.com/terraform/language/functions/jsonencode). Learn about how to [define the action payload](https://docs.getport.io/create-self-service-experiences/setup-backend/#define-the-actions-payload).
 - `method` (String) The HTTP method to invoke the action
 - `synchronized` (String) Synchronize the action
+
+

--- a/docs/resources/port_action.md
+++ b/docs/resources/port_action.md
@@ -304,7 +304,7 @@ resource "port_action" "create_microservice" {
 - `icon` (String) Icon
 - `kafka_method` (Attributes) Kafka invocation method (see [below for nested schema](#nestedatt--kafka_method))
 - `publish` (Boolean) Publish action
-- `required_approval` (String) Require approval before invoking the action
+- `required_approval` (String) Require approval before invoking the action. Can be one of "true", "false", "ANY" or "ALL"
 - `self_service_trigger` (Attributes) Self service trigger for the action (see [below for nested schema](#nestedatt--self_service_trigger))
 - `title` (String) Title
 - `upsert_entity_method` (Attributes) Upsert Entity invocation method (see [below for nested schema](#nestedatt--upsert_entity_method))

--- a/docs/resources/port_action_permissions.md
+++ b/docs/resources/port_action_permissions.md
@@ -265,3 +265,5 @@ Optional:
 - `roles` (List of String) The roles with execution permission
 - `teams` (List of String) The teams with execution permission
 - `users` (List of String) The users with execution permission
+
+

--- a/docs/resources/port_aggregation_properties.md
+++ b/docs/resources/port_aggregation_properties.md
@@ -645,3 +645,5 @@ Optional:
 
 - `average_of` (String) The time periods to calculate the average of, e.g. hour, day, week, month
 - `measure_time_by` (String) The property name on which to calculate the the time periods, e.g. $createdAt, $updated_at or any other date property
+
+

--- a/docs/resources/port_blueprint.md
+++ b/docs/resources/port_blueprint.md
@@ -499,3 +499,5 @@ Required:
 Optional:
 
 - `agent` (Boolean) The agent of the webhook changelog destination
+
+

--- a/docs/resources/port_blueprint_permissions.md
+++ b/docs/resources/port_blueprint_permissions.md
@@ -450,3 +450,5 @@ Optional:
 - `roles` (List of String) Roles with update specific relation permissions
 - `teams` (List of String) Teams with update specific relation permissions
 - `users` (List of String) Users with update specific relation permissions
+
+

--- a/docs/resources/port_entity.md
+++ b/docs/resources/port_entity.md
@@ -67,3 +67,5 @@ Optional:
 
 - `many_relations` (Map of List of String) The many relation of the entity
 - `single_relations` (Map of String) The single relation of the entity
+
+

--- a/docs/resources/port_integration.md
+++ b/docs/resources/port_integration.md
@@ -128,3 +128,5 @@ Required:
 Optional:
 
 - `agent` (Boolean) The agent of the webhook changelog destination
+
+

--- a/docs/resources/port_page.md
+++ b/docs/resources/port_page.md
@@ -481,3 +481,5 @@ terraform import port_page.home_page "\$home"
 - `id` (String) The ID of this resource.
 - `updated_at` (String) The last update date of the page
 - `updated_by` (String) The last updater of the page
+
+

--- a/docs/resources/port_page_permissions.md
+++ b/docs/resources/port_page_permissions.md
@@ -121,3 +121,5 @@ Optional:
 - `roles` (List of String) The roles with read permission
 - `teams` (List of String) The teams with read permission
 - `users` (List of String) The users with read permission
+
+

--- a/docs/resources/port_scorecard.md
+++ b/docs/resources/port_scorecard.md
@@ -475,3 +475,5 @@ Required:
 
 - `color` (String) The color of the level
 - `title` (String) The title of the level
+
+

--- a/docs/resources/port_team.md
+++ b/docs/resources/port_team.md
@@ -30,3 +30,5 @@ Team resource
 - `id` (String) The ID of this resource.
 - `provider_name` (String) The provider of the team
 - `updated_at` (String) The last update date of the team
+
+

--- a/docs/resources/port_webhook.md
+++ b/docs/resources/port_webhook.md
@@ -75,3 +75,5 @@ Optional:
 - `signature_algorithm` (String) The signature algorithm of the webhook
 - `signature_header_name` (String) The signature header name of the webhook
 - `signature_prefix` (String) The signature prefix of the webhook
+
+

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -246,7 +246,7 @@ type (
 		Description          *string               `json:"description,omitempty"`
 		Trigger              *Trigger              `json:"trigger"`
 		InvocationMethod     *InvocationMethod     `json:"invocationMethod,omitempty"`
-		RequiredApproval     *bool                 `json:"requiredApproval,omitempty"`
+		RequiredApproval     any                   `json:"requiredApproval,omitempty"`
 		ApprovalNotification *ApprovalNotification `json:"approvalNotification,omitempty"`
 		Publish              *bool                 `json:"publish,omitempty"`
 	}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -143,3 +143,20 @@ func TFStringListToStringArray(list []types.String) []string {
 
 	return res
 }
+
+func TerraformStringToBooleanOrString(s types.String) interface{} {
+	var obj interface{}
+
+	if s.IsNull() {
+		return obj
+	}
+
+	value := s.ValueString()
+	if value == "true" {
+		return true
+	}
+	if value == "false" {
+		return false
+	}
+	return value
+}

--- a/port/action/actionStateToPortBody.go
+++ b/port/action/actionStateToPortBody.go
@@ -48,7 +48,7 @@ func actionStateToPortBody(ctx context.Context, data *ActionModel) (*cli.Action,
 	}
 
 	action.RequiredApproval = utils.TerraformStringToBooleanOrString(data.RequiredApproval)
-	if reflect.TypeOf(action.RequiredApproval).Kind() == reflect.String {
+	if action.RequiredApproval != nil && reflect.TypeOf(action.RequiredApproval).Kind() == reflect.String {
 		action.RequiredApproval = map[string]interface{}{"type": action.RequiredApproval}
 	}
 

--- a/port/action/actionStateToPortBody.go
+++ b/port/action/actionStateToPortBody.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/consts"
@@ -39,12 +40,16 @@ func actionDataSetToPortBody(dataSet *DatasetModel) *cli.Dataset {
 func actionStateToPortBody(ctx context.Context, data *ActionModel) (*cli.Action, error) {
 	var err error
 	action := &cli.Action{
-		Identifier:       data.Identifier.ValueString(),
-		Title:            data.Title.ValueStringPointer(),
-		Icon:             data.Icon.ValueStringPointer(),
-		Description:      data.Description.ValueStringPointer(),
-		RequiredApproval: data.RequiredApproval.ValueBoolPointer(),
-		Publish:          data.Publish.ValueBoolPointer(),
+		Identifier:  data.Identifier.ValueString(),
+		Title:       data.Title.ValueStringPointer(),
+		Icon:        data.Icon.ValueStringPointer(),
+		Description: data.Description.ValueStringPointer(),
+		Publish:     data.Publish.ValueBoolPointer(),
+	}
+
+	action.RequiredApproval = utils.TerraformStringToBooleanOrString(data.RequiredApproval)
+	if reflect.TypeOf(action.RequiredApproval).Kind() == reflect.String {
+		action.RequiredApproval = map[string]interface{}{"type": action.RequiredApproval}
 	}
 
 	action.Trigger, err = triggerToBody(ctx, data)

--- a/port/action/model.go
+++ b/port/action/model.go
@@ -381,7 +381,7 @@ type ActionModel struct {
 	GitlabMethod                *GitlabMethodModel                `tfsdk:"gitlab_method"`
 	AzureMethod                 *AzureMethodModel                 `tfsdk:"azure_method"`
 	UpsertEntityMethod          *UpsertEntityMethodModel          `tfsdk:"upsert_entity_method"`
-	RequiredApproval            types.Bool                        `tfsdk:"required_approval"`
+	RequiredApproval            types.String                      `tfsdk:"required_approval"`
 	ApprovalWebhookNotification *ApprovalWebhookNotificationModel `tfsdk:"approval_webhook_notification"`
 	ApprovalEmailNotification   types.Object                      `tfsdk:"approval_email_notification"`
 	Publish                     types.Bool                        `tfsdk:"publish"`
@@ -403,7 +403,7 @@ type ActionValidationModel struct {
 	GitlabMethod                types.Object `tfsdk:"gitlab_method"`
 	AzureMethod                 types.Object `tfsdk:"azure_method"`
 	UpsertEntityMethod          types.Object `tfsdk:"upsert_entity_method"`
-	RequiredApproval            types.Bool   `tfsdk:"required_approval"`
+	RequiredApproval            types.String `tfsdk:"required_approval"`
 	ApprovalWebhookNotification types.Object `tfsdk:"approval_webhook_notification"`
 	ApprovalEmailNotification   types.Object `tfsdk:"approval_email_notification"`
 	Publish                     types.Bool   `tfsdk:"publish"`

--- a/port/action/refreshActionState.go
+++ b/port/action/refreshActionState.go
@@ -409,7 +409,9 @@ func refreshActionState(ctx context.Context, state *ActionModel, a *cli.Action) 
 		return err
 	}
 
-	if reflect.TypeOf(a.RequiredApproval).Kind() == reflect.Map {
+	if a.RequiredApproval == nil {
+		state.RequiredApproval = types.StringNull()
+	} else if reflect.TypeOf(a.RequiredApproval).Kind() == reflect.Map {
 		state.RequiredApproval = types.StringValue(a.RequiredApproval.(map[string]interface{})["type"].(string))
 	} else {
 		state.RequiredApproval = types.StringValue(strconv.FormatBool(a.RequiredApproval.(bool)))

--- a/port/action/refreshActionState.go
+++ b/port/action/refreshActionState.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strconv"
 
 	"github.com/samber/lo"
 
@@ -408,7 +409,12 @@ func refreshActionState(ctx context.Context, state *ActionModel, a *cli.Action) 
 		return err
 	}
 
-	state.RequiredApproval = flex.GoBoolToFramework(a.RequiredApproval)
+	if reflect.TypeOf(a.RequiredApproval).Kind() == reflect.Map {
+		state.RequiredApproval = types.StringValue(a.RequiredApproval.(map[string]interface{})["type"].(string))
+	} else {
+		state.RequiredApproval = types.StringValue(strconv.FormatBool(a.RequiredApproval.(bool)))
+	}
+
 	if a.ApprovalNotification != nil {
 		if a.ApprovalNotification.Type == "email" {
 			state.ApprovalEmailNotification, _ = types.ObjectValue(nil, nil)

--- a/port/action/resource_test.go
+++ b/port/action/resource_test.go
@@ -2067,3 +2067,83 @@ func TestAccPortActionUpsertEntityWithoutMappingIdentifier(t *testing.T) {
 		},
 	})
 }
+
+func TestRequiredApprovalAny(t *testing.T) {
+	identifier := utils.GenID()
+	actionIdentifier := utils.GenID()
+	var testAccActionConfigCreate = testAccCreateBlueprintConfig(identifier) + fmt.Sprintf(`
+	resource "port_action" "create_microservice" {
+		title = "TF Provider Test"
+		identifier = "%s"
+		icon = "Terraform"
+		self_service_trigger = {
+			operation = "DAY-2"
+			blueprint_identifier = port_blueprint.microservice.identifier
+		}
+		kafka_method = {}
+		required_approval = "ANY"
+		approval_webhook_notification = {
+			url = "https://example.com"
+			format = "json"
+		}
+	}`, actionIdentifier)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + testAccActionConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_action.create_microservice", "title", "TF Provider Test"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "identifier", actionIdentifier),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "icon", "Terraform"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.blueprint_identifier", identifier),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.operation", "DAY-2"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "required_approval", "ANY"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "approval_webhook_notification.url", "https://example.com"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "approval_webhook_notification.format", "json"),
+				),
+			},
+		},
+	})
+}
+
+func TestRequiredApprovalAll(t *testing.T) {
+	identifier := utils.GenID()
+	actionIdentifier := utils.GenID()
+	var testAccActionConfigCreate = testAccCreateBlueprintConfig(identifier) + fmt.Sprintf(`
+	resource "port_action" "create_microservice" {
+		title = "TF Provider Test"
+		identifier = "%s"
+		icon = "Terraform"
+		self_service_trigger = {
+			operation = "DAY-2"
+			blueprint_identifier = port_blueprint.microservice.identifier
+		}
+		kafka_method = {}
+		required_approval = "ALL"
+		approval_webhook_notification = {
+			url = "https://example.com"
+			format = "json"
+		}
+	}`, actionIdentifier)
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + testAccActionConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_action.create_microservice", "title", "TF Provider Test"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "identifier", actionIdentifier),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "icon", "Terraform"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.blueprint_identifier", identifier),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.operation", "DAY-2"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "required_approval", "ALL"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "approval_webhook_notification.url", "https://example.com"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "approval_webhook_notification.format", "json"),
+				),
+			},
+		},
+	})
+}

--- a/port/action/schema.go
+++ b/port/action/schema.go
@@ -392,7 +392,7 @@ func ActionSchema() map[string]schema.Attribute {
 			},
 		},
 		"required_approval": schema.StringAttribute{
-			MarkdownDescription: "Require approval before invoking the action",
+			MarkdownDescription: "Require approval before invoking the action. Can be one of \"true\", \"false\", \"ANY\" or \"ALL\"",
 			Optional:            true,
 			Validators: []validator.String{
 				stringvalidator.OneOf("true", "false", "ANY", "ALL"),

--- a/port/action/schema.go
+++ b/port/action/schema.go
@@ -391,9 +391,12 @@ func ActionSchema() map[string]schema.Attribute {
 				},
 			},
 		},
-		"required_approval": schema.BoolAttribute{
+		"required_approval": schema.StringAttribute{
 			MarkdownDescription: "Require approval before invoking the action",
 			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.OneOf("true", "false", "ANY", "ALL"),
+			},
 		},
 		"approval_webhook_notification": schema.SingleNestedAttribute{
 			MarkdownDescription: "The webhook notification of the approval",


### PR DESCRIPTION
# Description

What - Fix required approval to support ANY and ALL
Why - Support new API for actions
How - Change required_approval schema from boolean to string and allow "true", "false", "ANY", "ALL"

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [x] Documentation (added/updated documentation)