### PR TITLE
PORT-14153 feat: add blueprint to widget example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 .vscode/
-.env
+.env*
 local/
 __debug_bin*
 terraform-provider-port-labs
 .idea
 **/terraform.tfstat*
 **/.terraform
+pkg

--- a/docs/resources/port_page.md
+++ b/docs/resources/port_page.md
@@ -18,20 +18,16 @@ description: |-
     title                 = "Microservices"
     type                  = "blueprint-entities"
     icon                  = "Microservice"
-    blueprint             = portblueprint.base_blueprint.identifier
+    blueprint             = portblueprint.baseblueprint.identifier
     widgets               = [
       jsonencode(
         {
           "id" : "microservice-table-entities",
           "type" : "table-entities-explorer",
+          "blueprint": portblueprint.base_blueprint.identifier,
           "dataset" : {
             "combinator" : "and",
             "rules" : [
-              {
-                "operator" : "=",
-                "property" : "$blueprint",
-                "value" : {{blueprint}}
-              }
             ]
           }
         }
@@ -241,14 +237,10 @@ resource "port_page" "microservice_blueprint_page" {
       {
         "id" : "microservice-table-entities",
         "type" : "table-entities-explorer",
+        "blueprint": port_blueprint.base_blueprint.identifier,
         "dataset" : {
           "combinator" : "and",
           "rules" : [
-            {
-              "operator" : "=",
-              "property" : "$blueprint",
-              "value" : "{{blueprint}}"
-            }
           ]
         }
       }

--- a/examples/resources/port_page/main.tf
+++ b/examples/resources/port_page/main.tf
@@ -1,3 +1,31 @@
+resource "port_blueprint" "microservice" {
+  identifier  = "microservice"
+  title       = "Microsvc from Port TF Examples"
+  icon        = "Terraform"
+  description = ""
+  properties = {
+    string_props = {
+      url = {
+        type = "string"
+      }
+      author = {
+        icon       = "github"
+        required   = true
+        min_length = 1
+        max_length = 10
+        default    = "default"
+        enum       = ["default", "default2"]
+        pattern    = "^[a-zA-Z0-9]*$"
+        format     = "user"
+        enum_colors = {
+          default  = "red"
+          default2 = "green"
+        }
+      }
+    }
+  }
+}
+
 resource "port_page" "microservice_dashboard_page" {
   identifier = "microservice_dashboard_page"
   title      = "Microservices"
@@ -12,7 +40,7 @@ resource "port_page" "microservice_dashboard_page" {
             "height" = 400,
             "columns" = [
               {
-                "id"   = "microserviceGuide",
+                "id"   = "microservice-table-entities",
                 "size" = 12
               }
             ]
@@ -21,12 +49,14 @@ resource "port_page" "microservice_dashboard_page" {
         "type" = "dashboard-widget",
         "widgets" = [
           {
-            "title"       = "Microservices Guide",
-            "icon"        = "BlankPage",
-            "markdown"    = "# This is the new Microservice Dashboard",
-            "type"        = "markdown",
-            "description" = "",
-            "id"          = "microserviceGuide"
+            "id" : "microservice-table-entities",
+            "type" : "table-entities-explorer",
+            "blueprint" : port_blueprint.microservice.identifier,
+            "dataset" : {
+              "combinator" : "and",
+              "rules" : [
+              ]
+            }
           }
         ],
       }

--- a/port/page/resource_test.go
+++ b/port/page/resource_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/acctest"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/utils"
 )
@@ -49,14 +50,10 @@ resource "port_page" "microservice_blueprint_page" {
       {
         "id" : "blabla",
         "type" : "table-entities-explorer",
+        "blueprint" : port_blueprint.microservice.identifier,
         "dataset" : {
           "combinator" : "and",
           "rules" : [
-            {
-              "operator" : "=",
-              "property" : "$blueprint",
-              "value" : "{{blueprint}}"
-            }
           ]
         }
       }
@@ -104,14 +101,10 @@ resource "port_page" "microservice_blueprint_page" {
       {
         "id" : "blabla",
         "type" : "table-entities-explorer",
+        "blueprint" : port_blueprint.microservice.identifier,
         "dataset" : {
           "combinator" : "and",
           "rules" : [
-            {
-              "operator" : "=",
-              "property" : "$blueprint",
-              "value" : "{{blueprint}}"
-            }
           ]
         }
       }

--- a/port/page/schema.go
+++ b/port/page/schema.go
@@ -143,14 +143,10 @@ resource "port_page" "microservice_blueprint_page" {
       {
         "id" : "microservice-table-entities",
         "type" : "table-entities-explorer",
+        "blueprint": port_blueprint.base_blueprint.identifier,
         "dataset" : {
           "combinator" : "and",
           "rules" : [
-            {
-              "operator" : "=",
-              "property" : "$blueprint",
-              "value" : ` + "{{`\"{{blueprint}}\"`}}" + `
-            }
           ]
         }
       }


### PR DESCRIPTION
# Description

> [!WARNING]
> To be merged on the 22nd of June as part of the migration for filters UI.

What - add the `blueprint` prop to relevant widgets (see https://github.com/port-labs/Port/pull/7374)
Why -
How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [x] Documentation (added/updated documentation)

