### PR TITLE
Ensure that `version` is not part of the state if not explicitly in the tf file

### DIFF
--- a/docs/resources/port_integration.md
+++ b/docs/resources/port_integration.md
@@ -11,7 +11,7 @@ description: |-
   resource "portintegration" "mycustomintegration" {
       installationid       = "my-custom-integration-id"
       title                 = "My Custom Integration"
-      version               = "1.33.7"
+      version               = "1.33.7" # Optional, can be omitted
       config = jsonencode({
           createMissingRelatedEntitiesboolean = true
           deleteDependentEntities = true,
@@ -56,7 +56,7 @@ Docs about how to import existing integrations and manage their mappings can be 
 resource "port_integration" "my_custom_integration" {
 	installation_id       = "my-custom-integration-id"
 	title                 = "My Custom Integration"
-	version               = "1.33.7"
+	version               = "1.33.7" # Optional, can be omitted
 	config = jsonencode({
 		createMissingRelatedEntitiesboolean = true
 		deleteDependentEntities = true,

--- a/examples/resources/port_integration/main.tf
+++ b/examples/resources/port_integration/main.tf
@@ -1,7 +1,6 @@
 resource "port_integration" "my_custom_integration" {
   installation_id       = "my-custom-integration-id"
   title                 = "My Custom Integration"
-  version               = "1.33.7"
   installation_app_type = "WEBHOOK"
   config = jsonencode({
     createMissingRelatedEntitiesboolean = true
@@ -21,6 +20,39 @@ resource "port_integration" "my_custom_integration" {
               my_property = 123
             }
             relations = {}
+          }]
+        }
+      }
+    }]
+  })
+}
+
+resource "port_integration" "my_k8s_exporter" {
+  installation_id       = "my-"
+  title                 = "My K8S Exporter with version managed by Terraform"
+  installation_app_type = "K8S EXPORTER"
+  # NOTE: This property is by default not used, since it can change outside of terraform
+  # Include this only if you explicitly want to control the version with Terraform
+  version               = "1.33.7"
+  config = jsonencode({
+    createMissingRelatedEntitiesboolean = true
+    deleteDependentEntities             = true
+    resources = [{
+      kind = "apps/v1/replicasets"
+      selector = {
+        query = ".metadata.namespace | startswith(\"kube\") | not"
+      }
+      port = {
+        entity = {
+          mappings = [{
+            identifier = ".metadata.name"
+            title      = ".metadata.name"
+            blueprint  = "'deploymentConfig'"
+            properties = {
+              creationTimestamp = ".metadata.creationTimestamp"
+              annotations = ".metadata.annotations"
+              status = ".status"
+            }
           }]
         }
       }

--- a/port/integration/schema.go
+++ b/port/integration/schema.go
@@ -18,6 +18,7 @@ func IntegrationSchema() map[string]schema.Attribute {
 		},
 		"version": schema.StringAttribute{
 			Optional: true,
+			Computed: true,
 		},
 		"title": schema.StringAttribute{
 			Optional: true,
@@ -73,7 +74,6 @@ Docs about how to import existing integrations and manage their mappings can be 
 resource "port_integration" "my_custom_integration" {
 	installation_id       = "my-custom-integration-id"
 	title                 = "My Custom Integration"
-	version               = "1.33.7"
 	config = jsonencode({
 		createMissingRelatedEntitiesboolean = true
 		deleteDependentEntities = true,


### PR DESCRIPTION
# Description

What - When altering an integrations version outside of terraform, it would affect the state even if not specified in a `port_integration` section
Why - Allows updating versions of integrations outside of terraform, keep terraform for updating configuration and mappings
How - Make `version` both optionable and computed

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation (added/updated documentation)
