### PR TITLE
Add scorecard rule identifier length validation

### DIFF
--- a/port/scorecard/schema.go
+++ b/port/scorecard/schema.go
@@ -32,6 +32,9 @@ func RuleSchema() map[string]schema.Attribute {
 		"identifier": schema.StringAttribute{
 			MarkdownDescription: "The identifier of the rule",
 			Required:            true,
+			Validators: []validator.String{
+				stringvalidator.LengthBetween(1, 20),
+			},
 		},
 		"title": schema.StringAttribute{
 			MarkdownDescription: "The title of the rule",


### PR DESCRIPTION
# Description

What - Add scorecard rule identifier length validation

Why - If the rule identifier is longer than 20 chars apply stage will fail
![image](https://github.com/user-attachments/assets/61528b03-ac88-469c-9fa1-280e737f9863)

How - Add LengthBetween string validator on rule identifier which validates the length during validate and plan stages

## Type of change
- Bug fix (non-breaking change which fixes an issue)
