### PR TITLE
Replace all json.Marshal calls with utils.GoObjectToTerraformString

### DIFF
--- a/port/action-permissions/refreshActionPermissionsToState.go
+++ b/port/action-permissions/refreshActionPermissionsToState.go
@@ -1,13 +1,13 @@
 package action_permissions
 
 import (
-	"encoding/json"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/flex"
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/utils"
 )
 
-func refreshActionPermissionsState(state *ActionPermissionsModel, a *cli.ActionPermissions, actionId string) error {
+func (r *ActionPermissionsResource) refreshActionPermissionsState(state *ActionPermissionsModel, a *cli.ActionPermissions, actionId string) error {
 	state.ID = types.StringValue(actionId)
 	state.ActionIdentifier = types.StringValue(actionId)
 	state.BlueprintIdentifier = types.StringNull()
@@ -33,12 +33,12 @@ func refreshActionPermissionsState(state *ActionPermissionsModel, a *cli.ActionP
 	state.Permissions.Execute.OwnedByTeam = flex.GoBoolToFramework(a.Execute.OwnedByTeam)
 
 	if a.Execute.Policy != nil {
-		policy, err := json.Marshal(a.Execute.Policy)
+		policy, err := utils.GoObjectToTerraformString(a.Execute.Policy, r.portClient.JSONEscapeHTML)
 		if err != nil {
 			return err
 		}
 
-		state.Permissions.Execute.Policy = types.StringValue(string(policy))
+		state.Permissions.Execute.Policy = policy
 	}
 
 	state.Permissions.Approve = &ApproveModel{}
@@ -59,12 +59,12 @@ func refreshActionPermissionsState(state *ActionPermissionsModel, a *cli.ActionP
 	}
 
 	if a.Approve.Policy != nil {
-		policy, err := json.Marshal(a.Approve.Policy)
+		policy, err := utils.GoObjectToTerraformString(a.Approve.Policy, r.portClient.JSONEscapeHTML)
 		if err != nil {
 			return err
 		}
 
-		state.Permissions.Approve.Policy = types.StringValue(string(policy))
+		state.Permissions.Approve.Policy = policy
 	}
 
 	return nil

--- a/port/action-permissions/resource.go
+++ b/port/action-permissions/resource.go
@@ -62,7 +62,7 @@ func (r *ActionPermissionsResource) Read(ctx context.Context, req resource.ReadR
 		return
 	}
 
-	err = refreshActionPermissionsState(state, a, actionIdentifier)
+	err = r.refreshActionPermissionsState(state, a, actionIdentifier)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to refresh action permissions state", err.Error())
 		return

--- a/port/action/array.go
+++ b/port/action/array.go
@@ -2,7 +2,6 @@ package action
 
 import (
 	"context"
-	"encoding/json"
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -331,12 +330,11 @@ func (r *ActionResource) addArrayPropertiesToResource(v *cli.ActionProperty) (*A
 					objectArray := make([]map[string]interface{}, len(v.Default.([]interface{})))
 					attrs := make([]attr.Value, 0, len(objectArray))
 					for _, value := range v.Default.([]interface{}) {
-						stringfiyValue, err := json.Marshal(value)
+						stringValue, err := utils.GoObjectToTerraformString(value, r.portClient.JSONEscapeHTML)
 						if err != nil {
 							return nil, err
 						}
-						stringValue := string(stringfiyValue)
-						attrs = append(attrs, basetypes.NewStringValue(stringValue))
+						attrs = append(attrs, stringValue)
 					}
 					arrayProp.ObjectItems.Default, _ = types.ListValue(types.StringType, attrs)
 				}

--- a/port/action/refreshActionState.go
+++ b/port/action/refreshActionState.go
@@ -2,7 +2,6 @@ package action
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"strconv"
@@ -362,11 +361,11 @@ func (r *ActionResource) writeTriggerToResource(ctx context.Context, a *cli.Acti
 		}
 
 		if a.Trigger.Condition != nil {
-			triggerCondition, err := json.Marshal(a.Trigger.Condition)
+			triggerCondition, err := utils.GoObjectToTerraformString(a.Trigger.Condition, r.portClient.JSONEscapeHTML)
 			if err != nil {
 				return err
 			}
-			state.SelfServiceTrigger.Condition = types.StringValue(string(triggerCondition))
+			state.SelfServiceTrigger.Condition = triggerCondition
 		}
 	}
 

--- a/port/blueprint/array.go
+++ b/port/blueprint/array.go
@@ -2,8 +2,6 @@ package blueprint
 
 import (
 	"context"
-	"encoding/json"
-
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -114,7 +112,7 @@ func arrayPropResourceToBody(ctx context.Context, state *PropertiesModel, props 
 	return nil
 }
 
-func AddArrayPropertiesToState(v *cli.BlueprintProperty) *ArrayPropModel {
+func AddArrayPropertiesToState(v *cli.BlueprintProperty, jsonEscapeHTML bool) *ArrayPropModel {
 	arrayProp := &ArrayPropModel{
 		MinItems: flex.GoInt64ToFramework(v.MinItems),
 		MaxItems: flex.GoInt64ToFramework(v.MaxItems),
@@ -179,9 +177,8 @@ func AddArrayPropertiesToState(v *cli.BlueprintProperty) *ArrayPropModel {
 					}
 					attrs := make([]attr.Value, 0, len(objectArray))
 					for _, value := range objectArray {
-						js, _ := json.Marshal(&value)
-						stringValue := string(js)
-						attrs = append(attrs, basetypes.NewStringValue(stringValue))
+						stringValue, _ := utils.GoObjectToTerraformString(&value, jsonEscapeHTML)
+						attrs = append(attrs, stringValue)
 					}
 					arrayProp.ObjectItems.Default, _ = types.ListValue(types.StringType, attrs)
 				} else {

--- a/port/blueprint/resource.go
+++ b/port/blueprint/resource.go
@@ -57,7 +57,7 @@ func (r *BlueprintResource) Read(ctx context.Context, req resource.ReadRequest, 
 		return
 	}
 
-	err = refreshBlueprintState(ctx, state, b)
+	err = r.refreshBlueprintState(ctx, state, b)
 	if err != nil {
 		resp.Diagnostics.AddError("failed writing blueprint fields to resource", err.Error())
 		return
@@ -65,7 +65,7 @@ func (r *BlueprintResource) Read(ctx context.Context, req resource.ReadRequest, 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 }
 
-func refreshBlueprintState(ctx context.Context, bm *BlueprintModel, b *cli.Blueprint) error {
+func (r *BlueprintResource) refreshBlueprintState(ctx context.Context, bm *BlueprintModel, b *cli.Blueprint) error {
 	bm.Identifier = types.StringValue(b.Identifier)
 	bm.ID = types.StringValue(b.Identifier)
 	bm.CreatedAt = types.StringValue(b.CreatedAt.String())
@@ -120,7 +120,7 @@ func refreshBlueprintState(ctx context.Context, bm *BlueprintModel, b *cli.Bluep
 	}
 
 	if len(b.Schema.Properties) > 0 {
-		err := updatePropertiesToState(ctx, b, bm)
+		err := r.updatePropertiesToState(ctx, b, bm)
 		if err != nil {
 			return err
 		}

--- a/port/entity/resource.go
+++ b/port/entity/resource.go
@@ -60,7 +60,7 @@ func (r *EntityResource) Read(ctx context.Context, req resource.ReadRequest, res
 		return
 	}
 
-	err = refreshEntityState(ctx, state, e, b)
+	err = r.refreshEntityState(ctx, state, e, b)
 	if err != nil {
 		resp.Diagnostics.AddError("failed writing entity fields to resource", err.Error())
 		return

--- a/port/page/refreshPageToState.go
+++ b/port/page/refreshPageToState.go
@@ -1,12 +1,12 @@
 package page
 
 import (
-	"encoding/json"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/utils"
 )
 
-func refreshPageToState(pm *PageModel, b *cli.Page) error {
+func (r *PageResource) refreshPageToState(pm *PageModel, b *cli.Page) error {
 	pm.ID = types.StringValue(b.Identifier)
 	pm.Identifier = types.StringValue(b.Identifier)
 	pm.Type = types.StringValue(b.Type)
@@ -22,11 +22,11 @@ func refreshPageToState(pm *PageModel, b *cli.Page) error {
 	if b.Widgets != nil {
 		// go over each widget and convert it to a string and store it in the widgets array
 		for i, widget := range *b.Widgets {
-			bWidget, err := json.Marshal(widget)
+			bWidget, err := utils.GoObjectToTerraformString(widget, r.portClient.JSONEscapeHTML)
 			if err != nil {
 				return err
 			}
-			pm.Widgets[i] = types.StringValue(string(bWidget))
+			pm.Widgets[i] = bWidget
 		}
 	}
 	return nil

--- a/port/page/resource.go
+++ b/port/page/resource.go
@@ -62,7 +62,7 @@ func (r *PageResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
-	err = refreshPageToState(state, p)
+	err = r.refreshPageToState(state, p)
 
 	if err != nil {
 		resp.Diagnostics.AddError("failed to write page fields to resource", err.Error())

--- a/port/search/dataSource.go
+++ b/port/search/dataSource.go
@@ -60,7 +60,7 @@ func (d *SearchDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 
 	for _, entity := range searchResult.Entities {
 		matchingEntityBlueprint := blueprints[entity.Blueprint]
-		e := refreshEntityState(ctx, &entity, &matchingEntityBlueprint)
+		e := d.refreshEntityState(ctx, &entity, &matchingEntityBlueprint)
 		data.Entities = append(data.Entities, *e)
 	}
 

--- a/port/system_blueprint/resource.go
+++ b/port/system_blueprint/resource.go
@@ -14,26 +14,26 @@ func writeBlueprintComputedFieldsToState(b *cli.Blueprint, state *SystemBlueprin
 	state.Identifier = types.StringValue(b.Identifier)
 }
 
-func refreshBlueprintState(ctx context.Context, bm *SystemBlueprintModel, b *cli.Blueprint, systemBp *cli.Blueprint) error {
+func (r *Resource) refreshBlueprintState(ctx context.Context, bm *SystemBlueprintModel, b *cli.Blueprint, systemBp *cli.Blueprint) error {
 	bm.Identifier = types.StringValue(b.Identifier)
 	bm.ID = types.StringValue(b.Identifier)
 
-	if len(b.Schema.Properties) - len(systemBp.Schema.Properties) > 0 {
-		err := updatePropertiesToState(ctx, b, systemBp, bm)
+	if len(b.Schema.Properties)-len(systemBp.Schema.Properties) > 0 {
+		err := r.updatePropertiesToState(ctx, b, systemBp, bm)
 		if err != nil {
 			return err
 		}
 	}
 
-	if len(b.Relations) - len(systemBp.Relations) > 0 {
+	if len(b.Relations)-len(systemBp.Relations) > 0 {
 		addRelationsToState(b, systemBp, bm)
 	}
 
-	if len(b.MirrorProperties) - len(systemBp.MirrorProperties) > 0 {
+	if len(b.MirrorProperties)-len(systemBp.MirrorProperties) > 0 {
 		addMirrorPropertiesToState(b, systemBp, bm)
 	}
 
-	if len(b.CalculationProperties) - len(systemBp.CalculationProperties) > 0 {
+	if len(b.CalculationProperties)-len(systemBp.CalculationProperties) > 0 {
 		addCalculationPropertiesToState(ctx, b, systemBp, bm)
 	}
 
@@ -70,7 +70,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 
-	err = refreshBlueprintState(ctx, state, b, systemBp)
+	err = r.refreshBlueprintState(ctx, state, b, systemBp)
 	if err != nil {
 		resp.Diagnostics.AddError("failed writing blueprint fields to resource", err.Error())
 		return
@@ -106,7 +106,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		return
 	}
 
-	err = refreshBlueprintState(ctx, state, b, systemBp)
+	err = r.refreshBlueprintState(ctx, state, b, systemBp)
 	if err != nil {
 		resp.Diagnostics.AddError("failed writing blueprint fields to resource", err.Error())
 		return
@@ -166,18 +166,18 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		ChangelogDestination: existingBp.ChangelogDestination,
 		Schema: cli.BlueprintSchema{
 			Properties: props,
-			Required:  systemBp.Schema.Required,
+			Required:   systemBp.Schema.Required,
 		},
 		Relations:             relations,
-		MirrorProperties:     mirrorProps,
+		MirrorProperties:      mirrorProps,
 		CalculationProperties: calcProps,
 		AggregationProperties: existingBp.AggregationProperties,
 	}
-	
+
 	if existingBp.Ownership != nil {
 		b.Ownership = &cli.Ownership{
-			Type: existingBp.Ownership.Type,
-			Path: existingBp.Ownership.Path,
+			Type:  existingBp.Ownership.Type,
+			Path:  existingBp.Ownership.Path,
 			Title: existingBp.Ownership.Title,
 		}
 	}
@@ -204,4 +204,4 @@ func (r *Resource) ImportState(ctx context.Context, req resource.ImportStateRequ
 
 func (r *Resource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_system_blueprint"
-} 
+}

--- a/port/system_blueprint/updatePropertiesToState.go
+++ b/port/system_blueprint/updatePropertiesToState.go
@@ -10,7 +10,7 @@ import (
 	"github.com/samber/lo"
 )
 
-func updatePropertiesToState(ctx context.Context, b *cli.Blueprint, systemBp *cli.Blueprint, bm *SystemBlueprintModel) error {
+func (r *Resource) updatePropertiesToState(ctx context.Context, b *cli.Blueprint, systemBp *cli.Blueprint, bm *SystemBlueprintModel) error {
 	properties := &blueprint.PropertiesModel{}
 
 	for k, v := range b.Schema.Properties {
@@ -34,7 +34,7 @@ func updatePropertiesToState(ctx context.Context, b *cli.Blueprint, systemBp *cl
 				stringProp.Required = types.BoolValue(false)
 			}
 
-			blueprint.SetCommonProperties(v, stringProp)
+			blueprint.SetCommonProperties(v, stringProp, r.client.JSONEscapeHTML)
 
 			properties.StringProps[k] = *stringProp
 
@@ -51,7 +51,7 @@ func updatePropertiesToState(ctx context.Context, b *cli.Blueprint, systemBp *cl
 				numberProp.Required = types.BoolValue(false)
 			}
 
-			blueprint.SetCommonProperties(v, numberProp)
+			blueprint.SetCommonProperties(v, numberProp, r.client.JSONEscapeHTML)
 
 			properties.NumberProps[k] = *numberProp
 
@@ -60,7 +60,7 @@ func updatePropertiesToState(ctx context.Context, b *cli.Blueprint, systemBp *cl
 				properties.ArrayProps = make(map[string]blueprint.ArrayPropModel)
 			}
 
-			arrayProp := blueprint.AddArrayPropertiesToState(&v)
+			arrayProp := blueprint.AddArrayPropertiesToState(&v, r.client.JSONEscapeHTML)
 
 			if lo.Contains(b.Schema.Required, k) {
 				arrayProp.Required = types.BoolValue(true)
@@ -68,7 +68,7 @@ func updatePropertiesToState(ctx context.Context, b *cli.Blueprint, systemBp *cl
 				arrayProp.Required = types.BoolValue(false)
 			}
 
-			blueprint.SetCommonProperties(v, arrayProp)
+			blueprint.SetCommonProperties(v, arrayProp, r.client.JSONEscapeHTML)
 
 			properties.ArrayProps[k] = *arrayProp
 
@@ -79,7 +79,7 @@ func updatePropertiesToState(ctx context.Context, b *cli.Blueprint, systemBp *cl
 
 			booleanProp := &blueprint.BooleanPropModel{}
 
-			blueprint.SetCommonProperties(v, booleanProp)
+			blueprint.SetCommonProperties(v, booleanProp, r.client.JSONEscapeHTML)
 
 			if lo.Contains(b.Schema.Required, k) {
 				booleanProp.Required = types.BoolValue(true)
@@ -102,7 +102,7 @@ func updatePropertiesToState(ctx context.Context, b *cli.Blueprint, systemBp *cl
 				objectProp.Required = types.BoolValue(false)
 			}
 
-			blueprint.SetCommonProperties(v, objectProp)
+			blueprint.SetCommonProperties(v, objectProp, r.client.JSONEscapeHTML)
 
 			properties.ObjectProps[k] = *objectProp
 		}
@@ -112,7 +112,6 @@ func updatePropertiesToState(ctx context.Context, b *cli.Blueprint, systemBp *cl
 
 	return nil
 }
-
 
 func addRelationsToState(b *cli.Blueprint, systemBp *cli.Blueprint, bm *SystemBlueprintModel) {
 	for k, v := range b.Relations {


### PR DESCRIPTION
# Description

What -Replace all json.Marshal calls with utils.GoObjectToTerraformString
Why - To make sure everything uses the same jsonEscapeHTML flag
How -

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)