### PR TITLE
Sort permission lists as the last state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,11 @@ jobs:
     outputs:
       test_files: ${{steps.compile-tests.outputs.test_files}}
       test_files_include: ${{steps.compile-tests.outputs.test_files_include}}
+      go-version: ${{steps.setup-go.outputs.go-version}}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
+        id: setup-go
         with:
           go-version-file: 'go.mod'
           cache: 'true'
@@ -94,7 +96,7 @@ jobs:
           terraform_wrapper: false
       - uses: actions/setup-go@v5
         with:
-          go-version-file: 'go.mod'
+          go-version: ${{needs.acctest-build.outputs.go-version}}
           cache: 'false'
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
       - main
 
 env:
-  GO_VERSION: "1.22.0"
   FORCE_COLOR: 1
 
 jobs:
@@ -39,13 +38,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
-      - uses: actions/cache@v4
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version-file: 'go.mod'
+          cache: 'true'
       - name: Compile tests
         id: compile-tests
         shell: python
@@ -100,7 +94,7 @@ jobs:
           terraform_wrapper: false
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
           cache: 'false'
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,6 @@ jobs:
         with:
           report_paths: './test-results/*.xml'
           include_passed: 'true'
-          require_tests: 'true'
-          fail_on_failure: 'true'
           comment: 'true'
           check_retries: 'true'
           flaky_summary: 'true'

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
           cache: true
       
       - name: Install tfplugindocs

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Port is the Developer Platform meant to supercharge your DevOps and Developers, 
 
 ## Requirements
 - [Terraform](https://www.terraform.io/downloads.html)
-- [Go](https://golang.org/doc/install) >= 1.22 (to build the provider plugin)
+- [Go](https://golang.org/doc/install) >= 1.24 (to build the provider plugin)
 - [Port Credentials](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#find-your-port-credentials)
 
 ## Installation

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/port-labs/terraform-provider-port-labs/v2
 
-go 1.22
+go 1.24
 
 require (
 	github.com/go-resty/resty/v2 v2.13.1

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/port-labs/terraform-provider-port-labs/v2
 
 go 1.22
 
-toolchain go1.22.0
-
 require (
 	github.com/go-resty/resty/v2 v2.13.1
 	github.com/hashicorp/go-uuid v1.0.3

--- a/internal/utils/slices.go
+++ b/internal/utils/slices.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"cmp"
+	"iter"
+	"maps"
+	"slices"
+	"strings"
+)
+
+// SortSliceByOther sorts `slice` by the positioning of equal items that exist in the `other` slice.
+//
+// You can also provide `fallbackCompare` to be used if both items don't exist in the `other` slice. If only a single
+// item is missing from the `other` slice, it will do a simple compare (a > b / a < b / a == b).
+func SortSliceByOther[Slice ~[]E, E cmp.Ordered](slice, other Slice, fallbackCompare func(a, b E) int) Slice {
+	positionsMap := maps.Collect(AllCrossed(other))
+	return slices.SortedFunc(slices.Values(slice), CompareByMap(positionsMap, fallbackCompare))
+}
+
+func SortStringSliceByOther(slice, other []string) []string {
+	return SortSliceByOther(slice, other, strings.Compare)
+}
+
+func Map[S, R any](items []S, fn func(S) R) []R {
+	result := make([]R, 0, len(items))
+	for _, item := range items {
+		result = append(result, fn(item))
+	}
+	return result
+}
+
+func AllCrossed[Slice ~[]E, E comparable](s Slice) iter.Seq2[E, int] {
+	return func(yield func(E, int) bool) {
+		for i, v := range s {
+			if !yield(v, i) {
+				return
+			}
+		}
+	}
+}
+
+func SimpleCompare[E cmp.Ordered](a, b E) int {
+	switch true {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func CompareByMap[E cmp.Ordered](m map[E]int, fallbackCompare func(a, b E) int) func(a, b E) int {
+	return func(a, b E) int {
+		aPos, okA := m[a]
+		bPos, okB := m[b]
+		if !okA && !okB {
+			if fallbackCompare == nil {
+				return SimpleCompare(a, b)
+			}
+			return fallbackCompare(a, b)
+		}
+		return aPos - bPos
+	}
+}

--- a/port/action-permissions/refreshActionPermissionsToState.go
+++ b/port/action-permissions/refreshActionPermissionsToState.go
@@ -8,6 +8,8 @@ import (
 )
 
 func (r *ActionPermissionsResource) refreshActionPermissionsState(state *ActionPermissionsModel, a *cli.ActionPermissions, actionId string) error {
+	oldPermissions := state.Permissions
+
 	state.ID = types.StringValue(actionId)
 	state.ActionIdentifier = types.StringValue(actionId)
 	state.BlueprintIdentifier = types.StringNull()
@@ -15,20 +17,9 @@ func (r *ActionPermissionsResource) refreshActionPermissionsState(state *ActionP
 
 	state.Permissions.Execute = &ExecuteModel{}
 
-	state.Permissions.Execute.Users = make([]types.String, len(a.Execute.Users))
-	for i, u := range a.Execute.Users {
-		state.Permissions.Execute.Users[i] = types.StringValue(u)
-	}
-
-	state.Permissions.Execute.Roles = make([]types.String, len(a.Execute.Roles))
-	for i, u := range a.Execute.Roles {
-		state.Permissions.Execute.Roles[i] = types.StringValue(u)
-	}
-
-	state.Permissions.Execute.Teams = make([]types.String, len(a.Execute.Teams))
-	for i, u := range a.Execute.Teams {
-		state.Permissions.Execute.Teams[i] = types.StringValue(u)
-	}
+	state.Permissions.Execute.Users = utils.Map(utils.SortStringSliceByOther(a.Execute.Users, utils.TFStringListToStringArray(oldPermissions.Execute.Users)), types.StringValue)
+	state.Permissions.Execute.Roles = utils.Map(utils.SortStringSliceByOther(a.Execute.Roles, utils.TFStringListToStringArray(oldPermissions.Execute.Roles)), types.StringValue)
+	state.Permissions.Execute.Teams = utils.Map(utils.SortStringSliceByOther(a.Execute.Teams, utils.TFStringListToStringArray(oldPermissions.Execute.Teams)), types.StringValue)
 
 	state.Permissions.Execute.OwnedByTeam = flex.GoBoolToFramework(a.Execute.OwnedByTeam)
 
@@ -43,20 +34,9 @@ func (r *ActionPermissionsResource) refreshActionPermissionsState(state *ActionP
 
 	state.Permissions.Approve = &ApproveModel{}
 
-	state.Permissions.Approve.Users = make([]types.String, len(a.Approve.Users))
-	for i, u := range a.Approve.Users {
-		state.Permissions.Approve.Users[i] = types.StringValue(u)
-	}
-
-	state.Permissions.Approve.Roles = make([]types.String, len(a.Approve.Roles))
-	for i, u := range a.Approve.Roles {
-		state.Permissions.Approve.Roles[i] = types.StringValue(u)
-	}
-
-	state.Permissions.Approve.Teams = make([]types.String, len(a.Approve.Teams))
-	for i, u := range a.Approve.Teams {
-		state.Permissions.Approve.Teams[i] = types.StringValue(u)
-	}
+	state.Permissions.Approve.Users = utils.Map(utils.SortStringSliceByOther(a.Approve.Users, utils.TFStringListToStringArray(oldPermissions.Approve.Users)), types.StringValue)
+	state.Permissions.Approve.Roles = utils.Map(utils.SortStringSliceByOther(a.Approve.Roles, utils.TFStringListToStringArray(oldPermissions.Approve.Roles)), types.StringValue)
+	state.Permissions.Approve.Teams = utils.Map(utils.SortStringSliceByOther(a.Approve.Teams, utils.TFStringListToStringArray(oldPermissions.Approve.Teams)), types.StringValue)
 
 	if a.Approve.Policy != nil {
 		policy, err := utils.GoObjectToTerraformString(a.Approve.Policy, r.portClient.JSONEscapeHTML)

--- a/port/action-permissions/refreshActionPermissionsToState.go
+++ b/port/action-permissions/refreshActionPermissionsToState.go
@@ -17,9 +17,15 @@ func (r *ActionPermissionsResource) refreshActionPermissionsState(state *ActionP
 
 	state.Permissions.Execute = &ExecuteModel{}
 
-	state.Permissions.Execute.Users = utils.Map(utils.SortStringSliceByOther(a.Execute.Users, utils.TFStringListToStringArray(oldPermissions.Execute.Users)), types.StringValue)
-	state.Permissions.Execute.Roles = utils.Map(utils.SortStringSliceByOther(a.Execute.Roles, utils.TFStringListToStringArray(oldPermissions.Execute.Roles)), types.StringValue)
-	state.Permissions.Execute.Teams = utils.Map(utils.SortStringSliceByOther(a.Execute.Teams, utils.TFStringListToStringArray(oldPermissions.Execute.Teams)), types.StringValue)
+	if oldPermissions == nil || oldPermissions.Execute == nil {
+		state.Permissions.Execute.Users = utils.Map(a.Execute.Users, types.StringValue)
+		state.Permissions.Execute.Roles = utils.Map(a.Execute.Roles, types.StringValue)
+		state.Permissions.Execute.Teams = utils.Map(a.Execute.Teams, types.StringValue)
+	} else {
+		state.Permissions.Execute.Users = utils.Map(utils.SortStringSliceByOther(a.Execute.Users, utils.TFStringListToStringArray(oldPermissions.Execute.Users)), types.StringValue)
+		state.Permissions.Execute.Roles = utils.Map(utils.SortStringSliceByOther(a.Execute.Roles, utils.TFStringListToStringArray(oldPermissions.Execute.Roles)), types.StringValue)
+		state.Permissions.Execute.Teams = utils.Map(utils.SortStringSliceByOther(a.Execute.Teams, utils.TFStringListToStringArray(oldPermissions.Execute.Teams)), types.StringValue)
+	}
 
 	state.Permissions.Execute.OwnedByTeam = flex.GoBoolToFramework(a.Execute.OwnedByTeam)
 
@@ -34,9 +40,15 @@ func (r *ActionPermissionsResource) refreshActionPermissionsState(state *ActionP
 
 	state.Permissions.Approve = &ApproveModel{}
 
-	state.Permissions.Approve.Users = utils.Map(utils.SortStringSliceByOther(a.Approve.Users, utils.TFStringListToStringArray(oldPermissions.Approve.Users)), types.StringValue)
-	state.Permissions.Approve.Roles = utils.Map(utils.SortStringSliceByOther(a.Approve.Roles, utils.TFStringListToStringArray(oldPermissions.Approve.Roles)), types.StringValue)
-	state.Permissions.Approve.Teams = utils.Map(utils.SortStringSliceByOther(a.Approve.Teams, utils.TFStringListToStringArray(oldPermissions.Approve.Teams)), types.StringValue)
+	if oldPermissions == nil || oldPermissions.Approve == nil {
+		state.Permissions.Approve.Users = utils.Map(a.Execute.Users, types.StringValue)
+		state.Permissions.Approve.Roles = utils.Map(a.Execute.Roles, types.StringValue)
+		state.Permissions.Approve.Teams = utils.Map(a.Execute.Teams, types.StringValue)
+	} else {
+		state.Permissions.Approve.Users = utils.Map(utils.SortStringSliceByOther(a.Approve.Users, utils.TFStringListToStringArray(oldPermissions.Approve.Users)), types.StringValue)
+		state.Permissions.Approve.Roles = utils.Map(utils.SortStringSliceByOther(a.Approve.Roles, utils.TFStringListToStringArray(oldPermissions.Approve.Roles)), types.StringValue)
+		state.Permissions.Approve.Teams = utils.Map(utils.SortStringSliceByOther(a.Approve.Teams, utils.TFStringListToStringArray(oldPermissions.Approve.Teams)), types.StringValue)
+	}
 
 	if a.Approve.Policy != nil {
 		policy, err := utils.GoObjectToTerraformString(a.Approve.Policy, r.portClient.JSONEscapeHTML)

--- a/port/action-permissions/refreshActionPermissionsToState.go
+++ b/port/action-permissions/refreshActionPermissionsToState.go
@@ -41,9 +41,9 @@ func (r *ActionPermissionsResource) refreshActionPermissionsState(state *ActionP
 	state.Permissions.Approve = &ApproveModel{}
 
 	if oldPermissions == nil || oldPermissions.Approve == nil {
-		state.Permissions.Approve.Users = utils.Map(a.Execute.Users, types.StringValue)
-		state.Permissions.Approve.Roles = utils.Map(a.Execute.Roles, types.StringValue)
-		state.Permissions.Approve.Teams = utils.Map(a.Execute.Teams, types.StringValue)
+		state.Permissions.Approve.Users = utils.Map(a.Approve.Users, types.StringValue)
+		state.Permissions.Approve.Roles = utils.Map(a.Approve.Roles, types.StringValue)
+		state.Permissions.Approve.Teams = utils.Map(a.Approve.Teams, types.StringValue)
 	} else {
 		state.Permissions.Approve.Users = utils.Map(utils.SortStringSliceByOther(a.Approve.Users, utils.TFStringListToStringArray(oldPermissions.Approve.Users)), types.StringValue)
 		state.Permissions.Approve.Roles = utils.Map(utils.SortStringSliceByOther(a.Approve.Roles, utils.TFStringListToStringArray(oldPermissions.Approve.Roles)), types.StringValue)

--- a/port/blueprint-permissions/refreshBluePrintPermissionsToState.go
+++ b/port/blueprint-permissions/refreshBluePrintPermissionsToState.go
@@ -1,37 +1,74 @@
 package blueprint_permissions
 
 import (
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/utils"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
 )
 
-func goStringListToTFList(list []string) []types.String {
-	var result = make([]types.String, len(list))
-	for i, u := range list {
-		result[i] = types.StringValue(u)
-	}
-
-	return result
-}
-
-func blueprintPermissionsBlockToBlueprintPermissionsTFBlock(block cli.BlueprintPermissionsBlock) *BlueprintPermissionsTFBlock {
-	return &BlueprintPermissionsTFBlock{
-		Users:       goStringListToTFList(block.Users),
-		Roles:       goStringListToTFList(block.Roles),
-		Teams:       goStringListToTFList(block.Teams),
-		OwnedByTeam: types.BoolValue(*block.OwnedByTeam),
-	}
-}
-
 func refreshBlueprintPermissionsState(state *BlueprintPermissionsModel, a *cli.BlueprintPermissions, blueprintId string) error {
+	oldPermissions := state.Entities
+	if oldPermissions == nil {
+		oldPermissions = &EntitiesBlueprintPermissionsModel{}
+	}
+
 	state.ID = types.StringValue(blueprintId)
 	state.BlueprintIdentifier = types.StringValue(blueprintId)
 	state.Entities = &EntitiesBlueprintPermissionsModel{}
-	state.Entities.Update = blueprintPermissionsBlockToBlueprintPermissionsTFBlock(a.Entities.Update)
-	state.Entities.Unregister = blueprintPermissionsBlockToBlueprintPermissionsTFBlock(a.Entities.Unregister)
-	state.Entities.Register = blueprintPermissionsBlockToBlueprintPermissionsTFBlock(a.Entities.Register)
+
+	if oldPermissions.Update == nil {
+		state.Entities.Update = &BlueprintPermissionsTFBlock{
+			Users:       utils.Map(a.Entities.Update.Users, types.StringValue),
+			Roles:       utils.Map(a.Entities.Update.Roles, types.StringValue),
+			Teams:       utils.Map(a.Entities.Update.Teams, types.StringValue),
+			OwnedByTeam: types.BoolValue(*a.Entities.Update.OwnedByTeam),
+		}
+	} else {
+		state.Entities.Update = &BlueprintPermissionsTFBlock{
+			Users:       utils.Map(utils.SortStringSliceByOther(a.Entities.Update.Users, utils.TFStringListToStringArray(oldPermissions.Update.Users)), types.StringValue),
+			Roles:       utils.Map(utils.SortStringSliceByOther(a.Entities.Update.Roles, utils.TFStringListToStringArray(oldPermissions.Update.Roles)), types.StringValue),
+			Teams:       utils.Map(utils.SortStringSliceByOther(a.Entities.Update.Teams, utils.TFStringListToStringArray(oldPermissions.Update.Teams)), types.StringValue),
+			OwnedByTeam: types.BoolValue(*a.Entities.Update.OwnedByTeam),
+		}
+	}
+
+	if oldPermissions.Unregister == nil {
+		state.Entities.Unregister = &BlueprintPermissionsTFBlock{
+			Users:       utils.Map(a.Entities.Unregister.Users, types.StringValue),
+			Roles:       utils.Map(a.Entities.Unregister.Roles, types.StringValue),
+			Teams:       utils.Map(a.Entities.Unregister.Teams, types.StringValue),
+			OwnedByTeam: types.BoolValue(*a.Entities.Unregister.OwnedByTeam),
+		}
+	} else {
+		state.Entities.Unregister = &BlueprintPermissionsTFBlock{
+			Users:       utils.Map(utils.SortStringSliceByOther(a.Entities.Update.Users, utils.TFStringListToStringArray(oldPermissions.Unregister.Users)), types.StringValue),
+			Roles:       utils.Map(utils.SortStringSliceByOther(a.Entities.Update.Roles, utils.TFStringListToStringArray(oldPermissions.Unregister.Roles)), types.StringValue),
+			Teams:       utils.Map(utils.SortStringSliceByOther(a.Entities.Update.Teams, utils.TFStringListToStringArray(oldPermissions.Unregister.Teams)), types.StringValue),
+			OwnedByTeam: types.BoolValue(*a.Entities.Unregister.OwnedByTeam),
+		}
+	}
+
+	if oldPermissions.Register == nil {
+		state.Entities.Register = &BlueprintPermissionsTFBlock{
+			Users:       utils.Map(a.Entities.Register.Users, types.StringValue),
+			Roles:       utils.Map(a.Entities.Register.Roles, types.StringValue),
+			Teams:       utils.Map(a.Entities.Register.Teams, types.StringValue),
+			OwnedByTeam: types.BoolValue(*a.Entities.Register.OwnedByTeam),
+		}
+	} else {
+		state.Entities.Register = &BlueprintPermissionsTFBlock{
+			Users:       utils.Map(utils.SortStringSliceByOther(a.Entities.Update.Users, utils.TFStringListToStringArray(oldPermissions.Register.Users)), types.StringValue),
+			Roles:       utils.Map(utils.SortStringSliceByOther(a.Entities.Update.Roles, utils.TFStringListToStringArray(oldPermissions.Register.Roles)), types.StringValue),
+			Teams:       utils.Map(utils.SortStringSliceByOther(a.Entities.Update.Teams, utils.TFStringListToStringArray(oldPermissions.Register.Teams)), types.StringValue),
+			OwnedByTeam: types.BoolValue(*a.Entities.Register.OwnedByTeam),
+		}
+	}
+
+	if oldPermissions.UpdateProperties == nil {
+		oldPermissions.UpdateProperties = &BlueprintRelationsPermissionsTFBlock{}
+	}
 
 	state.Entities.UpdateProperties = nil
 	var mappedUpdateProperties BlueprintRelationsPermissionsTFBlock = nil
@@ -39,7 +76,37 @@ func refreshBlueprintPermissionsState(state *BlueprintPermissionsModel, a *cli.B
 		state.Entities.UpdateMetadataProperties = &BlueprintMetadataPermissionsTFBlock{}
 		mappedUpdateProperties = make(BlueprintRelationsPermissionsTFBlock)
 		for updatePropertyKey, updatePropertyValue := range a.Entities.UpdateProperties {
-			var current = blueprintPermissionsBlockToBlueprintPermissionsTFBlock(updatePropertyValue)
+			var oldPropValue *BlueprintPermissionsTFBlock
+			if strings.HasPrefix(updatePropertyKey, "$") {
+				switch updatePropertyKey {
+				case "$title":
+					oldPropValue = oldPermissions.UpdateMetadataProperties.Title
+				case "$identifier":
+					oldPropValue = oldPermissions.UpdateMetadataProperties.Identifier
+				case "$icon":
+					oldPropValue = oldPermissions.UpdateMetadataProperties.Icon
+				case "$team":
+					oldPropValue = oldPermissions.UpdateMetadataProperties.Team
+				}
+			} else if val, ok := (*oldPermissions.UpdateProperties)[updatePropertyKey]; ok {
+				oldPropValue = &val
+			}
+			var current *BlueprintPermissionsTFBlock
+			if oldPropValue == nil {
+				current = &BlueprintPermissionsTFBlock{
+					Users:       utils.Map(updatePropertyValue.Users, types.StringValue),
+					Roles:       utils.Map(updatePropertyValue.Roles, types.StringValue),
+					Teams:       utils.Map(updatePropertyValue.Teams, types.StringValue),
+					OwnedByTeam: types.BoolValue(*updatePropertyValue.OwnedByTeam),
+				}
+			} else {
+				current = &BlueprintPermissionsTFBlock{
+					Users:       utils.Map(utils.SortStringSliceByOther(updatePropertyValue.Users, utils.TFStringListToStringArray(oldPropValue.Users)), types.StringValue),
+					Roles:       utils.Map(utils.SortStringSliceByOther(updatePropertyValue.Roles, utils.TFStringListToStringArray(oldPropValue.Roles)), types.StringValue),
+					Teams:       utils.Map(utils.SortStringSliceByOther(updatePropertyValue.Teams, utils.TFStringListToStringArray(oldPropValue.Teams)), types.StringValue),
+					OwnedByTeam: types.BoolValue(*updatePropertyValue.OwnedByTeam),
+				}
+			}
 
 			if strings.HasPrefix(updatePropertyKey, "$") {
 				switch updatePropertyKey {
@@ -60,10 +127,26 @@ func refreshBlueprintPermissionsState(state *BlueprintPermissionsModel, a *cli.B
 			state.Entities.UpdateProperties = &mappedUpdateProperties
 		}
 	}
+
 	if len(a.Entities.UpdateRelations) > 0 {
 		var mappedUpdateRelations = make(BlueprintRelationsPermissionsTFBlock, len(a.Entities.UpdateRelations))
 		for updateRelationKey, updateRelationValue := range a.Entities.UpdateRelations {
-			mappedUpdateRelations[updateRelationKey] = *blueprintPermissionsBlockToBlueprintPermissionsTFBlock(updateRelationValue)
+			oldRelValue, hasOldRelValue := (*oldPermissions.UpdateRelations)[updateRelationKey]
+			if !hasOldRelValue {
+				mappedUpdateRelations[updateRelationKey] = BlueprintPermissionsTFBlock{
+					Users:       utils.Map(updateRelationValue.Users, types.StringValue),
+					Roles:       utils.Map(updateRelationValue.Roles, types.StringValue),
+					Teams:       utils.Map(updateRelationValue.Teams, types.StringValue),
+					OwnedByTeam: types.BoolValue(*updateRelationValue.OwnedByTeam),
+				}
+			} else {
+				mappedUpdateRelations[updateRelationKey] = BlueprintPermissionsTFBlock{
+					Users:       utils.Map(utils.SortStringSliceByOther(updateRelationValue.Users, utils.TFStringListToStringArray(oldRelValue.Users)), types.StringValue),
+					Roles:       utils.Map(utils.SortStringSliceByOther(updateRelationValue.Roles, utils.TFStringListToStringArray(oldRelValue.Roles)), types.StringValue),
+					Teams:       utils.Map(utils.SortStringSliceByOther(updateRelationValue.Teams, utils.TFStringListToStringArray(oldRelValue.Teams)), types.StringValue),
+					OwnedByTeam: types.BoolValue(*updateRelationValue.OwnedByTeam),
+				}
+			}
 		}
 		state.Entities.UpdateRelations = &mappedUpdateRelations
 	} else {

--- a/port/blueprint-permissions/refreshBluePrintPermissionsToState.go
+++ b/port/blueprint-permissions/refreshBluePrintPermissionsToState.go
@@ -43,9 +43,9 @@ func refreshBlueprintPermissionsState(state *BlueprintPermissionsModel, a *cli.B
 		}
 	} else {
 		state.Entities.Unregister = &BlueprintPermissionsTFBlock{
-			Users:       utils.Map(utils.SortStringSliceByOther(a.Entities.Update.Users, utils.TFStringListToStringArray(oldPermissions.Unregister.Users)), types.StringValue),
-			Roles:       utils.Map(utils.SortStringSliceByOther(a.Entities.Update.Roles, utils.TFStringListToStringArray(oldPermissions.Unregister.Roles)), types.StringValue),
-			Teams:       utils.Map(utils.SortStringSliceByOther(a.Entities.Update.Teams, utils.TFStringListToStringArray(oldPermissions.Unregister.Teams)), types.StringValue),
+			Users:       utils.Map(utils.SortStringSliceByOther(a.Entities.Unregister.Users, utils.TFStringListToStringArray(oldPermissions.Unregister.Users)), types.StringValue),
+			Roles:       utils.Map(utils.SortStringSliceByOther(a.Entities.Unregister.Roles, utils.TFStringListToStringArray(oldPermissions.Unregister.Roles)), types.StringValue),
+			Teams:       utils.Map(utils.SortStringSliceByOther(a.Entities.Unregister.Teams, utils.TFStringListToStringArray(oldPermissions.Unregister.Teams)), types.StringValue),
 			OwnedByTeam: types.BoolValue(*a.Entities.Unregister.OwnedByTeam),
 		}
 	}
@@ -59,9 +59,9 @@ func refreshBlueprintPermissionsState(state *BlueprintPermissionsModel, a *cli.B
 		}
 	} else {
 		state.Entities.Register = &BlueprintPermissionsTFBlock{
-			Users:       utils.Map(utils.SortStringSliceByOther(a.Entities.Update.Users, utils.TFStringListToStringArray(oldPermissions.Register.Users)), types.StringValue),
-			Roles:       utils.Map(utils.SortStringSliceByOther(a.Entities.Update.Roles, utils.TFStringListToStringArray(oldPermissions.Register.Roles)), types.StringValue),
-			Teams:       utils.Map(utils.SortStringSliceByOther(a.Entities.Update.Teams, utils.TFStringListToStringArray(oldPermissions.Register.Teams)), types.StringValue),
+			Users:       utils.Map(utils.SortStringSliceByOther(a.Entities.Register.Users, utils.TFStringListToStringArray(oldPermissions.Register.Users)), types.StringValue),
+			Roles:       utils.Map(utils.SortStringSliceByOther(a.Entities.Register.Roles, utils.TFStringListToStringArray(oldPermissions.Register.Roles)), types.StringValue),
+			Teams:       utils.Map(utils.SortStringSliceByOther(a.Entities.Register.Teams, utils.TFStringListToStringArray(oldPermissions.Register.Teams)), types.StringValue),
 			OwnedByTeam: types.BoolValue(*a.Entities.Register.OwnedByTeam),
 		}
 	}

--- a/port/page-permissions/refreshPagePermissionsToState.go
+++ b/port/page-permissions/refreshPagePermissionsToState.go
@@ -12,9 +12,15 @@ func refreshPagePermissionsState(state *PagePermissionsModel, a *cli.PagePermiss
 	state.PageIdentifier = types.StringValue(pageId)
 	state.Read = &ReadPagePermissionsModel{}
 
-	state.Read.Users = utils.Map(utils.SortStringSliceByOther(a.Read.Users, utils.TFStringListToStringArray(oldPermissions.Users)), types.StringValue)
-	state.Read.Roles = utils.Map(utils.SortStringSliceByOther(a.Read.Roles, utils.TFStringListToStringArray(oldPermissions.Roles)), types.StringValue)
-	state.Read.Teams = utils.Map(utils.SortStringSliceByOther(a.Read.Teams, utils.TFStringListToStringArray(oldPermissions.Teams)), types.StringValue)
+	if oldPermissions == nil {
+		state.Read.Users = utils.Map(a.Read.Users, types.StringValue)
+		state.Read.Roles = utils.Map(a.Read.Roles, types.StringValue)
+		state.Read.Teams = utils.Map(a.Read.Teams, types.StringValue)
+	} else {
+		state.Read.Users = utils.Map(utils.SortStringSliceByOther(a.Read.Users, utils.TFStringListToStringArray(oldPermissions.Users)), types.StringValue)
+		state.Read.Roles = utils.Map(utils.SortStringSliceByOther(a.Read.Roles, utils.TFStringListToStringArray(oldPermissions.Roles)), types.StringValue)
+		state.Read.Teams = utils.Map(utils.SortStringSliceByOther(a.Read.Teams, utils.TFStringListToStringArray(oldPermissions.Teams)), types.StringValue)
+	}
 
 	return nil
 }

--- a/port/page-permissions/refreshPagePermissionsToState.go
+++ b/port/page-permissions/refreshPagePermissionsToState.go
@@ -3,27 +3,18 @@ package page_permissions
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/utils"
 )
 
 func refreshPagePermissionsState(state *PagePermissionsModel, a *cli.PagePermissions, pageId string) error {
+	oldPermissions := state.Read
 	state.ID = types.StringValue(pageId)
 	state.PageIdentifier = types.StringValue(pageId)
 	state.Read = &ReadPagePermissionsModel{}
 
-	state.Read.Users = make([]types.String, len(a.Read.Users))
-	for i, u := range a.Read.Users {
-		state.Read.Users[i] = types.StringValue(u)
-	}
-
-	state.Read.Roles = make([]types.String, len(a.Read.Roles))
-	for i, u := range a.Read.Roles {
-		state.Read.Roles[i] = types.StringValue(u)
-	}
-
-	state.Read.Teams = make([]types.String, len(a.Read.Teams))
-	for i, u := range a.Read.Teams {
-		state.Read.Teams[i] = types.StringValue(u)
-	}
+	state.Read.Users = utils.Map(utils.SortStringSliceByOther(a.Read.Users, utils.TFStringListToStringArray(oldPermissions.Users)), types.StringValue)
+	state.Read.Roles = utils.Map(utils.SortStringSliceByOther(a.Read.Roles, utils.TFStringListToStringArray(oldPermissions.Roles)), types.StringValue)
+	state.Read.Teams = utils.Map(utils.SortStringSliceByOther(a.Read.Teams, utils.TFStringListToStringArray(oldPermissions.Teams)), types.StringValue)
 
 	return nil
 }


### PR DESCRIPTION
# Description

What - When refreshing permission lists, use the ordering of values from the previous state for sorting values from the server
Why - To keep the sort that exists in the state instead of forcing an arbitrary sorting from the server.
How - Transform the old lists to a mapping from their string values to their index in the slice. Then use SortedFunc to sort the values according to their positioning.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)