### PR TITLE
Fix permissions sorting

### DIFF
--- a/port/action-permissions/schema.go
+++ b/port/action-permissions/schema.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -35,25 +35,25 @@ func ActionPermissionsSchema() map[string]schema.Attribute {
 					MarkdownDescription: "The permission to execute the action",
 					Required:            true,
 					Attributes: map[string]schema.Attribute{
-						"users": schema.ListAttribute{
+						"users": schema.SetAttribute{
 							MarkdownDescription: "The users with execution permission",
 							Optional:            true,
 							Computed:            true,
-							Default:             listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
+							Default:             setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
 							ElementType:         types.StringType,
 						},
-						"roles": schema.ListAttribute{
+						"roles": schema.SetAttribute{
 							MarkdownDescription: "The roles with execution permission",
 							Optional:            true,
 							Computed:            true,
-							Default:             listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
+							Default:             setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
 							ElementType:         types.StringType,
 						},
-						"teams": schema.ListAttribute{
+						"teams": schema.SetAttribute{
 							MarkdownDescription: "The teams with execution permission",
 							Optional:            true,
 							Computed:            true,
-							Default:             listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
+							Default:             setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
 							ElementType:         types.StringType,
 						},
 						"owned_by_team": schema.BoolAttribute{
@@ -72,25 +72,25 @@ func ActionPermissionsSchema() map[string]schema.Attribute {
 					MarkdownDescription: "The permission to approve the action's runs",
 					Required:            true,
 					Attributes: map[string]schema.Attribute{
-						"users": schema.ListAttribute{
+						"users": schema.SetAttribute{
 							MarkdownDescription: "The users with approval permission",
 							Optional:            true,
 							Computed:            true,
-							Default:             listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
+							Default:             setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
 							ElementType:         types.StringType,
 						},
-						"roles": schema.ListAttribute{
+						"roles": schema.SetAttribute{
 							MarkdownDescription: "The roles with approval permission",
 							Optional:            true,
 							Computed:            true,
-							Default:             listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
+							Default:             setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
 							ElementType:         types.StringType,
 						},
-						"teams": schema.ListAttribute{
+						"teams": schema.SetAttribute{
 							MarkdownDescription: "The teams with approval permission",
 							Optional:            true,
 							Computed:            true,
-							Default:             listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
+							Default:             setdefault.StaticValue(types.SetValueMust(types.StringType, []attr.Value{})),
 							ElementType:         types.StringType,
 						},
 						"policy": schema.StringAttribute{

--- a/port/action/schema.go
+++ b/port/action/schema.go
@@ -453,7 +453,7 @@ func ActionSchema() map[string]schema.Attribute {
 							MarkdownDescription: "Required when selecting type Upsert Entity. The entity identifier for the upsert",
 							Optional:            true,
 						},
-						"teams": schema.ListAttribute{
+						"teams": schema.SetAttribute{
 							MarkdownDescription: "The teams the entity belongs to",
 							ElementType:         types.StringType,
 							Optional:            true,

--- a/port/blueprint-permissions/schema.go
+++ b/port/blueprint-permissions/schema.go
@@ -16,17 +16,17 @@ import (
 
 func getAssigneeProps(permName string) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
-		"users": schema.ListAttribute{
+		"users": schema.SetAttribute{
 			MarkdownDescription: fmt.Sprintf("Users with %+v permissions", permName),
 			Optional:            true,
 			ElementType:         types.StringType,
 		},
-		"roles": schema.ListAttribute{
+		"roles": schema.SetAttribute{
 			MarkdownDescription: fmt.Sprintf("Roles with %+v permissions", permName),
 			Optional:            true,
 			ElementType:         types.StringType,
 		},
-		"teams": schema.ListAttribute{
+		"teams": schema.SetAttribute{
 			MarkdownDescription: fmt.Sprintf("Teams with %+v permissions", permName),
 			Optional:            true,
 			ElementType:         types.StringType,

--- a/port/entity/schema.go
+++ b/port/entity/schema.go
@@ -42,7 +42,7 @@ func EntitySchema() map[string]schema.Attribute {
 			Computed:            true,
 			Default:             booldefault.StaticBool(false),
 		},
-		"teams": schema.ListAttribute{
+		"teams": schema.SetAttribute{
 			MarkdownDescription: "The teams the entity belongs to",
 			Optional:            true,
 			ElementType:         types.StringType,

--- a/port/page-permissions/schema.go
+++ b/port/page-permissions/schema.go
@@ -19,17 +19,17 @@ func PagePermissionsSchema() map[string]schema.Attribute {
 			MarkdownDescription: "The permission to read the page",
 			Required:            true,
 			Attributes: map[string]schema.Attribute{
-				"users": schema.ListAttribute{
+				"users": schema.SetAttribute{
 					MarkdownDescription: "The users with read permission",
 					Optional:            true,
 					ElementType:         types.StringType,
 				},
-				"roles": schema.ListAttribute{
+				"roles": schema.SetAttribute{
 					MarkdownDescription: "The roles with read permission",
 					Optional:            true,
 					ElementType:         types.StringType,
 				},
-				"teams": schema.ListAttribute{
+				"teams": schema.SetAttribute{
 					MarkdownDescription: "The teams with read permission",
 					Optional:            true,
 					ElementType:         types.StringType,

--- a/port/search/dataSourceSchema.go
+++ b/port/search/dataSourceSchema.go
@@ -29,7 +29,7 @@ func EntitySchema() map[string]schema.Attribute {
 			Computed:            true,
 			Optional:            true,
 		},
-		"teams": schema.ListAttribute{
+		"teams": schema.SetAttribute{
 			MarkdownDescription: "The teams the entity belongs to",
 			Computed:            true,
 			Optional:            true,


### PR DESCRIPTION
# Description

**What**
Replaces most lists of roles/teams/users in the Terraform schema with sets, resolving recurring drift caused by the reordering of these on the server side.

I believe fixing this issue might have been attempted in #247 but the presence of #273, even in `2.13.1`, suggests that it was incomplete. In either case, I believe using the data structures which most closely describe the server-side complement is ideal.

**Why**
Because these fields use List, they represent ordered arrays according to the Terraform schema specification. Because the list is apparently reordered/unordered within the Port data model, these cause recurring drift in some circumstances (#273).

**How**
While [Lists](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/types/list) are _ordered_ arrays of elements, [Sets](https://developer.hashicorp.com/terraform/plugin/framework/handling-data/types/set) are _unordered_ arrays of distinct values. By using Set in the schema instead of List, Terraform "ignores" changes resulting from reordering, since there are no ordering guarantees associated with Sets, thereby avoiding drift.

## Type of change
Bug fix (non-breaking change which fixes an issue).