### PR TITLE
Allow to disable the auto JSON HTML escaping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
       group: acctest
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       fail-fast: false
       matrix:
         test_file: ${{fromJSON(needs.acctest-build.outputs.test_files)}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,6 @@ jobs:
       group: acctest
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
       fail-fast: false
       matrix:
         test_file: ${{fromJSON(needs.acctest-build.outputs.test_files)}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
           PORT_BASE_URL: ${{ secrets.PORT_BASE_URL }}
         run: |
           chmod u+x "${{matrix.test_file}}"
-          gotestsum --raw-command --rerun-fails --format testname --junitfile "./test-results/${{matrix.test_file}}.xml" \
+          gotestsum --raw-command --rerun-fails=3 --format testname --junitfile "./test-results/${{matrix.test_file}}.xml" \
             -- go tool test2json -t -p "${{matrix.package}}" "./${{matrix.test_file}}" \
             -test.v=test2json -test.timeout 10m -test.parallel 1 -test.shuffle "${{ github.run_id }}" -test.coverprofile=cover-${{ env.SHORT_NAME }}.out
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,6 @@ jobs:
           comment: 'true'
           check_retries: 'true'
           flaky_summary: 'true'
-          detailed_summary: 'true'
           include_time_in_summary: 'true'
           simplified_summary: 'true'
       - name: Download all coverage reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,9 @@ jobs:
           comment: 'true'
           check_retries: 'true'
           flaky_summary: 'true'
+          detailed_summary: 'true'
+          include_time_in_summary: 'true'
+          simplified_summary: 'true'
       - name: Download all coverage reports
         uses: actions/download-artifact@v4
         with:

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,5 +19,6 @@ Interact with Port-labs
 
 - `base_url` (String)
 - `client_id` (String) Client ID for Port-labs
+- `json_escape_html` (Boolean) When set to `false` disables the default HTML escaping of json.Marshal when reading data from Port. Defaults to `true`
 - `secret` (String, Sensitive) Client Secret for Port-labs
 - `token` (String, Sensitive) Token for Port-labs

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,13 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.15.0
 	github.com/hashicorp/terraform-plugin-framework v1.10.0
 	github.com/samber/lo v1.46.0
+	github.com/stretchr/testify v1.10.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -198,7 +198,7 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/tetify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.4+incompatible h1:dSLoQfGFAo3F6OoNhwUmLwVgaUXK79GlxNBwueZn0xI=

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -28,6 +28,14 @@ var ProviderConfig = fmt.Sprintf(`provider "port" {
 	}
 `, os.Getenv("PORT_CLIENT_ID"), os.Getenv("PORT_CLIENT_SECRET"), os.Getenv("PORT_BASE_URL"))
 
+var ProviderConfigNoEscapeHTML = fmt.Sprintf(`provider "port" {
+	client_id = "%s"
+	secret = "%s"
+	base_url = "%s"
+	json_escape_html = false
+	}
+`, os.Getenv("PORT_CLIENT_ID"), os.Getenv("PORT_CLIENT_SECRET"), os.Getenv("PORT_BASE_URL"))
+
 func TestAccPreCheck(t *testing.T) {
 	if v := os.Getenv("PORT_CLIENT_ID"); v == "" {
 		t.Fatal("PORT_CLIENT_ID must be set for acceptance tests")

--- a/internal/cli/client.go
+++ b/internal/cli/client.go
@@ -13,10 +13,11 @@ import (
 type Option func(*PortClient)
 
 type PortClient struct {
-	Client       *resty.Client
-	ClientID     string
-	Token        string
-	featureFlags []string
+	Client         *resty.Client
+	ClientID       string
+	Token          string
+	featureFlags   []string
+	JSONEscapeHTML bool
 }
 
 func New(baseURL string, opts ...Option) (*PortClient, error) {

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -548,10 +548,11 @@ type PortTeamBody struct {
 }
 
 type PortProviderModel struct {
-	ClientId types.String `tfsdk:"client_id"`
-	Secret   types.String `tfsdk:"secret"`
-	Token    types.String `tfsdk:"token"`
-	BaseUrl  types.String `tfsdk:"base_url"`
+	ClientId       types.String `tfsdk:"client_id"`
+	Secret         types.String `tfsdk:"secret"`
+	Token          types.String `tfsdk:"token"`
+	BaseUrl        types.String `tfsdk:"base_url"`
+	JSONEscapeHTML types.Bool   `tfsdk:"json_escape_html"`
 }
 
 type PortBodyDelete struct {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -99,7 +99,8 @@ func GoObjectToTerraformString(v interface{}) (types.String, error) {
 		return types.StringNull(), err
 	}
 
-	return types.StringValue(jsonBuilder.String()), nil
+	jsonStr, _ := strings.CutSuffix(jsonBuilder.String(), "\n")
+	return types.StringValue(jsonStr), nil
 }
 
 func TerraformStringToGoType[T any](s types.String) (T, error) {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -81,7 +81,7 @@ func TerraformListToGoArray(ctx context.Context, list types.List, arrayType stri
 
 var nillableKinds = []reflect.Kind{reflect.Ptr, reflect.Map, reflect.Array, reflect.Chan, reflect.Slice}
 
-func GoObjectToTerraformString(v interface{}) (types.String, error) {
+func GoObjectToTerraformString(v interface{}, jsonEscapeHTML bool) (types.String, error) {
 	if v == nil {
 		return types.StringNull(), nil
 	}
@@ -93,7 +93,7 @@ func GoObjectToTerraformString(v interface{}) (types.String, error) {
 
 	jsonBuilder := new(strings.Builder)
 	jsonEncoder := json.NewEncoder(jsonBuilder)
-	jsonEncoder.SetEscapeHTML(false)
+	jsonEncoder.SetEscapeHTML(jsonEscapeHTML)
 	err := jsonEncoder.Encode(v)
 	if err != nil {
 		return types.StringNull(), err

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -93,6 +93,12 @@ func TestGoObjectToTerraformString(t *testing.T) {
 			args: args{v: "{\"property\": \"sum\", \"operator\": \">\", \"value\": 2}", JSONEscapeHTML: false},
 			want: types.StringValue("\"{\\\"property\\\": \\\"sum\\\", \\\"operator\\\": \\\">\\\", \\\"value\\\": 2}\""),
 		},
+		{
+			name:    "encode error",
+			args:    args{v: func() {}},
+			want:    types.StringNull(),
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -8,7 +8,8 @@ import (
 
 func TestGoObjectToTerraformString(t *testing.T) {
 	type args struct {
-		v interface{}
+		v              interface{}
+		JSONEscapeHTML bool
 	}
 	tests := []struct {
 		name    string
@@ -16,17 +17,16 @@ func TestGoObjectToTerraformString(t *testing.T) {
 		want    types.String
 		wantErr bool
 	}{
-		{name: "nil map", args: args{v: (map[any]any)(nil)}, want: types.StringNull()},
-		{name: "nil *map", args: args{v: (*map[any]any)(nil)}, want: types.StringNull()},
-		{name: "nil array", args: args{v: (*[0]any)(nil)}, want: types.StringNull()},
-		{name: "nil chan", args: args{v: (chan any)(nil)}, want: types.StringNull()},
-		{name: "nil *chan", args: args{v: (*chan any)(nil)}, want: types.StringNull()},
-		{name: "nil slice", args: args{v: ([]any)(nil)}, want: types.StringNull()},
-		{name: "nil *slice", args: args{v: (*[]any)(nil)}, want: types.StringNull()},
-		{name: "nil *string", args: args{v: (*string)(nil)}, want: types.StringNull()},
-
+		{name: "escape-html nil map", args: args{v: (map[any]any)(nil), JSONEscapeHTML: true}, want: types.StringNull()},
+		{name: "escape-html nil *map", args: args{v: (*map[any]any)(nil), JSONEscapeHTML: true}, want: types.StringNull()},
+		{name: "escape-html nil array", args: args{v: (*[0]any)(nil), JSONEscapeHTML: true}, want: types.StringNull()},
+		{name: "escape-html nil chan", args: args{v: (chan any)(nil), JSONEscapeHTML: true}, want: types.StringNull()},
+		{name: "escape-html nil *chan", args: args{v: (*chan any)(nil), JSONEscapeHTML: true}, want: types.StringNull()},
+		{name: "escape-html nil slice", args: args{v: ([]any)(nil), JSONEscapeHTML: true}, want: types.StringNull()},
+		{name: "escape-html nil *slice", args: args{v: (*[]any)(nil), JSONEscapeHTML: true}, want: types.StringNull()},
+		{name: "escape-html nil *string", args: args{v: (*string)(nil), JSONEscapeHTML: true}, want: types.StringNull()},
 		{
-			name: "nested map",
+			name: "escape-html nested map",
 			args: args{v: map[string]any{
 				"string": "hello world",
 				"int":    42,
@@ -35,32 +35,68 @@ func TestGoObjectToTerraformString(t *testing.T) {
 				"list":   []any{1, 2, 3},
 				"nil":    nil,
 				"nested": map[string]any{"foo": "bar"},
-			}},
+			}, JSONEscapeHTML: true},
 			want: types.StringValue(
 				"{\"bool\":true,\"float\":42.42,\"int\":42,\"list\":[1,2,3],\"nested\":{\"foo\":\"bar\"},\"nil\":null,\"string\":\"hello world\"}",
 			),
 		},
-
 		{
-			name: "nested slice",
-			args: args{v: []any{"hello world", 1, map[string]any{"foo": "bar"}}},
+			name: "escape-html nested slice",
+			args: args{v: []any{"hello world", 1, map[string]any{"foo": "bar"}}, JSONEscapeHTML: true},
 			want: types.StringValue("[\"hello world\",1,{\"foo\":\"bar\"}]"),
 		},
-
 		{
-			name: "html unsafe characters",
-			args: args{v: map[string]any{"property": "sum", "operator": ">", "value": 2}},
+			name: "escape-html html unsafe characters",
+			args: args{v: map[string]any{"property": "sum", "operator": ">", "value": 2}, JSONEscapeHTML: true},
+			want: types.StringValue("{\"operator\":\"\\u003e\",\"property\":\"sum\",\"value\":2}"),
+		},
+		{
+			name: "escape-html html unsafe characters (double escape)",
+			args: args{v: "{\"property\": \"sum\", \"operator\": \">\", \"value\": 2}", JSONEscapeHTML: true},
+			want: types.StringValue("\"{\\\"property\\\": \\\"sum\\\", \\\"operator\\\": \\\"\\u003e\\\", \\\"value\\\": 2}\""),
+		},
+		{name: "no-escape-html nil map", args: args{v: (map[any]any)(nil), JSONEscapeHTML: false}, want: types.StringNull()},
+		{name: "no-escape-html nil *map", args: args{v: (*map[any]any)(nil), JSONEscapeHTML: false}, want: types.StringNull()},
+		{name: "no-escape-html nil array", args: args{v: (*[0]any)(nil), JSONEscapeHTML: false}, want: types.StringNull()},
+		{name: "no-escape-html nil chan", args: args{v: (chan any)(nil), JSONEscapeHTML: false}, want: types.StringNull()},
+		{name: "no-escape-html nil *chan", args: args{v: (*chan any)(nil), JSONEscapeHTML: false}, want: types.StringNull()},
+		{name: "no-escape-html nil slice", args: args{v: ([]any)(nil), JSONEscapeHTML: false}, want: types.StringNull()},
+		{name: "no-escape-html nil *slice", args: args{v: (*[]any)(nil), JSONEscapeHTML: false}, want: types.StringNull()},
+		{name: "no-escape-html nil *string", args: args{v: (*string)(nil), JSONEscapeHTML: false}, want: types.StringNull()},
+		{
+			name: "no-escape-html nested map",
+			args: args{v: map[string]any{
+				"string": "hello world",
+				"int":    42,
+				"bool":   true,
+				"float":  42.42,
+				"list":   []any{1, 2, 3},
+				"nil":    nil,
+				"nested": map[string]any{"foo": "bar"},
+			}, JSONEscapeHTML: false},
+			want: types.StringValue(
+				"{\"bool\":true,\"float\":42.42,\"int\":42,\"list\":[1,2,3],\"nested\":{\"foo\":\"bar\"},\"nil\":null,\"string\":\"hello world\"}",
+			),
+		},
+		{
+			name: "no-escape-html nested slice",
+			args: args{v: []any{"hello world", 1, map[string]any{"foo": "bar"}}, JSONEscapeHTML: false},
+			want: types.StringValue("[\"hello world\",1,{\"foo\":\"bar\"}]"),
+		},
+		{
+			name: "no-escape-html html unsafe characters",
+			args: args{v: map[string]any{"property": "sum", "operator": ">", "value": 2}, JSONEscapeHTML: false},
 			want: types.StringValue("{\"operator\":\">\",\"property\":\"sum\",\"value\":2}"),
 		},
 		{
-			name: "html unsafe characters (double escape)",
-			args: args{v: "{\"property\": \"sum\", \"operator\": \">\", \"value\": 2}"},
+			name: "no-escape-html html unsafe characters (double escape)",
+			args: args{v: "{\"property\": \"sum\", \"operator\": \">\", \"value\": 2}", JSONEscapeHTML: false},
 			want: types.StringValue("\"{\\\"property\\\": \\\"sum\\\", \\\"operator\\\": \\\">\\\", \\\"value\\\": 2}\""),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GoObjectToTerraformString(tt.args.v)
+			got, err := GoObjectToTerraformString(tt.args.v, tt.args.JSONEscapeHTML)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -37,25 +37,25 @@ func TestGoObjectToTerraformString(t *testing.T) {
 				"nested": map[string]any{"foo": "bar"},
 			}},
 			want: types.StringValue(
-				"{\"bool\":true,\"float\":42.42,\"int\":42,\"list\":[1,2,3],\"nested\":{\"foo\":\"bar\"},\"nil\":null,\"string\":\"hello world\"}\n",
+				"{\"bool\":true,\"float\":42.42,\"int\":42,\"list\":[1,2,3],\"nested\":{\"foo\":\"bar\"},\"nil\":null,\"string\":\"hello world\"}",
 			),
 		},
 
 		{
 			name: "nested slice",
 			args: args{v: []any{"hello world", 1, map[string]any{"foo": "bar"}}},
-			want: types.StringValue("[\"hello world\",1,{\"foo\":\"bar\"}]\n"),
+			want: types.StringValue("[\"hello world\",1,{\"foo\":\"bar\"}]"),
 		},
 
 		{
 			name: "html unsafe characters",
 			args: args{v: map[string]any{"property": "sum", "operator": ">", "value": 2}},
-			want: types.StringValue("{\"operator\":\">\",\"property\":\"sum\",\"value\":2}\n"),
+			want: types.StringValue("{\"operator\":\">\",\"property\":\"sum\",\"value\":2}"),
 		},
 		{
 			name: "html unsafe characters (double escape)",
 			args: args{v: "{\"property\": \"sum\", \"operator\": \">\", \"value\": 2}"},
-			want: types.StringValue("\"{\\\"property\\\": \\\"sum\\\", \\\"operator\\\": \\\">\\\", \\\"value\\\": 2}\"\n"),
+			want: types.StringValue("\"{\\\"property\\\": \\\"sum\\\", \\\"operator\\\": \\\">\\\", \\\"value\\\": 2}\""),
 		},
 	}
 	for _, tt := range tests {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -1,0 +1,72 @@
+package utils
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGoObjectToTerraformString(t *testing.T) {
+	type args struct {
+		v interface{}
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    types.String
+		wantErr bool
+	}{
+		{name: "nil map", args: args{v: (map[any]any)(nil)}, want: types.StringNull()},
+		{name: "nil *map", args: args{v: (*map[any]any)(nil)}, want: types.StringNull()},
+		{name: "nil array", args: args{v: (*[0]any)(nil)}, want: types.StringNull()},
+		{name: "nil chan", args: args{v: (chan any)(nil)}, want: types.StringNull()},
+		{name: "nil *chan", args: args{v: (*chan any)(nil)}, want: types.StringNull()},
+		{name: "nil slice", args: args{v: ([]any)(nil)}, want: types.StringNull()},
+		{name: "nil *slice", args: args{v: (*[]any)(nil)}, want: types.StringNull()},
+		{name: "nil *string", args: args{v: (*string)(nil)}, want: types.StringNull()},
+
+		{
+			name: "nested map",
+			args: args{v: map[string]any{
+				"string": "hello world",
+				"int":    42,
+				"bool":   true,
+				"float":  42.42,
+				"list":   []any{1, 2, 3},
+				"nil":    nil,
+				"nested": map[string]any{"foo": "bar"},
+			}},
+			want: types.StringValue(
+				"{\"bool\":true,\"float\":42.42,\"int\":42,\"list\":[1,2,3],\"nested\":{\"foo\":\"bar\"},\"nil\":null,\"string\":\"hello world\"}\n",
+			),
+		},
+
+		{
+			name: "nested slice",
+			args: args{v: []any{"hello world", 1, map[string]any{"foo": "bar"}}},
+			want: types.StringValue("[\"hello world\",1,{\"foo\":\"bar\"}]\n"),
+		},
+
+		{
+			name: "html unsafe characters",
+			args: args{v: map[string]any{"property": "sum", "operator": ">", "value": 2}},
+			want: types.StringValue("{\"operator\":\">\",\"property\":\"sum\",\"value\":2}\n"),
+		},
+		{
+			name: "html unsafe characters (double escape)",
+			args: args{v: "{\"property\": \"sum\", \"operator\": \">\", \"value\": 2}"},
+			want: types.StringValue("\"{\\\"property\\\": \\\"sum\\\", \\\"operator\\\": \\\">\\\", \\\"value\\\": 2}\"\n"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GoObjectToTerraformString(tt.args.v)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/port/action/array.go
+++ b/port/action/array.go
@@ -208,7 +208,7 @@ func arrayPropResourceToBody(ctx context.Context, d *SelfServiceTriggerModel, pr
 	return nil
 }
 
-func addArrayPropertiesToResource(v *cli.ActionProperty) (*ArrayPropModel, error) {
+func (r *ActionResource) addArrayPropertiesToResource(v *cli.ActionProperty) (*ArrayPropModel, error) {
 	arrayProp := &ArrayPropModel{
 		MinItems: flex.GoInt64ToFramework(v.MinItems),
 		MaxItems: flex.GoInt64ToFramework(v.MaxItems),
@@ -254,7 +254,7 @@ func addArrayPropertiesToResource(v *cli.ActionProperty) (*ArrayPropModel, error
 					arrayProp.StringItems.Blueprint = types.StringValue(v.Items["blueprint"].(string))
 				}
 				if value, ok := v.Items["dataset"]; ok && value != nil {
-					ds, err := utils.GoObjectToTerraformString(v.Items["dataset"])
+					ds, err := utils.GoObjectToTerraformString(v.Items["dataset"], r.portClient.JSONEscapeHTML)
 					if err != nil {
 						return nil, err
 					}

--- a/port/action/resource.go
+++ b/port/action/resource.go
@@ -62,7 +62,7 @@ func (r *ActionResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	err = refreshActionState(ctx, state, a)
+	err = r.refreshActionState(ctx, state, a)
 	if err != nil {
 		resp.Diagnostics.AddError("failed writing action fields to resource", err.Error())
 		return

--- a/port/aggregation-properties/refreshAggregationPropertyToState.go
+++ b/port/aggregation-properties/refreshAggregationPropertyToState.go
@@ -6,7 +6,7 @@ import (
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/utils"
 )
 
-func refreshAggregationPropertiesState(state *AggregationPropertiesModel, aggregationProperties map[string]cli.BlueprintAggregationProperty) error {
+func (r *AggregationPropertiesResource) refreshAggregationPropertiesState(state *AggregationPropertiesModel, aggregationProperties map[string]cli.BlueprintAggregationProperty) error {
 	state.ID = state.BlueprintIdentifier
 
 	state.Properties = map[string]*AggregationPropertyModel{}
@@ -22,7 +22,7 @@ func refreshAggregationPropertiesState(state *AggregationPropertiesModel, aggreg
 			Query:                     types.StringPointerValue(nil),
 		}
 
-		query, err := utils.GoObjectToTerraformString(aggregationProperty.Query)
+		query, err := utils.GoObjectToTerraformString(aggregationProperty.Query, r.portClient.JSONEscapeHTML)
 		if err != nil {
 			return err
 		}

--- a/port/aggregation-properties/resource.go
+++ b/port/aggregation-properties/resource.go
@@ -60,7 +60,7 @@ func (r *AggregationPropertiesResource) Read(ctx context.Context, req resource.R
 		return
 	}
 
-	err = refreshAggregationPropertiesState(state, b.AggregationProperties)
+	err = r.refreshAggregationPropertiesState(state, b.AggregationProperties)
 	if err != nil {
 		resp.Diagnostics.AddError("failed writing aggregation property fields to resource", err.Error())
 		return

--- a/port/integration/refreshIntegrationToState.go
+++ b/port/integration/refreshIntegrationToState.go
@@ -7,7 +7,7 @@ import (
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/utils"
 )
 
-func refreshIntegrationState(state *IntegrationModel, a *cli.Integration, integrationId string) error {
+func (r *IntegrationResource) refreshIntegrationState(state *IntegrationModel, a *cli.Integration, integrationId string) error {
 	state.ID = types.StringValue(integrationId)
 	state.InstallationId = types.StringValue(integrationId)
 
@@ -16,7 +16,7 @@ func refreshIntegrationState(state *IntegrationModel, a *cli.Integration, integr
 	state.Version = types.StringPointerValue(a.Version)
 
 	if a.Config != nil {
-		config, _ := utils.GoObjectToTerraformString(a.Config)
+		config, _ := utils.GoObjectToTerraformString(a.Config, r.portClient.JSONEscapeHTML)
 		state.Config = config
 	}
 	if a.ChangelogDestination != nil {

--- a/port/integration/resource.go
+++ b/port/integration/resource.go
@@ -58,7 +58,7 @@ func (r *IntegrationResource) Read(ctx context.Context, req resource.ReadRequest
 		return
 	}
 
-	err = refreshIntegrationState(state, a, integrationIdentifier)
+	err = r.refreshIntegrationState(state, a, integrationIdentifier)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to refresh integration state", err.Error())
 		return
@@ -92,7 +92,7 @@ func (r *IntegrationResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
-	err = refreshIntegrationState(state, updated, integrationIdentifier)
+	err = r.refreshIntegrationState(state, updated, integrationIdentifier)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to refresh integration state", err.Error())
 		return
@@ -143,7 +143,7 @@ func (r *IntegrationResource) Create(ctx context.Context, req resource.CreateReq
 		return
 	}
 
-	err = refreshIntegrationState(state, created, created.InstallationId)
+	err = r.refreshIntegrationState(state, created, created.InstallationId)
 
 	if err != nil {
 		resp.Diagnostics.AddError("failed to create integration", err.Error())

--- a/port/scorecard/refreshScorecardState.go
+++ b/port/scorecard/refreshScorecardState.go
@@ -66,7 +66,7 @@ func DefaultCliLevels() []cli.Level {
 	}
 }
 
-func refreshScorecardState(ctx context.Context, state *ScorecardModel, s *cli.Scorecard, blueprintIdentifier string) {
+func (r *ScorecardResource) refreshScorecardState(ctx context.Context, state *ScorecardModel, s *cli.Scorecard, blueprintIdentifier string) {
 	state.ID = types.StringValue(fmt.Sprintf("%s:%s", blueprintIdentifier, s.Identifier))
 	state.Identifier = types.StringValue(s.Identifier)
 	state.Blueprint = types.StringValue(blueprintIdentifier)
@@ -82,7 +82,7 @@ func refreshScorecardState(ctx context.Context, state *ScorecardModel, s *cli.Sc
 		}
 		stateFilter.Conditions = make([]types.String, len(s.Filter.Conditions))
 		for i, u := range s.Filter.Conditions {
-			cond, _ := utils.GoObjectToTerraformString(u)
+			cond, _ := utils.GoObjectToTerraformString(u, r.portClient.JSONEscapeHTML)
 			stateFilter.Conditions[i] = cond
 		}
 		state.Filter = stateFilter
@@ -108,7 +108,7 @@ func refreshScorecardState(ctx context.Context, state *ScorecardModel, s *cli.Sc
 
 		stateQuery.Conditions = make([]types.String, len(rule.Query.Conditions))
 		for i, u := range rule.Query.Conditions {
-			cond, _ := utils.GoObjectToTerraformString(u)
+			cond, _ := utils.GoObjectToTerraformString(u, r.portClient.JSONEscapeHTML)
 			stateQuery.Conditions[i] = cond
 		}
 

--- a/port/scorecard/resource.go
+++ b/port/scorecard/resource.go
@@ -53,7 +53,7 @@ func (r *ScorecardResource) Read(ctx context.Context, req resource.ReadRequest, 
 		resp.Diagnostics.AddError("failed to read scorecard", err.Error())
 		return
 	}
-	refreshScorecardState(ctx, state, s, blueprintIdentifier)
+	r.refreshScorecardState(ctx, state, s, blueprintIdentifier)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -78,7 +78,7 @@ func (r *ScorecardResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	refreshScorecardState(ctx, state, sp, state.Blueprint.ValueString())
+	r.refreshScorecardState(ctx, state, sp, state.Blueprint.ValueString())
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
@@ -112,8 +112,8 @@ func (r *ScorecardResource) Update(ctx context.Context, req resource.UpdateReque
 		resp.Diagnostics.AddError("failed to update the scorecard", err.Error())
 		return
 	}
-	
-	refreshScorecardState(ctx, state, sp, state.Blueprint.ValueString())
+
+	r.refreshScorecardState(ctx, state, sp, state.Blueprint.ValueString())
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }

--- a/port/scorecard/resource_test.go
+++ b/port/scorecard/resource_test.go
@@ -151,6 +151,50 @@ func TestAccPortScorecard(t *testing.T) {
 		  port_blueprint.microservice
 		]
 	  }`, scorecardIdentifier, blueprintIdentifier)
+	var testAccActionConfigCreateNoEscapeHTML = testAccCreateBlueprintConfig(blueprintIdentifier) + fmt.Sprintf(`
+	resource "port_scorecard" "test" {
+		identifier = "%s"
+		title      = "Scorecard 1"
+		blueprint  = "%s"
+		rules = [
+			{
+				identifier = "test1"
+				title      = "Test1"
+				level      = "Gold"
+				query = {
+					combinator = "and"
+					conditions = [
+						"{\"operator\":\"isNotEmpty\",\"property\":\"$team\"}",
+						"{\"operator\":\"=\",\"property\":\"author\",\"value\":\"myValue\"}"
+					]
+				}
+			},
+			{
+				identifier = "test2"
+				title      = "Test2"
+				level      = "Silver"
+				query = {
+				  combinator = "and"
+				  conditions = ["{\"operator\":\"isNotEmpty\",\"property\":\"url\"}"]
+				}
+			},
+			{
+				identifier = "test3"
+				title      = "Test3"
+				level      = "Bronze"
+				query = {
+					combinator = "or"
+					conditions = [
+						"{\"operator\":\"=\",\"property\":\"required\",\"value\":true}",
+						"{\"operator\":\">\",\"property\":\"sum\",\"value\":2}"
+					]
+				}
+			}
+		]
+		depends_on = [
+		  port_blueprint.microservice
+		]
+	  }`, scorecardIdentifier, blueprintIdentifier)
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
@@ -178,6 +222,37 @@ func TestAccPortScorecard(t *testing.T) {
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.#", "2"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.0", "{\"operator\":\"=\",\"property\":\"required\",\"value\":true}"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.1", "{\"operator\":\"\\u003e\",\"property\":\"sum\",\"value\":2}"),
+				),
+			},
+		},
+	})
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfigNoEscapeHTML + testAccActionConfigCreateNoEscapeHTML,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_scorecard.test", "title", "Scorecard 1"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "blueprint", blueprintIdentifier),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.#", "3"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.0.identifier", "test1"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.0.title", "Test1"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.0.level", "Gold"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.0.query.combinator", "and"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.0.query.conditions.#", "2"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.0.query.conditions.0", "{\"operator\":\"isNotEmpty\",\"property\":\"$team\"}"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.0.query.conditions.1", "{\"operator\":\"=\",\"property\":\"author\",\"value\":\"myValue\"}"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.1.identifier", "test2"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.1.title", "Test2"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.1.level", "Silver"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.1.query.combinator", "and"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.1.query.conditions.#", "1"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.1.query.conditions.0", "{\"operator\":\"isNotEmpty\",\"property\":\"url\"}"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.combinator", "or"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.#", "2"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.0", "{\"operator\":\"=\",\"property\":\"required\",\"value\":true}"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.1", "{\"operator\":\">\",\"property\":\"sum\",\"value\":2}"),
 				),
 			},
 		},

--- a/port/scorecard/resource_test.go
+++ b/port/scorecard/resource_test.go
@@ -177,7 +177,7 @@ func TestAccPortScorecard(t *testing.T) {
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.combinator", "or"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.#", "2"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.0", "{\"operator\":\"=\",\"property\":\"required\",\"value\":true}"),
-					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.1", "{\"operator\":\">\",\"property\":\"sum\",\"value\":2}"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.1", "{\"operator\":\"\\u003e\",\"property\":\"sum\",\"value\":2}"),
 				),
 			},
 		},
@@ -290,7 +290,7 @@ func TestAccPortScorecardUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("port_scorecard.test", "filter.combinator", "or"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "filter.conditions.#", "2"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "filter.conditions.0", "{\"operator\":\"=\",\"property\":\"required\",\"value\":true}"),
-					resource.TestCheckResourceAttr("port_scorecard.test", "filter.conditions.1", "{\"operator\":\">\",\"property\":\"sum\",\"value\":10}"), // u003e is how > is returned
+					resource.TestCheckResourceAttr("port_scorecard.test", "filter.conditions.1", "{\"operator\":\"\\u003e\",\"property\":\"sum\",\"value\":10}"), // u003e is how > is returned
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.#", "1"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.0.identifier", "hasTeam"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.0.title", "Has Team"),

--- a/port/scorecard/resource_test.go
+++ b/port/scorecard/resource_test.go
@@ -177,7 +177,7 @@ func TestAccPortScorecard(t *testing.T) {
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.combinator", "or"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.#", "2"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.0", "{\"operator\":\"=\",\"property\":\"required\",\"value\":true}"),
-					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.1", "{\"operator\":\"\\u003e\",\"property\":\"sum\",\"value\":2}"),
+					resource.TestCheckResourceAttr("port_scorecard.test", "rules.2.query.conditions.1", "{\"operator\":\">\",\"property\":\"sum\",\"value\":2}"),
 				),
 			},
 		},
@@ -290,7 +290,7 @@ func TestAccPortScorecardUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("port_scorecard.test", "filter.combinator", "or"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "filter.conditions.#", "2"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "filter.conditions.0", "{\"operator\":\"=\",\"property\":\"required\",\"value\":true}"),
-					resource.TestCheckResourceAttr("port_scorecard.test", "filter.conditions.1", "{\"operator\":\"\\u003e\",\"property\":\"sum\",\"value\":10}"), // u003e is how > is returned
+					resource.TestCheckResourceAttr("port_scorecard.test", "filter.conditions.1", "{\"operator\":\">\",\"property\":\"sum\",\"value\":10}"), // u003e is how > is returned
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.#", "1"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.0.identifier", "hasTeam"),
 					resource.TestCheckResourceAttr("port_scorecard.test", "rules.0.title", "Has Team"),

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -2,8 +2,6 @@ package provider
 
 import (
 	"context"
-	"os"
-
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
@@ -26,6 +24,7 @@ import (
 	"github.com/port-labs/terraform-provider-port-labs/v2/port/team"
 	"github.com/port-labs/terraform-provider-port-labs/v2/port/webhook"
 	"github.com/port-labs/terraform-provider-port-labs/v2/version"
+	"os"
 )
 
 var (
@@ -63,6 +62,10 @@ func (p *PortLabsProvider) Schema(ctx context.Context, req provider.SchemaReques
 			"base_url": schema.StringAttribute{
 				Optional: true,
 			},
+			"json_escape_html": schema.BoolAttribute{
+				Optional:            true,
+				MarkdownDescription: "When set to `false` disables the default HTML escaping of json.Marshal when reading data from Port. Defaults to `true`",
+			},
 		},
 	}
 }
@@ -92,6 +95,12 @@ func (p *PortLabsProvider) Configure(ctx context.Context, req provider.Configure
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to create Port-labs client", err.Error())
 		return
+	}
+
+	if data.JSONEscapeHTML.IsNull() {
+		c.JSONEscapeHTML = true
+	} else {
+		c.JSONEscapeHTML = data.JSONEscapeHTML.ValueBool()
 	}
 
 	if data.Token.ValueString() != "" {


### PR DESCRIPTION
# Description

What - Allow to disable the auto JSON HTML escaping
Why - To support clients that don't use Terraform directly and are hurt by the forced encoding issue.
How - Used the `json.Encoder` structure and passed a global json_escape_html in the provider block.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)