### PR TITLE
Fixed broken link in port integration documentation

### DIFF
--- a/docs/resources/port_integration.md
+++ b/docs/resources/port_integration.md
@@ -6,7 +6,7 @@ description: |-
   Integration resource
   NOTE: This resource manages existing integration and integration mappings, not for creating new integrations.
   Docs about integrations can be found here https://docs.getport.io/integrations-index/.
-  Docs about how to import existing integrations and manage their mappings can be found here https://docs.getport.io/build-your-software-catalog/custom-integration/iac/terraform/examples/import-and-manage-integration.
+  Docs about how to import existing integrations and manage their mappings can be found here https://docs.getport.io/guides/all/import-and-manage-integration.
   ```hcl
   resource "portintegration" "mycustomintegration" {
       installationid       = "my-custom-integration-id"
@@ -48,7 +48,7 @@ description: |-
 
 Docs about integrations can be found [here](https://docs.getport.io/integrations-index/).
 
-Docs about how to import existing integrations and manage their mappings can be found [here](https://docs.getport.io/build-your-software-catalog/custom-integration/iac/terraform/examples/import-and-manage-integration).
+Docs about how to import existing integrations and manage their mappings can be found [here](https://docs.getport.io/guides/all/import-and-manage-integration).
 
 
 ```hcl

--- a/port/integration/schema.go
+++ b/port/integration/schema.go
@@ -67,7 +67,7 @@ var IntegrationResourceMarkdownDescription = `
 
 Docs about integrations can be found [here](https://docs.getport.io/integrations-index/).
 
-Docs about how to import existing integrations and manage their mappings can be found [here](https://docs.getport.io/build-your-software-catalog/custom-integration/iac/terraform/examples/import-and-manage-integration).
+Docs about how to import existing integrations and manage their mappings can be found [here](https://docs.getport.io/guides/all/import-and-manage-integration).
 
 
 ` + "```hcl" + `


### PR DESCRIPTION
# Description

What - replace the link to mapping on documentation to import existing integrations and manage their mappings
Why - Link was broken as guides have been moved
How - Restructuring in documentation service

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] Documentation (added/updated documentation)