### PR TITLE
Bugfix - Allow isEmpty operator in dataset

### DIFF
--- a/port/action/actionStateToPortBody.go
+++ b/port/action/actionStateToPortBody.go
@@ -18,10 +18,14 @@ func actionDataSetToPortBody(dataSet *DatasetModel) *cli.Dataset {
 	for _, rule := range dataSet.Rules {
 		dataSetRule := cli.DatasetRule{
 			Operator: rule.Operator.ValueString(),
-			Value: &cli.DatasetValue{
-				JqQuery: rule.Value.JqQuery.ValueString(),
-			},
 		}
+
+		if rule.Value != nil {
+			dataSetRule.Value = &cli.DatasetValue{
+				JqQuery: rule.Value.JqQuery.ValueString(),
+			}
+		}
+
 		if !rule.Blueprint.IsNull() {
 			blueprint := rule.Blueprint.ValueString()
 			dataSetRule.Blueprint = &blueprint

--- a/port/action/refreshActionState.go
+++ b/port/action/refreshActionState.go
@@ -153,15 +153,18 @@ func writeDatasetToResource(ds *cli.Dataset) *DatasetModel {
 			Blueprint: flex.GoStringToFramework(v.Blueprint),
 			Property:  flex.GoStringToFramework(v.Property),
 			Operator:  flex.GoStringToFramework(&v.Operator),
-			Value: &Value{
-				JqQuery: flex.GoStringToFramework(&v.Value.JqQuery),
-			},
 		}
+
+		if v.Value != nil {
+			rule.Value = &Value{
+				JqQuery: flex.GoStringToFramework(&v.Value.JqQuery),
+			}
+		}
+
 		datasetModel.Rules = append(datasetModel.Rules, *rule)
 	}
 
 	return datasetModel
-
 }
 
 func writeVisibleToResource(v cli.ActionProperty) (types.Bool, types.String) {


### PR DESCRIPTION
# Description

What - Allow isEmpty / isNotEmpty on dataset
Why - Let users add isEmpty filters on dataset filters
How - Fixing value to allow it be nullable

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)