### PR TITLE
Fix link to Port documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Port is the Developer Platform meant to supercharge your DevOps and Developers, 
 ## Documentation
 
 - [Terraform registry docs](https://registry.terraform.io/providers/port-labs/port-labs/latest/docs)
-- [Port docs](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/iac/terraform)
+- [Port docs](https://docs.getport.io/build-your-software-catalog/custom-integration/iac/terraform/)
 
 ## Requirements
 


### PR DESCRIPTION
# Description

What - Link to the Port documentation about Terraform integration.
Why - The link in the README file is broken.
How - The link is updated to point to the proper location.

## Type of change

Please leave one option from the following and delete the rest:

- [X] Documentation (added/updated documentation)