### PR TITLE
Port 12879 terraform support create missing related entities entity

### DIFF
--- a/docs/resources/port_entity.md
+++ b/docs/resources/port_entity.md
@@ -21,7 +21,7 @@ Entity resource
 
 ### Optional
 
-- `create_missing_related_entities` (Boolean) Whether to create missing related entities, default is False
+- `create_missing_related_entities` (Boolean) Whether to create missing related entities
 - `icon` (String) The icon of the entity
 - `identifier` (String) The identifier of the entity
 - `properties` (Attributes) The properties of the entity (see [below for nested schema](#nestedatt--properties))

--- a/docs/resources/port_entity.md
+++ b/docs/resources/port_entity.md
@@ -21,6 +21,7 @@ Entity resource
 
 ### Optional
 
+- `create_missing_related_entities` (Boolean) Whether to create missing related entities, default is False
 - `icon` (String) The icon of the entity
 - `identifier` (String) The identifier of the entity
 - `properties` (Attributes) The properties of the entity (see [below for nested schema](#nestedatt--properties))

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -33,14 +33,13 @@ type (
 
 	Entity struct {
 		Meta
-		Identifier                   string                    `json:"identifier,omitempty"`
-		Title                        string                    `json:"title"`
-		Blueprint                    string                    `json:"blueprint"`
-		Team                         []string                  `json:"team,omitempty"`
-		Properties                   map[string]any            `json:"properties"`
-		Relations                    map[string]any            `json:"relations"`
-		Scorecards                   map[string]ScorecardModel `json:"scorecards,omitempty"`
-		CreateMissingRelatedEntities bool                      `json:"createMissingRelatedEntities,omitempty"`
+		Identifier string                    `json:"identifier,omitempty"`
+		Title      string                    `json:"title"`
+		Blueprint  string                    `json:"blueprint"`
+		Team       []string                  `json:"team,omitempty"`
+		Properties map[string]any            `json:"properties"`
+		Relations  map[string]any            `json:"relations"`
+		Scorecards map[string]ScorecardModel `json:"scorecards,omitempty"`
 		// TODO: add the rest of the fields.
 	}
 

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -33,13 +33,14 @@ type (
 
 	Entity struct {
 		Meta
-		Identifier string                    `json:"identifier,omitempty"`
-		Title      string                    `json:"title"`
-		Blueprint  string                    `json:"blueprint"`
-		Team       []string                  `json:"team,omitempty"`
-		Properties map[string]any            `json:"properties"`
-		Relations  map[string]any            `json:"relations"`
-		Scorecards map[string]ScorecardModel `json:"scorecards,omitempty"`
+		Identifier                   string                    `json:"identifier,omitempty"`
+		Title                        string                    `json:"title"`
+		Blueprint                    string                    `json:"blueprint"`
+		Team                         []string                  `json:"team,omitempty"`
+		Properties                   map[string]any            `json:"properties"`
+		Relations                    map[string]any            `json:"relations"`
+		Scorecards                   map[string]ScorecardModel `json:"scorecards,omitempty"`
+		CreateMissingRelatedEntities bool                      `json:"createMissingRelatedEntities,omitempty"`
 		// TODO: add the rest of the fields.
 	}
 

--- a/port/blueprint/resource_test.go
+++ b/port/blueprint/resource_test.go
@@ -800,7 +800,7 @@ func TestAccPortDestroyDeleteAllEntities(t *testing.T) {
 	}
 
 	// create entity
-	_, err = portClient.CreateEntity(ctx, entity, "")
+	_, err = portClient.CreateEntity(ctx, entity, "", false)
 	if err != nil {
 		t.Fatalf("Failed to create entity: %s", err.Error())
 		return

--- a/port/entity/entityResourceToPortBody.go
+++ b/port/entity/entityResourceToPortBody.go
@@ -153,5 +153,10 @@ func entityResourceToBody(ctx context.Context, state *EntityModel, bp *cli.Bluep
 	}
 
 	e.Relations = relations
+
+	if !state.CreateMissingRelatedEntities.IsNull() {
+		e.CreateMissingRelatedEntities = state.CreateMissingRelatedEntities.ValueBool()
+	}
+
 	return e, nil
 }

--- a/port/entity/entityResourceToPortBody.go
+++ b/port/entity/entityResourceToPortBody.go
@@ -154,9 +154,5 @@ func entityResourceToBody(ctx context.Context, state *EntityModel, bp *cli.Bluep
 
 	e.Relations = relations
 
-	if !state.CreateMissingRelatedEntities.IsNull() {
-		e.CreateMissingRelatedEntities = state.CreateMissingRelatedEntities.ValueBool()
-	}
-
 	return e, nil
 }

--- a/port/entity/model.go
+++ b/port/entity/model.go
@@ -25,17 +25,18 @@ type RelationModel struct {
 }
 
 type EntityModel struct {
-	ID         types.String           `tfsdk:"id"`
-	Identifier types.String           `tfsdk:"identifier"`
-	Blueprint  types.String           `tfsdk:"blueprint"`
-	Title      types.String           `tfsdk:"title"`
-	Icon       types.String           `tfsdk:"icon"`
-	RunID      types.String           `tfsdk:"run_id"`
-	CreatedAt  types.String           `tfsdk:"created_at"`
-	CreatedBy  types.String           `tfsdk:"created_by"`
-	UpdatedAt  types.String           `tfsdk:"updated_at"`
-	UpdatedBy  types.String           `tfsdk:"updated_by"`
-	Properties *EntityPropertiesModel `tfsdk:"properties"`
-	Teams      []types.String         `tfsdk:"teams"`
-	Relations  *RelationModel         `tfsdk:"relations"`
+	ID                           types.String           `tfsdk:"id"`
+	Identifier                   types.String           `tfsdk:"identifier"`
+	Blueprint                    types.String           `tfsdk:"blueprint"`
+	Title                        types.String           `tfsdk:"title"`
+	Icon                         types.String           `tfsdk:"icon"`
+	RunID                        types.String           `tfsdk:"run_id"`
+	CreatedAt                    types.String           `tfsdk:"created_at"`
+	CreatedBy                    types.String           `tfsdk:"created_by"`
+	UpdatedAt                    types.String           `tfsdk:"updated_at"`
+	UpdatedBy                    types.String           `tfsdk:"updated_by"`
+	Properties                   *EntityPropertiesModel `tfsdk:"properties"`
+	Teams                        []types.String         `tfsdk:"teams"`
+	Relations                    *RelationModel         `tfsdk:"relations"`
+	CreateMissingRelatedEntities types.Bool             `tfsdk:"create_missing_related_entities"`
 }

--- a/port/entity/resource.go
+++ b/port/entity/resource.go
@@ -93,7 +93,12 @@ func (r *EntityResource) Create(ctx context.Context, req resource.CreateRequest,
 		runID = state.RunID.ValueString()
 	}
 
-	en, err := r.portClient.CreateEntity(ctx, e, runID, state.CreateMissingRelatedEntities.ValueBool())
+	createMissingRelatedEntities := false
+	if !state.CreateMissingRelatedEntities.IsNull() && state.CreateMissingRelatedEntities.ValueBool() {
+		createMissingRelatedEntities = true
+	}
+
+	en, err := r.portClient.CreateEntity(ctx, e, runID, createMissingRelatedEntities)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to create entity", err.Error())
 		return
@@ -141,14 +146,19 @@ func (r *EntityResource) Update(ctx context.Context, req resource.UpdateRequest,
 		runID = state.RunID.ValueString()
 	}
 
+	createMissingRelatedEntities := false
+	if !state.CreateMissingRelatedEntities.IsNull() && state.CreateMissingRelatedEntities.ValueBool() {
+		createMissingRelatedEntities = true
+	}
+
 	var en *cli.Entity
 
 	isBlueprintChanged := !previousState.Blueprint.IsNull() && previousState.Blueprint.ValueString() != state.Blueprint.ValueString()
 
 	if previousState.Identifier.IsNull() || isBlueprintChanged {
-		en, err = r.portClient.CreateEntity(ctx, e, runID, state.CreateMissingRelatedEntities.ValueBool())
+		en, err = r.portClient.CreateEntity(ctx, e, runID, createMissingRelatedEntities)
 	} else {
-		en, err = r.portClient.UpdateEntity(ctx, previousState.Identifier.ValueString(), previousState.Blueprint.ValueString(), e, runID, state.CreateMissingRelatedEntities.ValueBool())
+		en, err = r.portClient.UpdateEntity(ctx, previousState.Identifier.ValueString(), previousState.Blueprint.ValueString(), e, runID, createMissingRelatedEntities)
 	}
 
 	if err != nil {
@@ -183,7 +193,6 @@ func (r *EntityResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		resp.Diagnostics.AddError("failed to delete entity", err.Error())
 		return
 	}
-
 }
 
 func (r *EntityResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {

--- a/port/entity/resource.go
+++ b/port/entity/resource.go
@@ -93,7 +93,7 @@ func (r *EntityResource) Create(ctx context.Context, req resource.CreateRequest,
 		runID = state.RunID.ValueString()
 	}
 
-	en, err := r.portClient.CreateEntity(ctx, e, runID)
+	en, err := r.portClient.CreateEntity(ctx, e, runID, state.CreateMissingRelatedEntities.ValueBool())
 	if err != nil {
 		resp.Diagnostics.AddError("failed to create entity", err.Error())
 		return
@@ -146,9 +146,9 @@ func (r *EntityResource) Update(ctx context.Context, req resource.UpdateRequest,
 	isBlueprintChanged := !previousState.Blueprint.IsNull() && previousState.Blueprint.ValueString() != state.Blueprint.ValueString()
 
 	if previousState.Identifier.IsNull() || isBlueprintChanged {
-		en, err = r.portClient.CreateEntity(ctx, e, runID)
+		en, err = r.portClient.CreateEntity(ctx, e, runID, state.CreateMissingRelatedEntities.ValueBool())
 	} else {
-		en, err = r.portClient.UpdateEntity(ctx, previousState.Identifier.ValueString(), previousState.Blueprint.ValueString(), e, runID)
+		en, err = r.portClient.UpdateEntity(ctx, previousState.Identifier.ValueString(), previousState.Blueprint.ValueString(), e, runID, state.CreateMissingRelatedEntities.ValueBool())
 	}
 
 	if err != nil {

--- a/port/entity/schema.go
+++ b/port/entity/schema.go
@@ -35,6 +35,10 @@ func EntitySchema() map[string]schema.Attribute {
 			MarkdownDescription: "The runID of the action run that created the entity",
 			Optional:            true,
 		},
+		"create_missing_related_entities": schema.BoolAttribute{
+			MarkdownDescription: "Whether to create missing related entities, default is False",
+			Optional:            true,
+		},
 		"teams": schema.ListAttribute{
 			MarkdownDescription: "The teams the entity belongs to",
 			Optional:            true,

--- a/port/entity/schema.go
+++ b/port/entity/schema.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -36,8 +37,10 @@ func EntitySchema() map[string]schema.Attribute {
 			Optional:            true,
 		},
 		"create_missing_related_entities": schema.BoolAttribute{
-			MarkdownDescription: "Whether to create missing related entities, default is False",
+			MarkdownDescription: "Whether to create missing related entities",
 			Optional:            true,
+			Computed:            true,
+			Default:             booldefault.StaticBool(false),
 		},
 		"teams": schema.ListAttribute{
 			MarkdownDescription: "The teams the entity belongs to",


### PR DESCRIPTION
# Description

What: Added [create_missing_related_entities] attribute to port_entity resource.
Updated test TestAccPortEntityWithMissingRelation.
Why: To automatically create missing related entities.
How: Added the attribute to the schema.
Updated the test to use the attribute.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)