### PR TITLE
add pattern_jq_query parameter to string_props

### DIFF
--- a/docs/resources/port_action.md
+++ b/docs/resources/port_action.md
@@ -675,6 +675,7 @@ Optional:
 - `max_length` (Number) The max length of the string property
 - `min_length` (Number) The min length of the string property
 - `pattern` (String) The pattern of the string property
+- `pattern_jq_query` (String) The pattern jq query of the string property
 - `required` (Boolean) Whether the property is required, by default not required, this property can't be set at the same time if `required_jq_query` is set, and only supports true as value
 - `sort` (Attributes) How to sort entities when in the self service action form in the UI (see [below for nested schema](#nestedatt--self_service_trigger--user_properties--string_props--sort))
 - `title` (String) The title of the property

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -88,7 +88,7 @@ type (
 		Minimum            *float64            `json:"minimum,omitempty"`
 		Description        *string             `json:"description,omitempty"`
 		Blueprint          *string             `json:"blueprint,omitempty"`
-		Pattern            *string             `json:"pattern,omitempty"`
+		Pattern            any                 `json:"pattern,omitempty"`
 		Enum               any                 `json:"enum,omitempty"`
 		Spec               *string             `json:"spec,omitempty"`
 		SpecAuthentication *SpecAuthentication `json:"specAuthentication,omitempty"`

--- a/port/action/model.go
+++ b/port/action/model.go
@@ -30,17 +30,18 @@ type StringPropModel struct {
 	Visible        types.Bool    `tfsdk:"visible"`
 	VisibleJqQuery types.String  `tfsdk:"visible_jq_query"`
 
-	Default     types.String       `tfsdk:"default"`
-	Blueprint   types.String       `tfsdk:"blueprint"`
-	Format      types.String       `tfsdk:"format"`
-	MaxLength   types.Int64        `tfsdk:"max_length"`
-	MinLength   types.Int64        `tfsdk:"min_length"`
-	Pattern     types.String       `tfsdk:"pattern"`
-	Enum        types.List         `tfsdk:"enum"`
-	EnumColors  types.Map          `tfsdk:"enum_colors"`
-	EnumJqQuery types.String       `tfsdk:"enum_jq_query"`
-	Encryption  types.String       `tfsdk:"encryption"`
-	Sort        *EntitiesSortModel `tfsdk:"sort"`
+	Default        types.String       `tfsdk:"default"`
+	Blueprint      types.String       `tfsdk:"blueprint"`
+	Format         types.String       `tfsdk:"format"`
+	MaxLength      types.Int64        `tfsdk:"max_length"`
+	MinLength      types.Int64        `tfsdk:"min_length"`
+	Pattern        types.String       `tfsdk:"pattern"`
+	PatternJqQuery types.String       `tfsdk:"pattern_jq_query"`
+	Enum           types.List         `tfsdk:"enum"`
+	EnumColors     types.Map          `tfsdk:"enum_colors"`
+	EnumJqQuery    types.String       `tfsdk:"enum_jq_query"`
+	Encryption     types.String       `tfsdk:"encryption"`
+	Sort           *EntitiesSortModel `tfsdk:"sort"`
 }
 
 // StringPropValidationModel is a model used for the validation of StringPropModel resources

--- a/port/action/resource_test.go
+++ b/port/action/resource_test.go
@@ -1024,7 +1024,8 @@ func TestAccPortActionPatternJqQuery(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.ProviderConfig + testAccActionConfigCreate,
+				ExpectNonEmptyPlan: true,
+				Config:             acctest.ProviderConfig + testAccActionConfigCreate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("port_action.create_microservice", "title", "Action 1"),
 					resource.TestCheckResourceAttr("port_action.create_microservice", "identifier", actionIdentifier),
@@ -1066,7 +1067,8 @@ func TestAccPortActionPattern(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.ProviderConfig + testAccActionConfigCreate,
+				ExpectNonEmptyPlan: true,
+				Config:             acctest.ProviderConfig + testAccActionConfigCreate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("port_action.create_microservice", "title", "Action 1"),
 					resource.TestCheckResourceAttr("port_action.create_microservice", "identifier", actionIdentifier),

--- a/port/action/resource_test.go
+++ b/port/action/resource_test.go
@@ -994,6 +994,92 @@ func TestAccPortActionEnum(t *testing.T) {
 		},
 	})
 }
+
+func TestAccPortActionPatternJqQuery(t *testing.T) {
+	identifier := utils.GenID()
+	actionIdentifier := utils.GenID()
+	var testAccActionConfigCreate = testAccCreateBlueprintConfig(identifier) + fmt.Sprintf(`
+	resource "port_action" "create_microservice" {
+		title             = "Action 1"
+		identifier        = "%s"
+		self_service_trigger = {
+			operation = "DAY-2"
+			blueprint_identifier = port_blueprint.microservice.identifier
+			user_properties = {
+				string_props = {
+					myStringIdentifier = {
+						title      = "myStringIdentifier"
+						pattern_jq_query = "[\"test1\", \"test2\"]"
+					}
+				}
+			}
+		}
+		description       = "This is a test action"
+		kafka_method = {}
+	}`, actionIdentifier)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + testAccActionConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_action.create_microservice", "title", "Action 1"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "identifier", actionIdentifier),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.operation", "DAY-2"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "description", "This is a test action"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.user_properties.string_props.myStringIdentifier.title", "myStringIdentifier"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.user_properties.string_props.myStringIdentifier.pattern_jq_query", "[\"test1\", \"test2\"]"),
+				),
+			},
+		},
+	})
+}
+func TestAccPortActionPattern(t *testing.T) {
+	identifier := utils.GenID()
+	actionIdentifier := utils.GenID()
+	var testAccActionConfigCreate = testAccCreateBlueprintConfig(identifier) + fmt.Sprintf(`
+	resource "port_action" "create_microservice" {
+		title             = "Action 1"
+		identifier        = "%s"
+		self_service_trigger = {
+			operation = "DAY-2"
+			blueprint_identifier = port_blueprint.microservice.identifier
+			user_properties = {
+				string_props = {
+					myStringIdentifier = {
+						title   = "myStringIdentifier"
+						pattern = "^[a-zA-Z0-9-]*-service$"
+					}
+				}
+			}
+		}
+		description       = "This is a test action"
+		kafka_method = {}
+	}`, actionIdentifier)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + testAccActionConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_action.create_microservice", "title", "Action 1"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "identifier", actionIdentifier),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.operation", "DAY-2"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "description", "This is a test action"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.user_properties.string_props.myStringIdentifier.title", "myStringIdentifier"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.user_properties.string_props.myStringIdentifier.pattern", "^[a-zA-Z0-9-]*-service$"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccPortActionOrderProperties(t *testing.T) {
 	identifier := utils.GenID()
 	actionIdentifier := utils.GenID()

--- a/port/action/schema.go
+++ b/port/action/schema.go
@@ -531,6 +531,13 @@ func StringPropertySchema() schema.Attribute {
 			MarkdownDescription: "The pattern of the string property",
 			Optional:            true,
 		},
+		"pattern_jq_query": schema.StringAttribute{
+			MarkdownDescription: "The pattern jq query of the string property",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("pattern")),
+			},
+		},
 		"enum": schema.ListAttribute{
 			MarkdownDescription: "The enum of the string property",
 			Optional:            true,

--- a/port/action/string.go
+++ b/port/action/string.go
@@ -65,6 +65,13 @@ func stringPropResourceToBody(ctx context.Context, d *SelfServiceTriggerModel, p
 			property.Pattern = &pattern
 		}
 
+		if !prop.PatternJqQuery.IsNull() {
+			patternJqQueryMap := map[string]string{
+				"jqQuery": prop.PatternJqQuery.ValueString(),
+			}
+			property.Pattern = patternJqQueryMap
+		}
+
 		if !prop.Description.IsNull() {
 			description := prop.Description.ValueString()
 			property.Description = &description
@@ -149,7 +156,6 @@ func addStringPropertiesToResource(ctx context.Context, v *cli.ActionProperty) *
 	stringProp := &StringPropModel{
 		MinLength:  flex.GoInt64ToFramework(v.MinLength),
 		MaxLength:  flex.GoInt64ToFramework(v.MaxLength),
-		Pattern:    flex.GoStringToFramework(v.Pattern),
 		Format:     flex.GoStringToFramework(v.Format),
 		Blueprint:  flex.GoStringToFramework(v.Blueprint),
 		Encryption: flex.GoStringToFramework(v.Encryption),


### PR DESCRIPTION
# Description

What - Add `pattern_jq_query` parameter to `self_service_trigger.user_properties.string_props`
Why - Because this is a missing parameter
How - Implemented the above, and added test to confirm

## Type of change

Please leave one option from the following and delete the rest:

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation (added/updated documentation)