### PR TITLE
Add a nil check during port_action buildUserProperties

### DIFF
--- a/port/action/refreshActionState.go
+++ b/port/action/refreshActionState.go
@@ -314,7 +314,7 @@ func buildUserProperties(ctx context.Context, a *cli.Action, state *ActionModel)
 	if properties.StringProps == nil && properties.NumberProps == nil && properties.ArrayProps == nil && properties.BooleanProps == nil && properties.ObjectProps == nil {
 		// this logic is handling default initialization of user properties as there is no option to define default user properties in the action schema
 		// if there was a state defined for the user properties, return the initiated properties
-		if state.SelfServiceTrigger.UserProperties != nil {
+		if state.SelfServiceTrigger != nil && state.SelfServiceTrigger.UserProperties != nil {
 			return properties, nil
 		}
 		// if there are no user properties defined, return nil


### PR DESCRIPTION
# Description

What - Add a nil check during port_action buildUserProperties
Why - When running terraform plan with import statements, the
SelfServiceTrigger is nil.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)