### PR TITLE
validate step title at plan time to avoid unexpected apply errors

### DIFF
--- a/docs/resources/port_action.md
+++ b/docs/resources/port_action.md
@@ -514,7 +514,7 @@ Optional:
 Required:
 
 - `order` (List of String) The order of the properties in this step
-- `title` (String) The step's title
+- `title` (String) The step's title (max 25 characters)
 
 
 <a id="nestedatt--self_service_trigger--user_properties"></a>

--- a/port/action/schema.go
+++ b/port/action/schema.go
@@ -135,8 +135,11 @@ func ActionSchema() map[string]schema.Attribute {
 					NestedObject: schema.NestedAttributeObject{
 						Attributes: map[string]schema.Attribute{
 							"title": schema.StringAttribute{
-								MarkdownDescription: "The step's title",
+								MarkdownDescription: "The step's title (max 25 characters)",
 								Required:            true,
+								Validators: []validator.String{
+									stringvalidator.LengthAtMost(25),
+								},
 							},
 							"order": schema.ListAttribute{
 								MarkdownDescription: "The order of the properties in this step",


### PR DESCRIPTION
# Description

What - Validate an action's step title to ensure it is at most 25 characters
Why - There's an undocumented character limit of 25 for the step title which causes a change to succeed to plan but then fail to apply. 
How - Use `stringvalidator.LengthAtMost` validator for the `title` attribute validation

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)