### PR TITLE
add validation that required won't be false

### DIFF
--- a/port/action/isTrueValidator.go
+++ b/port/action/isTrueValidator.go
@@ -1,0 +1,40 @@
+package action
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/helpers/validatordiag"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type isTrueValidator struct{}
+
+var _ validator.Bool = isTrueValidator{}
+
+// Description describes the validation in plain text formatting.
+func (v isTrueValidator) Description(ctx context.Context) string {
+	return "Value must be true"
+}
+
+// MarkdownDescription describes the validation in Markdown formatting.
+func (v isTrueValidator) MarkdownDescription(ctx context.Context) string {
+	return v.Description(ctx)
+}
+
+// ValidateBool performs the validation.
+func (v isTrueValidator) ValidateBool(ctx context.Context, req validator.BoolRequest, resp *validator.BoolResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() {
+		return
+	}
+	value := req.ConfigValue
+	if value.Equal(types.BoolValue(true)) {
+		return
+	}
+	resp.Diagnostics.Append(validatordiag.InvalidAttributeValueMatchDiagnostic(
+		req.Path,
+		v.Description(ctx),
+		value.String(),
+	))
+
+}

--- a/port/action/resource_test.go
+++ b/port/action/resource_test.go
@@ -502,6 +502,44 @@ func TestAccPortActionImport(t *testing.T) {
 	})
 }
 
+func TestPortActionFalseRequiredPropShouldNotWork(t *testing.T) {
+	blueprintIdentifier := utils.GenID()
+	actionIdentifier := utils.GenID()
+	var testAccActionConfigCreate = testAccCreateBlueprintConfig(blueprintIdentifier) + fmt.Sprintf(`
+	resource "port_action" "create_microservice" {
+		title = "TF Provider Test"
+		identifier = "%s"
+		icon = "Terraform"
+		self_service_trigger = {
+			operation = "DAY-2"
+			blueprint_identifier = port_blueprint.microservice.identifier
+			user_properties = {
+				"string_props" = {
+					"myStringIdentifier" = {
+						"title" = "My String Identifier"
+						"required" = false
+					}
+				}
+			}
+		}
+		webhook_method = {
+			url = "https://getport.io"
+		}
+	}`, actionIdentifier)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+
+		Steps: []resource.TestStep{
+			{
+				Config:      acctest.ProviderConfig + testAccActionConfigCreate,
+				ExpectError: regexp.MustCompile(`.*Invalid Attribute Value Match*`),
+			},
+		},
+	})
+}
+
 func TestAccPortActionUpdate(t *testing.T) {
 	identifier := utils.GenID()
 	actionIdentifier := utils.GenID()

--- a/port/action/schema.go
+++ b/port/action/schema.go
@@ -38,6 +38,7 @@ func MetadataProperties() map[string]schema.Attribute {
 			MarkdownDescription: "Whether the property is required, by default not required, this property can't be set at the same time if `required_jq_query` is set, and only supports true as value",
 			Optional:            true,
 			Validators: []validator.Bool{
+				isTrueValidator{},
 				boolvalidator.ConflictsWith(path.MatchRoot("self_service_trigger").AtName("required_jq_query")),
 			},
 		},


### PR DESCRIPTION
# Description

What - i've added validation that checks that the required value is only true and not false
Why - cause some users have used false and it cause them to have problems in re applying the actions. it creates drifts
How - ive added validations that checks if it is only true

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)