### PR TITLE
Calculation property icons mishandle

### DIFF
--- a/port/blueprint/readStateToPortBody.go
+++ b/port/blueprint/readStateToPortBody.go
@@ -108,7 +108,7 @@ func calculationPropertiesToBody(ctx context.Context, state *BlueprintModel) map
 			calculationProp.Title = &title
 		}
 
-		if !state.Icon.IsNull() {
+		if !prop.Icon.IsNull() {
 			icon := prop.Icon.ValueString()
 			calculationProp.Icon = &icon
 		}


### PR DESCRIPTION
# Description

Calculation properties icons were checked against the state rather than the property itself. This caused icons to not be applied if the blueprint itself had no icon.
