### PR TITLE
Add support for board view in blueprint entities page

### DIFF
--- a/docs/resources/port_page.md
+++ b/docs/resources/port_page.md
@@ -250,6 +250,48 @@ resource "port_page" "microservice_blueprint_page" {
 
 ```
 
+### Blueprint Entities Page with Board View
+
+The `table-entities-explorer` widget supports a `dataViewMode` property that controls how entities are displayed:
+- `table` (default): Display entities in a table format
+- `board`: Display entities in a Kanban-style board format
+
+**Note:** When using `board` mode, you must configure exactly one `groupBy` property in the widget's `blueprintConfig`. The board columns are determined by the values of this grouped property.
+
+```hcl
+
+resource "port_page" "microservice_board_page" {
+  identifier            = "microservice_board_page"
+  title                 = "Microservices Board"
+  type                  = "blueprint-entities"
+  icon                  = "Microservice"
+  blueprint             = port_blueprint.base_blueprint.identifier
+  widgets               = [
+    jsonencode(
+      {
+        "id" : "microservice-board",
+        "type" : "table-entities-explorer",
+        "blueprint" : port_blueprint.base_blueprint.identifier,
+        "dataViewMode" : "board",
+        "blueprintConfig" : {
+          (port_blueprint.base_blueprint.identifier) : {
+            "groupSettings" : {
+              "groupBy" : ["status"]
+            }
+          }
+        },
+        "dataset" : {
+          "combinator" : "and",
+          "rules" : [
+          ]
+        }
+      }
+    )
+  ]
+}
+
+```
+
 ### Dashboard Page
 
 ```hcl

--- a/port/page/schema.go
+++ b/port/page/schema.go
@@ -161,6 +161,48 @@ resource "port_page" "microservice_blueprint_page" {
 
 ` + "```" + `
 
+### Blueprint Entities Page with Board View
+
+The ` + "`table-entities-explorer`" + ` widget supports a ` + "`dataViewMode`" + ` property that controls how entities are displayed:
+- ` + "`table`" + ` (default): Display entities in a table format
+- ` + "`board`" + `: Display entities in a Kanban-style board format
+
+**Note:** When using ` + "`board`" + ` mode, you must configure exactly one ` + "`groupBy`" + ` property in the widget's ` + "`blueprintConfig`" + `. The board columns are determined by the values of this grouped property.
+
+` + "```hcl" + `
+
+resource "port_page" "microservice_board_page" {
+  identifier            = "microservice_board_page"
+  title                 = "Microservices Board"
+  type                  = "blueprint-entities"
+  icon                  = "Microservice"
+  blueprint             = port_blueprint.base_blueprint.identifier
+  widgets               = [
+    jsonencode(
+      {
+        "id" : "microservice-board",
+        "type" : "table-entities-explorer",
+        "blueprint" : port_blueprint.base_blueprint.identifier,
+        "dataViewMode" : "board",
+        "blueprintConfig" : {
+          (port_blueprint.base_blueprint.identifier) : {
+            "groupSettings" : {
+              "groupBy" : ["status"]
+            }
+          }
+        },
+        "dataset" : {
+          "combinator" : "and",
+          "rules" : [
+          ]
+        }
+      }
+    )
+  ]
+}
+
+` + "```" + `
+
 ### Dashboard Page
 
 ` + "```hcl" + `


### PR DESCRIPTION
- Introduced a new `dataViewMode` property for the `table-entities-explorer` widget, allowing display in either table or Kanban-style board format.
- Updated documentation to reflect the new board view configuration requirements.
- Added tests for both table and board view modes in the `port_page` resource.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)