### PR TITLE
fix: Updating an integration errors when changing installation_id

### DIFF
--- a/port/integration/schema.go
+++ b/port/integration/schema.go
@@ -6,6 +6,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
 
 func IntegrationSchema() map[string]schema.Attribute {
@@ -15,6 +17,9 @@ func IntegrationSchema() map[string]schema.Attribute {
 		},
 		"installation_id": schema.StringAttribute{
 			Required: true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
 		},
 		"version": schema.StringAttribute{
 			Optional: true,


### PR DESCRIPTION
# Description

Fixes #174

What - Make changes to `installation_id` force resource replacement
Why - Changing the the installation identifier should create new resources
How - Add a PlanModifier to the schema for the `installation_id` attribute

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)