### PR TITLE
PORT-13253: Update the state when refreshing the entity relations.

### DIFF
--- a/port/entity/refreshEntityToState.go
+++ b/port/entity/refreshEntityToState.go
@@ -147,19 +147,24 @@ func refreshPropertiesEntityState(ctx context.Context, state *EntityModel, e *cl
 }
 
 func refreshRelationsEntityState(ctx context.Context, state *EntityModel, e *cli.Entity) {
-	state.Relations = &RelationModel{
-		SingleRelation: make(map[string]*string),
-		ManyRelations:  make(map[string][]string),
-	}
+	state.Relations = &RelationModel{}
 
 	for identifier, r := range e.Relations {
 		switch v := r.(type) {
-		case []string:
-			if len(v) != 0 {
-				state.Relations.ManyRelations[identifier] = v
+		case []any:
+			if state.Relations.ManyRelations == nil {
+				state.Relations.ManyRelations = make(map[string][]string)
 			}
-
+			state.Relations.ManyRelations[identifier] = make([]string, 0, len(v))
+			for _, rawValue := range v {
+				if strVal, ok := rawValue.(string); ok {
+					state.Relations.ManyRelations[identifier] = append(state.Relations.ManyRelations[identifier], strVal)
+				}
+			}
 		case string:
+			if state.Relations.SingleRelation == nil {
+				state.Relations.SingleRelation = make(map[string]*string)
+			}
 			if len(v) != 0 {
 				state.Relations.SingleRelation[identifier] = &v
 			}

--- a/port/entity/refreshEntityToState.go
+++ b/port/entity/refreshEntityToState.go
@@ -147,7 +147,7 @@ func refreshPropertiesEntityState(ctx context.Context, state *EntityModel, e *cl
 }
 
 func refreshRelationsEntityState(ctx context.Context, state *EntityModel, e *cli.Entity) {
-	relations := &RelationModel{
+	state.Relations = &RelationModel{
 		SingleRelation: make(map[string]*string),
 		ManyRelations:  make(map[string][]string),
 	}
@@ -156,12 +156,12 @@ func refreshRelationsEntityState(ctx context.Context, state *EntityModel, e *cli
 		switch v := r.(type) {
 		case []string:
 			if len(v) != 0 {
-				relations.ManyRelations[identifier] = v
+				state.Relations.ManyRelations[identifier] = v
 			}
 
 		case string:
 			if len(v) != 0 {
-				relations.SingleRelation[identifier] = &v
+				state.Relations.SingleRelation[identifier] = &v
 			}
 		}
 	}


### PR DESCRIPTION
# Description

What - Update the state when refreshing the entity relations
Why - Because otherwise nothing gets updated.
How - by referencing the state struct.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)