### PR TITLE
verify contribution from hedinasr

### DIFF
--- a/docs/resources/port_action.md
+++ b/docs/resources/port_action.md
@@ -142,7 +142,7 @@ description: |-
             runId: "{{.run.id}}"
           })
       }
-  ```
+  }
 ---
 
 # port_action (Resource)
@@ -675,7 +675,25 @@ Optional:
 - `max_length` (Number) The max length of the string property
 - `min_length` (Number) The min length of the string property
 - `pattern` (String) The pattern of the string property
-- `pattern_jq_query` (String) The pattern jq query of the string property
+- `pattern_jq_query` (String) The pattern jq query of the string property. See the examples directory for a demonstration of how to use dynamic patterns.
+  This field can be used in three ways:
+
+  1. To generate a regex pattern dynamically:
+  ```hcl
+  pattern_jq_query = "if .environment == \"production\" then \"^[a-z][a-z0-9-]{3,20}$\" else \"^[a-z][a-z0-9-]{2,10}$\" end"
+  ```
+
+  2. To generate a list of allowed values dynamically:
+  ```hcl
+  pattern_jq_query = "if .team == \"platform\" then [\"dev\", \"staging\", \"production\"] else [\"dev\", \"staging\"] end"
+  ```
+
+  3. Direct JSON array of allowed values:
+  ```hcl
+  pattern_jq_query = "[\"value1\", \"value2\", \"value3\"]"
+  ```
+
+  The JQ expression is evaluated by the Port API at runtime to determine the validation rules based on context.
 - `required` (Boolean) Whether the property is required, by default not required, this property can't be set at the same time if `required_jq_query` is set, and only supports true as value
 - `sort` (Attributes) How to sort entities when in the self service action form in the UI (see [below for nested schema](#nestedatt--self_service_trigger--user_properties--string_props--sort))
 - `title` (String) The title of the property

--- a/docs/resources/port_action.md
+++ b/docs/resources/port_action.md
@@ -675,7 +675,7 @@ Optional:
 - `max_length` (Number) The max length of the string property
 - `min_length` (Number) The min length of the string property
 - `pattern` (String) The pattern of the string property
-- `pattern_jq_query` (String) The pattern jq query of the string property. This field accepts a JQ expression to dynamically generate either a regex pattern (as a string) or a list of allowed values (as an array). Cannot be used with `pattern`. Examples: `"if .env == \"prod\" then \"^[a-z]+$\" else \"^[a-zA-Z]+$\" end"` for dynamic regex patterns, or `"[\"value1\", \"value2\"]"` for a fixed list of allowed values.
+- `pattern_jq_query` (String) The pattern jq query of the string property. This field accepts a JQ expression to dynamically generate either a regex pattern (as a string) or a list of allowed values (as an array). Cannot be used with `pattern`. Empty values are not allowed. Examples: `"if .env == \"prod\" then \"^[a-z]+$\" else \"^[a-zA-Z]+$\" end"` for dynamic regex patterns, or `"[\"value1\", \"value2\"]"` for a fixed list of allowed values.
 - `required` (Boolean) Whether the property is required, by default not required, this property can't be set at the same time if `required_jq_query` is set, and only supports true as value
 - `sort` (Attributes) How to sort entities when in the self service action form in the UI (see [below for nested schema](#nestedatt--self_service_trigger--user_properties--string_props--sort))
 - `title` (String) The title of the property

--- a/docs/resources/port_action.md
+++ b/docs/resources/port_action.md
@@ -675,6 +675,7 @@ Optional:
 - `max_length` (Number) The max length of the string property
 - `min_length` (Number) The min length of the string property
 - `pattern` (String) The pattern of the string property
+- `pattern_jq_query` (String) The pattern jq query of the string property
 - `required` (Boolean) Whether the property is required, by default not required, this property can't be set at the same time if `required_jq_query` is set, and only supports true as value
 - `sort` (Attributes) How to sort entities when in the self service action form in the UI (see [below for nested schema](#nestedatt--self_service_trigger--user_properties--string_props--sort))
 - `title` (String) The title of the property

--- a/docs/resources/port_action.md
+++ b/docs/resources/port_action.md
@@ -142,7 +142,7 @@ description: |-
             runId: "{{.run.id}}"
           })
       }
-  }
+  ```
 ---
 
 # port_action (Resource)
@@ -675,25 +675,7 @@ Optional:
 - `max_length` (Number) The max length of the string property
 - `min_length` (Number) The min length of the string property
 - `pattern` (String) The pattern of the string property
-- `pattern_jq_query` (String) The pattern jq query of the string property. See the examples directory for a demonstration of how to use dynamic patterns.
-  This field can be used in three ways:
-
-  1. To generate a regex pattern dynamically:
-  ```hcl
-  pattern_jq_query = "if .environment == \"production\" then \"^[a-z][a-z0-9-]{3,20}$\" else \"^[a-z][a-z0-9-]{2,10}$\" end"
-  ```
-
-  2. To generate a list of allowed values dynamically:
-  ```hcl
-  pattern_jq_query = "if .team == \"platform\" then [\"dev\", \"staging\", \"production\"] else [\"dev\", \"staging\"] end"
-  ```
-
-  3. Direct JSON array of allowed values:
-  ```hcl
-  pattern_jq_query = "[\"value1\", \"value2\", \"value3\"]"
-  ```
-
-  The JQ expression is evaluated by the Port API at runtime to determine the validation rules based on context.
+- `pattern_jq_query` (String) The pattern jq query of the string property. This field accepts a JQ expression to dynamically generate either a regex pattern (as a string) or a list of allowed values (as an array). Cannot be used with `pattern`. Examples: `"if .env == \"prod\" then \"^[a-z]+$\" else \"^[a-zA-Z]+$\" end"` for dynamic regex patterns, or `"[\"value1\", \"value2\"]"` for a fixed list of allowed values.
 - `required` (Boolean) Whether the property is required, by default not required, this property can't be set at the same time if `required_jq_query` is set, and only supports true as value
 - `sort` (Attributes) How to sort entities when in the self service action form in the UI (see [below for nested schema](#nestedatt--self_service_trigger--user_properties--string_props--sort))
 - `title` (String) The title of the property

--- a/examples/resources/port_action/pattern_jq_query/README.md
+++ b/examples/resources/port_action/pattern_jq_query/README.md
@@ -1,0 +1,44 @@
+# Pattern JQ Query Examples
+
+This example demonstrates how to use the `pattern_jq_query` attribute in different ways:
+
+## Ways to Use `pattern_jq_query`
+
+The `pattern_jq_query` field accepts a JQ expression that gets evaluated by the Port API at runtime. This JQ expression can produce:
+
+### 1. A Regex Pattern
+
+```hcl
+pattern_jq_query = "if .environment == \"production\" then \"^[a-z][a-z0-9-]{3,20}$\" else \"^[a-z][a-z0-9-]{2,10}$\" end"
+```
+
+This approach generates a regex pattern dynamically based on context. It works like the static `pattern` field but allows the regex to change based on other properties.
+
+### 2. A List of Allowed Values
+
+```hcl
+pattern_jq_query = "if .team == \"platform\" then [\"dev\", \"staging\", \"production\"] else [\"dev\", \"staging\"] end"
+```
+
+This approach generates a list of allowed values dynamically. It's similar to an enum but with values that can change based on context.
+
+### 3. Direct JSON Array of Allowed Values
+
+```hcl
+pattern_jq_query = "[\"value1\", \"value2\", \"value3\"]"
+```
+
+This simpler format can be used to specify a fixed list of allowed values directly.
+
+## Important Notes
+
+- You cannot use both `pattern` and `pattern_jq_query` at the same time on the same property
+- The JQ query is evaluated at runtime by the Port API
+- The context available to the JQ expression depends on where the pattern is being used (entity context, action context, etc.)
+- For regex patterns, make sure to escape special characters properly
+
+## How to Use
+
+1. Choose which approach is most appropriate for your use case
+2. Write a JQ expression or JSON array as needed
+3. Apply the pattern validation to the appropriate string property in your action definition 

--- a/examples/resources/port_action/pattern_jq_query/README.md
+++ b/examples/resources/port_action/pattern_jq_query/README.md
@@ -33,7 +33,7 @@ This simpler format can be used to specify a fixed list of allowed values direct
 ## Important Notes
 
 - You cannot use both `pattern` and `pattern_jq_query` at the same time on the same property
-- The JQ query is evaluated at runtime by the Port API
+- The JQ query is evaluated at runtime by Port
 - The context available to the JQ expression depends on where the pattern is being used (entity context, action context, etc.)
 - For regex patterns, make sure to escape special characters properly
 

--- a/examples/resources/port_action/pattern_jq_query/main.tf
+++ b/examples/resources/port_action/pattern_jq_query/main.tf
@@ -1,0 +1,73 @@
+# This example demonstrates different ways to use pattern_jq_query
+
+# Example 1: Using pattern_jq_query to dynamically generate a regex pattern
+resource "port_action" "regex_pattern_example" {
+  title      = "Create Service"
+  identifier = "create_service"
+  self_service_trigger = {
+    operation           = "CREATE"
+    blueprint_identifier = "service"
+    user_properties = {
+      string_props = {
+        service_name = {
+          title      = "Service Name"
+          # Dynamic regex pattern based on context
+          pattern_jq_query = "if .environment == \"production\" then \"^[a-z][a-z0-9-]{3,20}$\" else \"^[a-z][a-z0-9-]{2,10}$\" end"
+          description = "Name of the service (lowercase, numbers, hyphens)"
+        }
+      }
+    }
+  }
+  description = "Create a new service"
+  webhook_method = {
+    url = "https://api.example.com/create-service"
+  }
+}
+
+# Example 2: Using pattern_jq_query to dynamically generate a list of allowed values
+resource "port_action" "allowed_values_example" {
+  title      = "Deploy To Environment"
+  identifier = "deploy_to_env"
+  self_service_trigger = {
+    operation           = "DAY-2"
+    blueprint_identifier = "microservice"
+    user_properties = {
+      string_props = {
+        target_environment = {
+          title      = "Target Environment"
+          # Dynamic allowed values based on context
+          pattern_jq_query = "if .team == \"platform\" then [\"dev\", \"staging\", \"production\"] else [\"dev\", \"staging\"] end"
+          description = "Environment to deploy to (platform team can deploy to production)"
+        }
+      }
+    }
+  }
+  description = "Deploy service to environment"
+  webhook_method = {
+    url = "https://api.example.com/deploy"
+  }
+}
+
+# Example 3: Using pattern_jq_query with a direct JSON array of allowed values
+resource "port_action" "direct_array_example" {
+  title      = "Select Region"
+  identifier = "select_region"
+  self_service_trigger = {
+    operation           = "CREATE"
+    blueprint_identifier = "deployment"
+    user_properties = {
+      string_props = {
+        region = {
+          title      = "Region"
+          # Direct JSON array of allowed values
+          pattern_jq_query = "[\"us-east-1\", \"us-west-1\", \"eu-west-1\", \"ap-northeast-1\"]"
+          description = "AWS region for deployment"
+        }
+      }
+    }
+  }
+  description = "Select deployment region"
+  webhook_method = {
+    url = "https://api.example.com/select-region"
+  }
+} 

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -88,7 +88,7 @@ type (
 		Minimum            *float64            `json:"minimum,omitempty"`
 		Description        *string             `json:"description,omitempty"`
 		Blueprint          *string             `json:"blueprint,omitempty"`
-		Pattern            *string             `json:"pattern,omitempty"`
+		Pattern            any                 `json:"pattern,omitempty"`
 		Enum               any                 `json:"enum,omitempty"`
 		Spec               *string             `json:"spec,omitempty"`
 		SpecAuthentication *SpecAuthentication `json:"specAuthentication,omitempty"`

--- a/port/action/model.go
+++ b/port/action/model.go
@@ -30,17 +30,18 @@ type StringPropModel struct {
 	Visible        types.Bool    `tfsdk:"visible"`
 	VisibleJqQuery types.String  `tfsdk:"visible_jq_query"`
 
-	Default     types.String       `tfsdk:"default"`
-	Blueprint   types.String       `tfsdk:"blueprint"`
-	Format      types.String       `tfsdk:"format"`
-	MaxLength   types.Int64        `tfsdk:"max_length"`
-	MinLength   types.Int64        `tfsdk:"min_length"`
-	Pattern     types.String       `tfsdk:"pattern"`
-	Enum        types.List         `tfsdk:"enum"`
-	EnumColors  types.Map          `tfsdk:"enum_colors"`
-	EnumJqQuery types.String       `tfsdk:"enum_jq_query"`
-	Encryption  types.String       `tfsdk:"encryption"`
-	Sort        *EntitiesSortModel `tfsdk:"sort"`
+	Default        types.String       `tfsdk:"default"`
+	Blueprint      types.String       `tfsdk:"blueprint"`
+	Format         types.String       `tfsdk:"format"`
+	MaxLength      types.Int64        `tfsdk:"max_length"`
+	MinLength      types.Int64        `tfsdk:"min_length"`
+	Pattern        types.String       `tfsdk:"pattern"`
+	PatternJqQuery types.String       `tfsdk:"pattern_jq_query"`
+	Enum           types.List         `tfsdk:"enum"`
+	EnumColors     types.Map          `tfsdk:"enum_colors"`
+	EnumJqQuery    types.String       `tfsdk:"enum_jq_query"`
+	Encryption     types.String       `tfsdk:"encryption"`
+	Sort           *EntitiesSortModel `tfsdk:"sort"`
 }
 
 // StringPropValidationModel is a model used for the validation of StringPropModel resources

--- a/port/action/resource_test.go
+++ b/port/action/resource_test.go
@@ -1113,7 +1113,7 @@ func TestAccPortActionPatternConflict(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				ExpectError: regexp.MustCompile("Attribute .* conflicts with pattern_jq_query"),
+				ExpectError: regexp.MustCompile(`(?s)Error: Invalid Attribute Combination.*Attribute.*pattern.*cannot be specified when.*pattern_jq_query.*is specified`),
 				Config:      acctest.ProviderConfig + testAccActionConfigCreate,
 			},
 		},

--- a/port/action/resource_test.go
+++ b/port/action/resource_test.go
@@ -1150,7 +1150,7 @@ func TestAccPortActionEmptyPatternJqQuery(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				ExpectError: regexp.MustCompile(`(?s)Error: Invalid Attribute Value Length.*String length must be at least 1`),
+				ExpectError: regexp.MustCompile(`string length must be at least 1`),
 				Config:      acctest.ProviderConfig + testAccActionConfigCreate,
 			},
 		},
@@ -1189,8 +1189,7 @@ func TestAccPortActionPatternJqQueryComplex(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				ExpectNonEmptyPlan: true,
-				Config:             acctest.ProviderConfig + testAccActionConfigComplex,
+				Config: acctest.ProviderConfig + testAccActionConfigComplex,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.user_properties.string_props.myStringIdentifier.pattern_jq_query", "if .blueprint == \"microservice\" then \"^[a-z]+$\" else \"^[0-9]+$\" end"),
 				),
@@ -1230,8 +1229,7 @@ func TestAccPortActionPatternJqQueryAllowedValues(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				ExpectNonEmptyPlan: true,
-				Config:             acctest.ProviderConfig + testAccActionConfigCreate,
+				Config: acctest.ProviderConfig + testAccActionConfigCreate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("port_action.create_microservice", "title", "Action 1"),
 					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.user_properties.string_props.myStringIdentifier.pattern_jq_query", "if .blueprint == \"microservice\" then [\"micro-1\", \"micro-2\"] else [\"other-1\", \"other-2\"] end"),

--- a/port/action/resource_test.go
+++ b/port/action/resource_test.go
@@ -1024,8 +1024,7 @@ func TestAccPortActionPatternJqQuery(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				ExpectNonEmptyPlan: true,
-				Config:             acctest.ProviderConfig + testAccActionConfigCreate,
+				Config: acctest.ProviderConfig + testAccActionConfigCreate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("port_action.create_microservice", "title", "Action 1"),
 					resource.TestCheckResourceAttr("port_action.create_microservice", "identifier", actionIdentifier),
@@ -1067,8 +1066,7 @@ func TestAccPortActionPattern(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				ExpectNonEmptyPlan: true,
-				Config:             acctest.ProviderConfig + testAccActionConfigCreate,
+				Config: acctest.ProviderConfig + testAccActionConfigCreate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("port_action.create_microservice", "title", "Action 1"),
 					resource.TestCheckResourceAttr("port_action.create_microservice", "identifier", actionIdentifier),
@@ -1270,8 +1268,7 @@ func TestAccPortActionPatternJqQueryDirectArray(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				ExpectNonEmptyPlan: true,
-				Config:             acctest.ProviderConfig + testAccActionConfigCreate,
+				Config: acctest.ProviderConfig + testAccActionConfigCreate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("port_action.create_microservice", "title", "Action 1"),
 					resource.TestCheckResourceAttr("port_action.create_microservice", "identifier", actionIdentifier),

--- a/port/action/resource_test.go
+++ b/port/action/resource_test.go
@@ -1120,7 +1120,7 @@ func TestAccPortActionPatternConflict(t *testing.T) {
 	})
 }
 
-// TestAccPortActionPatternJqQueryEdgeCases tests edge cases for pattern_jq_query
+// tests empty pattern_jq_query
 func TestAccPortActionPatternJqQueryEdgeCases(t *testing.T) {
 	identifier := utils.GenID()
 	actionIdentifier := utils.GenID()
@@ -1190,7 +1190,7 @@ func TestAccPortActionPatternJqQueryEdgeCases(t *testing.T) {
 	})
 }
 
-// TestAccPortActionPatternJqQueryAllowedValues tests using pattern_jq_query to generate a list of allowed values
+// tests using pattern_jq_query to generate a list of allowed values
 func TestAccPortActionPatternJqQueryAllowedValues(t *testing.T) {
 	identifier := utils.GenID()
 	actionIdentifier := utils.GenID()
@@ -1232,7 +1232,7 @@ func TestAccPortActionPatternJqQueryAllowedValues(t *testing.T) {
 	})
 }
 
-// TestAccPortActionPatternJqQueryDirectArray tests using pattern_jq_query with a direct JSON array format
+// tests using pattern_jq_query with a direct JSON array format
 func TestAccPortActionPatternJqQueryDirectArray(t *testing.T) {
 	identifier := utils.GenID()
 	actionIdentifier := utils.GenID()

--- a/port/action/resource_test.go
+++ b/port/action/resource_test.go
@@ -1024,7 +1024,8 @@ func TestAccPortActionPatternJqQuery(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.ProviderConfig + testAccActionConfigCreate,
+				ExpectNonEmptyPlan: true,
+				Config:             acctest.ProviderConfig + testAccActionConfigCreate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("port_action.create_microservice", "title", "Action 1"),
 					resource.TestCheckResourceAttr("port_action.create_microservice", "identifier", actionIdentifier),
@@ -1066,7 +1067,8 @@ func TestAccPortActionPattern(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: acctest.ProviderConfig + testAccActionConfigCreate,
+				ExpectNonEmptyPlan: true,
+				Config:             acctest.ProviderConfig + testAccActionConfigCreate,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("port_action.create_microservice", "title", "Action 1"),
 					resource.TestCheckResourceAttr("port_action.create_microservice", "identifier", actionIdentifier),

--- a/port/action/resource_test.go
+++ b/port/action/resource_test.go
@@ -994,6 +994,92 @@ func TestAccPortActionEnum(t *testing.T) {
 		},
 	})
 }
+
+func TestAccPortActionPatternJqQuery(t *testing.T) {
+	identifier := utils.GenID()
+	actionIdentifier := utils.GenID()
+	var testAccActionConfigCreate = testAccCreateBlueprintConfig(identifier) + fmt.Sprintf(`
+	resource "port_action" "create_microservice" {
+		title             = "Action 1"
+		identifier        = "%s"
+		self_service_trigger = {
+			operation = "DAY-2"
+			blueprint_identifier = port_blueprint.microservice.identifier
+			user_properties = {
+				string_props = {
+					myStringIdentifier = {
+						title      = "myStringIdentifier"
+						pattern_jq_query = "[\"test1\", \"test2\"]"
+					}
+				}
+			}
+		}
+		description       = "This is a test action"
+		kafka_method = {}
+	}`, actionIdentifier)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + testAccActionConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_action.create_microservice", "title", "Action 1"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "identifier", actionIdentifier),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.operation", "DAY-2"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "description", "This is a test action"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.user_properties.string_props.myStringIdentifier.title", "myStringIdentifier"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.user_properties.string_props.myStringIdentifier.pattern_jq_query", "[\"test1\", \"test2\"]"),
+				),
+			},
+		},
+	})
+}
+func TestAccPortActionPattern(t *testing.T) {
+	identifier := utils.GenID()
+	actionIdentifier := utils.GenID()
+	var testAccActionConfigCreate = testAccCreateBlueprintConfig(identifier) + fmt.Sprintf(`
+	resource "port_action" "create_microservice" {
+		title             = "Action 1"
+		identifier        = "%s"
+		self_service_trigger = {
+			operation = "DAY-2"
+			blueprint_identifier = port_blueprint.microservice.identifier
+			user_properties = {
+				string_props = {
+					myStringIdentifier = {
+						title   = "myStringIdentifier"
+						pattern = "^[a-zA-Z0-9-]*-service$"
+					}
+				}
+			}
+		}
+		description       = "This is a test action"
+		kafka_method = {}
+	}`, actionIdentifier)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + testAccActionConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_action.create_microservice", "title", "Action 1"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "identifier", actionIdentifier),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.operation", "DAY-2"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "description", "This is a test action"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.user_properties.string_props.myStringIdentifier.title", "myStringIdentifier"),
+					resource.TestCheckResourceAttr("port_action.create_microservice", "self_service_trigger.user_properties.string_props.myStringIdentifier.pattern", "^[a-zA-Z0-9-]*-service$"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccPortActionOrderProperties(t *testing.T) {
 	identifier := utils.GenID()
 	actionIdentifier := utils.GenID()

--- a/port/action/schema.go
+++ b/port/action/schema.go
@@ -532,10 +532,11 @@ func StringPropertySchema() schema.Attribute {
 			Optional:            true,
 		},
 		"pattern_jq_query": schema.StringAttribute{
-			MarkdownDescription: "The pattern jq query of the string property. This field accepts a JQ expression to dynamically generate either a regex pattern (as a string) or a list of allowed values (as an array). Cannot be used with `pattern`. Examples: `\"if .env == \\\"prod\\\" then \\\"^[a-z]+$\\\" else \\\"^[a-zA-Z]+$\\\" end\"` for dynamic regex patterns, or `\"[\\\"value1\\\", \\\"value2\\\"]\"` for a fixed list of allowed values.",
+			MarkdownDescription: "The pattern jq query of the string property. This field accepts a JQ expression to dynamically generate either a regex pattern (as a string) or a list of allowed values (as an array). Cannot be used with `pattern`. Empty values are not allowed. Examples: `\"if .env == \\\"prod\\\" then \\\"^[a-z]+$\\\" else \\\"^[a-zA-Z]+$\\\" end\"` for dynamic regex patterns, or `\"[\\\"value1\\\", \\\"value2\\\"]\"` for a fixed list of allowed values.",
 			Optional:            true,
 			Validators: []validator.String{
 				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("pattern")),
+				stringvalidator.LengthAtLeast(1),
 			},
 		},
 		"enum": schema.ListAttribute{

--- a/port/action/schema.go
+++ b/port/action/schema.go
@@ -531,6 +531,13 @@ func StringPropertySchema() schema.Attribute {
 			MarkdownDescription: "The pattern of the string property",
 			Optional:            true,
 		},
+		"pattern_jq_query": schema.StringAttribute{
+			MarkdownDescription: "The pattern jq query of the string property",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("pattern")),
+			},
+		},
 		"enum": schema.ListAttribute{
 			MarkdownDescription: "The enum of the string property",
 			Optional:            true,

--- a/port/action/schema.go
+++ b/port/action/schema.go
@@ -532,7 +532,7 @@ func StringPropertySchema() schema.Attribute {
 			Optional:            true,
 		},
 		"pattern_jq_query": schema.StringAttribute{
-			MarkdownDescription: "The pattern jq query of the string property",
+			MarkdownDescription: "The pattern jq query of the string property. This field accepts a JQ expression to dynamically generate either a regex pattern (as a string) or a list of allowed values (as an array). Cannot be used with `pattern`. Examples: `\"if .env == \\\"prod\\\" then \\\"^[a-z]+$\\\" else \\\"^[a-zA-Z]+$\\\" end\"` for dynamic regex patterns, or `\"[\\\"value1\\\", \\\"value2\\\"]\"` for a fixed list of allowed values.",
 			Optional:            true,
 			Validators: []validator.String{
 				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("pattern")),

--- a/port/action/string.go
+++ b/port/action/string.go
@@ -65,6 +65,13 @@ func stringPropResourceToBody(ctx context.Context, d *SelfServiceTriggerModel, p
 			property.Pattern = &pattern
 		}
 
+		if !prop.PatternJqQuery.IsNull() {
+			patternJqQueryMap := map[string]string{
+				"jqQuery": prop.PatternJqQuery.ValueString(),
+			}
+			property.Pattern = patternJqQueryMap
+		}
+
 		if !prop.Description.IsNull() {
 			description := prop.Description.ValueString()
 			property.Description = &description
@@ -149,7 +156,6 @@ func addStringPropertiesToResource(ctx context.Context, v *cli.ActionProperty) *
 	stringProp := &StringPropModel{
 		MinLength:  flex.GoInt64ToFramework(v.MinLength),
 		MaxLength:  flex.GoInt64ToFramework(v.MaxLength),
-		Pattern:    flex.GoStringToFramework(v.Pattern),
 		Format:     flex.GoStringToFramework(v.Format),
 		Blueprint:  flex.GoStringToFramework(v.Blueprint),
 		Encryption: flex.GoStringToFramework(v.Encryption),

--- a/port/action/string.go
+++ b/port/action/string.go
@@ -162,6 +162,21 @@ func addStringPropertiesToResource(ctx context.Context, v *cli.ActionProperty) *
 		Dataset:    writeDatasetToResource(v.Dataset),
 	}
 
+	if v.Pattern != nil {
+		patternVal := reflect.ValueOf(v.Pattern)
+		if patternVal.Kind() == reflect.String {
+			stringProp.Pattern = types.StringValue(v.Pattern.(string))
+		} else if patternVal.Kind() == reflect.Map {
+			patternMap := v.Pattern.(map[string]interface{})
+			if jqQuery, ok := patternMap["jqQuery"]; ok {
+				stringProp.PatternJqQuery = types.StringValue(jqQuery.(string))
+			}
+		}
+	} else {
+		stringProp.Pattern = types.StringNull()
+		stringProp.PatternJqQuery = types.StringNull()
+	}
+
 	if v.Enum != nil {
 		v := reflect.ValueOf(v.Enum)
 		switch v.Kind() {

--- a/port/action/string.go
+++ b/port/action/string.go
@@ -162,13 +162,19 @@ func addStringPropertiesToResource(ctx context.Context, v *cli.ActionProperty) *
 		Dataset:    writeDatasetToResource(v.Dataset),
 	}
 
+	// Handle pattern (could be a string or a map with jqQuery)
 	if v.Pattern != nil {
-		patternVal := reflect.ValueOf(v.Pattern)
-		if patternVal.Kind() == reflect.String {
+		vPattern := reflect.ValueOf(v.Pattern)
+
+		if vPattern.Kind() == reflect.String {
+			// Regular pattern
 			stringProp.Pattern = types.StringValue(v.Pattern.(string))
-		} else if patternVal.Kind() == reflect.Map {
+			stringProp.PatternJqQuery = types.StringNull()
+		} else if vPattern.Kind() == reflect.Map {
+			// JQ Query pattern
 			patternMap := v.Pattern.(map[string]interface{})
 			if jqQuery, ok := patternMap["jqQuery"]; ok {
+				stringProp.Pattern = types.StringNull()
 				stringProp.PatternJqQuery = types.StringValue(jqQuery.(string))
 			}
 		}


### PR DESCRIPTION
Verify CI for https://github.com/port-labs/terraform-provider-port-labs/pull/224

- Update schema to support the new parameter: pattern_jq_query
- Update documentation with examples of both usage patterns
- Add comprehensive tests for all use cases
- Adjust existing pattern validation to prevent conflicts

Description
What - Added support for dynamic pattern validation using JQ queries for string properties. The pattern_jq_query parameter allows users to specify validation rules that change based on context.

Why - This enhancement enables more flexible validation rules that can adapt to different situations without requiring multiple actions or complex conditional logic

How - Implemented by:
Adding the pattern_jq_query field to the schema with conflict validation against pattern
Modifying the API request handling to wrap JQ queries in a proper format
Adding comprehensive tests for both usage patterns and edge cases
Creating clear documentation and examples showing both approaches

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)
