### PR TITLE
Change port_entity title attribute from optional to required

### DIFF
--- a/docs/resources/port_entity.md
+++ b/docs/resources/port_entity.md
@@ -18,6 +18,7 @@ Entity resource
 ### Required
 
 - `blueprint` (String) The blueprint identifier the entity relates to
+- `title` (String) The title of the entity
 
 ### Optional
 
@@ -28,7 +29,6 @@ Entity resource
 - `relations` (Attributes) The relations of the entity (see [below for nested schema](#nestedatt--relations))
 - `run_id` (String) The runID of the action run that created the entity
 - `teams` (List of String) The teams the entity belongs to
-- `title` (String) The title of the entity
 
 ### Read-Only
 

--- a/port/entity/schema.go
+++ b/port/entity/schema.go
@@ -26,7 +26,7 @@ func EntitySchema() map[string]schema.Attribute {
 		},
 		"title": schema.StringAttribute{
 			MarkdownDescription: "The title of the entity",
-			Optional:            true,
+			Required:            true,
 		},
 		"icon": schema.StringAttribute{
 			MarkdownDescription: "The icon of the entity",


### PR DESCRIPTION
# Description

What - Change port_entity title attribute from optional to required
Why - The title is required in the server, and if it is missing it causes weird
warnings during plan.


## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)