### PR TITLE
GoObjectToTerraformString: JSON encode without HTML escaping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       group: acctest
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       fail-fast: false
       matrix:
         test_file: ${{fromJSON(needs.acctest-build.outputs.test_files)}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,6 @@ jobs:
       group: acctest
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
       fail-fast: false
       matrix:
         test_file: ${{fromJSON(needs.acctest-build.outputs.test_files)}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
           PORT_BASE_URL: ${{ secrets.PORT_BASE_URL }}
         run: |
           chmod u+x "${{matrix.test_file}}"
-          gotestsum --raw-command --rerun-fails --format testname --junitfile "./test-results/${{matrix.test_file}}.xml" \
+          gotestsum --raw-command --rerun-fails=3 --format testname --junitfile "./test-results/${{matrix.test_file}}.xml" \
             -- go tool test2json -t -p "${{matrix.package}}" "./${{matrix.test_file}}" \
             -test.v=test2json -test.timeout 10m -test.parallel 1 -test.shuffle "${{ github.run_id }}" -test.coverprofile=cover-${{ env.SHORT_NAME }}.out
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,9 @@ jobs:
           comment: 'true'
           check_retries: 'true'
           flaky_summary: 'true'
+          detailed_summary: 'true'
+          include_time_in_summary: 'true'
+          simplified_summary: 'true'
       - name: Download all coverage reports
         uses: actions/download-artifact@v4
         with:

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,13 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.15.0
 	github.com/hashicorp/terraform-plugin-framework v1.10.0
 	github.com/samber/lo v1.46.0
+	github.com/stretchr/testify v1.10.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -198,7 +198,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/tetify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -99,7 +99,8 @@ func GoObjectToTerraformString(v interface{}) (types.String, error) {
 		return types.StringNull(), err
 	}
 
-	return types.StringValue(jsonBuilder.String()), nil
+	jsonStr, _ := strings.CutSuffix(jsonBuilder.String(), "\n")
+	return types.StringValue(jsonStr), nil
 }
 
 func TerraformStringToGoType[T any](s types.String) (T, error) {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -37,25 +37,25 @@ func TestGoObjectToTerraformString(t *testing.T) {
 				"nested": map[string]any{"foo": "bar"},
 			}},
 			want: types.StringValue(
-				"{\"bool\":true,\"float\":42.42,\"int\":42,\"list\":[1,2,3],\"nested\":{\"foo\":\"bar\"},\"nil\":null,\"string\":\"hello world\"}\n",
+				"{\"bool\":true,\"float\":42.42,\"int\":42,\"list\":[1,2,3],\"nested\":{\"foo\":\"bar\"},\"nil\":null,\"string\":\"hello world\"}",
 			),
 		},
 
 		{
 			name: "nested slice",
 			args: args{v: []any{"hello world", 1, map[string]any{"foo": "bar"}}},
-			want: types.StringValue("[\"hello world\",1,{\"foo\":\"bar\"}]\n"),
+			want: types.StringValue("[\"hello world\",1,{\"foo\":\"bar\"}]"),
 		},
 
 		{
 			name: "html unsafe characters",
 			args: args{v: map[string]any{"property": "sum", "operator": ">", "value": 2}},
-			want: types.StringValue("{\"operator\":\">\",\"property\":\"sum\",\"value\":2}\n"),
+			want: types.StringValue("{\"operator\":\">\",\"property\":\"sum\",\"value\":2}"),
 		},
 		{
 			name: "html unsafe characters (double escape)",
 			args: args{v: "{\"property\": \"sum\", \"operator\": \">\", \"value\": 2}"},
-			want: types.StringValue("\"{\\\"property\\\": \\\"sum\\\", \\\"operator\\\": \\\">\\\", \\\"value\\\": 2}\"\n"),
+			want: types.StringValue("\"{\\\"property\\\": \\\"sum\\\", \\\"operator\\\": \\\">\\\", \\\"value\\\": 2}\""),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,72 @@
+package utils
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGoObjectToTerraformString(t *testing.T) {
+	type args struct {
+		v interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    types.String
+		wantErr bool
+	}{
+		{name: "nil map", args: args{v: (map[any]any)(nil)}, want: types.StringNull()},
+		{name: "nil *map", args: args{v: (*map[any]any)(nil)}, want: types.StringNull()},
+		{name: "nil array", args: args{v: (*[0]any)(nil)}, want: types.StringNull()},
+		{name: "nil chan", args: args{v: (chan any)(nil)}, want: types.StringNull()},
+		{name: "nil *chan", args: args{v: (*chan any)(nil)}, want: types.StringNull()},
+		{name: "nil slice", args: args{v: ([]any)(nil)}, want: types.StringNull()},
+		{name: "nil *slice", args: args{v: (*[]any)(nil)}, want: types.StringNull()},
+		{name: "nil *string", args: args{v: (*string)(nil)}, want: types.StringNull()},
+
+		{
+			name: "nested map",
+			args: args{v: map[string]any{
+				"string": "hello world",
+				"int":    42,
+				"bool":   true,
+				"float":  42.42,
+				"list":   []any{1, 2, 3},
+				"nil":    nil,
+				"nested": map[string]any{"foo": "bar"},
+			}},
+			want: types.StringValue(
+				"{\"bool\":true,\"float\":42.42,\"int\":42,\"list\":[1,2,3],\"nested\":{\"foo\":\"bar\"},\"nil\":null,\"string\":\"hello world\"}\n",
+			),
+		},
+
+		{
+			name: "nested slice",
+			args: args{v: []any{"hello world", 1, map[string]any{"foo": "bar"}}},
+			want: types.StringValue("[\"hello world\",1,{\"foo\":\"bar\"}]\n"),
+		},
+
+		{
+			name: "html unsafe characters",
+			args: args{v: map[string]any{"property": "sum", "operator": ">", "value": 2}},
+			want: types.StringValue("{\"operator\":\">\",\"property\":\"sum\",\"value\":2}\n"),
+		},
+		{
+			name: "html unsafe characters (double escape)",
+			args: args{v: "{\"property\": \"sum\", \"operator\": \">\", \"value\": 2}"},
+			want: types.StringValue("\"{\\\"property\\\": \\\"sum\\\", \\\"operator\\\": \\\">\\\", \\\"value\\\": 2}\"\n"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GoObjectToTerraformString(tt.args.v)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/port/scorecard/resource_test.go
+++ b/port/scorecard/resource_test.go
@@ -177,7 +177,7 @@ func TestAccPortScorecard(t *testing.T) {
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.combinator", "or"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.#", "2"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.0", "{\"operator\":\"=\",\"property\":\"required\",\"value\":true}"),
-					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.1", "{\"operator\":\">\",\"property\":\"sum\",\"value\":2}"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.1", "{\"operator\":\"\\u003e\",\"property\":\"sum\",\"value\":2}"),
 				),
 			},
 		},
@@ -290,7 +290,7 @@ func TestAccPortScorecardUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("port_scorecard.test", "filter.combinator", "or"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "filter.conditions.#", "2"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "filter.conditions.0", "{\"operator\":\"=\",\"property\":\"required\",\"value\":true}"),
-					resource.TestCheckResourceAttr("port_scorecard.test", "filter.conditions.1", "{\"operator\":\">\",\"property\":\"sum\",\"value\":10}"), // u003e is how > is returned
+					resource.TestCheckResourceAttr("port_scorecard.test", "filter.conditions.1", "{\"operator\":\"\\u003e\",\"property\":\"sum\",\"value\":10}"), // u003e is how > is returned
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.#", "1"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.0.identifier", "hasTeam"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.0.title", "Has Team"),

--- a/port/scorecard/resource_test.go
+++ b/port/scorecard/resource_test.go
@@ -177,7 +177,7 @@ func TestAccPortScorecard(t *testing.T) {
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.combinator", "or"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.#", "2"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.0", "{\"operator\":\"=\",\"property\":\"required\",\"value\":true}"),
-					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.1", "{\"operator\":\"\\u003e\",\"property\":\"sum\",\"value\":2}"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.1", "{\"operator\":\">\",\"property\":\"sum\",\"value\":2}"),
 				),
 			},
 		},
@@ -290,7 +290,7 @@ func TestAccPortScorecardUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("port_scorecard.test", "filter.combinator", "or"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "filter.conditions.#", "2"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "filter.conditions.0", "{\"operator\":\"=\",\"property\":\"required\",\"value\":true}"),
-					resource.TestCheckResourceAttr("port_scorecard.test", "filter.conditions.1", "{\"operator\":\"\\u003e\",\"property\":\"sum\",\"value\":10}"), // u003e is how > is returned
+					resource.TestCheckResourceAttr("port_scorecard.test", "filter.conditions.1", "{\"operator\":\">\",\"property\":\"sum\",\"value\":10}"), // u003e is how > is returned
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.#", "1"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.0.identifier", "hasTeam"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.0.title", "Has Team"),


### PR DESCRIPTION
# Description

What - GoObjectToTerraformString: JSON encode without HTML escaping
Why - [URL encoding of > and < symbols cause "inconsistent result after apply" error #222](https://github.com/port-labs/terraform-provider-port-labs/issues/222)
How - Replace json.Marshal with a json.Encoder and configure SetEscapeHTML to false.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)