### PR TITLE
Port 15003 bug inconsistent apply result on resource update in tf provider

### DIFF
--- a/port/page/resource.go
+++ b/port/page/resource.go
@@ -163,7 +163,7 @@ func (r *PageResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
-	p, err = r.portClient.UpdatePage(ctx, state.Identifier.ValueString(), page)
+	p, err = r.portClient.UpdatePage(ctx, page.Identifier, page)
 
 	if err != nil {
 		resp.Diagnostics.AddError("failed to update page", err.Error())


### PR DESCRIPTION
# Description

Why - user had errors
How - used the page that got returned from the response of the update instead of just the page that was there in the get before the update

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)