### PR TITLE
PORT-17207-tf-fail-folder-without-parent

### DIFF
--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -32,6 +32,7 @@ description: |-
   
   Folder with After
   Create a folder after another folder.
+  Note: When using after without explicitly setting parent, the folder will automatically inherit the parent from the folder specified in after. To create a root-level folder positioned after another folder, explicitly set parent to an empty string or the desired parent identifier.
   
   
   resource "port_folder" "another_folder" {
@@ -83,6 +84,8 @@ resource "port_folder" "child_folder" {
 
 Create a folder after another folder.
 
+**Note:** When using `after` without explicitly setting `parent`, the folder will automatically inherit the parent from the folder specified in `after`. To create a root-level folder positioned after another folder, explicitly set `parent` to an empty string or the desired parent identifier.
+
 ```hcl
 
 resource "port_folder" "another_folder" {
@@ -104,8 +107,8 @@ resource "port_folder" "another_folder" {
 
 ### Optional
 
-- `after` (String) The identifier of the folder after which the folder should be placed
-- `parent` (String) The identifier of the parent folder
+- `after` (String) The identifier of the folder after which the folder should be placed. Note: If `parent` is not explicitly set and `after` is specified, the parent will be automatically inherited from the folder specified in `after`.
+- `parent` (String) The identifier of the parent folder. If not specified but `after` is set, this will be automatically inherited from the parent of the folder specified in `after`.
 - `title` (String) The title of the folder
 
 ### Read-Only

--- a/port/folder/refreshFolderToState.go
+++ b/port/folder/refreshFolderToState.go
@@ -19,6 +19,8 @@ func refreshFolderToState(fm *FolderModel, f *cli.Folder) error {
 
 	if f.Parent != "" {
 		fm.Parent = types.StringValue(f.Parent)
+	} else {
+		fm.Parent = types.StringNull()
 	}
 
 	return nil

--- a/port/folder/resource.go
+++ b/port/folder/resource.go
@@ -39,7 +39,6 @@ func (r *FolderResource) Create(ctx context.Context, req resource.CreateRequest,
 		return
 	}
 
-	// Pre-compute parent when inherited from 'after' to avoid state inconsistencies
 	if err := r.computeExpectedParent(ctx, state); err != nil {
 		resp.Diagnostics.AddWarning("failed to compute expected parent", err.Error())
 	}
@@ -89,7 +88,6 @@ func (r *FolderResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	// Pre-compute parent when inherited from 'after' to avoid state inconsistencies
 	if err := r.computeExpectedParent(ctx, state); err != nil {
 		resp.Diagnostics.AddWarning("failed to compute expected parent", err.Error())
 	}
@@ -167,10 +165,8 @@ func writeFolderComputedFieldsToState(state *FolderModel, fr *cli.Folder) {
 	}
 }
 
-// computeExpectedParent pre-computes the parent when it will be inherited from the 'after' folder.
-// The Port API automatically assigns parent from 'after' when parent is null/empty.
+// computeExpectedParent pre-computes parent inherited from 'after' folder.
 func (r *FolderResource) computeExpectedParent(ctx context.Context, state *FolderModel) error {
-	// Only compute if parent is null/empty AND after is set
 	if (state.Parent.IsNull() || state.Parent.ValueString() == "") && !state.After.IsNull() && state.After.ValueString() != "" {
 		afterFolderId := state.After.ValueString()
 
@@ -182,7 +178,6 @@ func (r *FolderResource) computeExpectedParent(ctx context.Context, state *Folde
 			return fmt.Errorf("failed to fetch after folder '%s': %w", afterFolderId, err)
 		}
 
-		// Inherit parent from the after folder to match API behavior
 		if afterFolder.Parent != "" {
 			state.Parent = types.StringValue(afterFolder.Parent)
 		}

--- a/port/folder/resource_test.go
+++ b/port/folder/resource_test.go
@@ -179,9 +179,7 @@ func TestAccPortFolderResourceImport(t *testing.T) {
 	})
 }
 
-// TestAccPortFolderResourceAutomaticParentInheritance tests the fix for the bug where
-// folders with 'after' set but 'parent' null would inherit the parent from the 'after' folder.
-// This test ensures the provider correctly handles the Port API's automatic parent assignment.
+// TestAccPortFolderResourceAutomaticParentInheritance verifies parent inheritance from 'after' folder.
 func TestAccPortFolderResourceAutomaticParentInheritance(t *testing.T) {
 	parentFolderIdentifier := utils.GenID()
 	firstChildIdentifier := utils.GenID()
@@ -192,9 +190,6 @@ func TestAccPortFolderResourceAutomaticParentInheritance(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create a parent folder, a first child with explicit parent,
-	// and a second child with 'after' pointing to first child but no parent specified.
-	// The second child should automatically inherit the parent from the first child.
 	var testAccPortFolderResourceConfig = fmt.Sprintf(`
     resource "port_folder" "parent_folder" {
         identifier = "%s"
@@ -211,7 +206,6 @@ func TestAccPortFolderResourceAutomaticParentInheritance(t *testing.T) {
         identifier = "%s"
         after      = port_folder.first_child.identifier
         title      = "Second Child"
-        # Note: parent is not explicitly set, but should be inherited from first_child
     }
     `, parentFolderIdentifier, firstChildIdentifier, secondChildIdentifier)
 
@@ -226,7 +220,6 @@ func TestAccPortFolderResourceAutomaticParentInheritance(t *testing.T) {
 					resource.TestCheckResourceAttr("port_folder.first_child", "identifier", firstChildIdentifier),
 					resource.TestCheckResourceAttr("port_folder.first_child", "parent", parentFolderIdentifier),
 					resource.TestCheckResourceAttr("port_folder.second_child", "identifier", secondChildIdentifier),
-					// This is the key check: second_child should have inherited parent from first_child
 					resource.TestCheckResourceAttr("port_folder.second_child", "parent", parentFolderIdentifier),
 					resource.TestCheckResourceAttr("port_folder.second_child", "after", firstChildIdentifier),
 				),

--- a/port/folder/schema.go
+++ b/port/folder/schema.go
@@ -23,11 +23,11 @@ func FolderSchema() map[string]schema.Attribute {
 			Optional:            true,
 		},
 		"after": schema.StringAttribute{
-			MarkdownDescription: "The identifier of the folder after which the folder should be placed",
+			MarkdownDescription: "The identifier of the folder after which the folder should be placed. Note: If `parent` is not explicitly set and `after` is specified, the parent will be automatically inherited from the folder specified in `after`.",
 			Optional:            true,
 		},
 		"parent": schema.StringAttribute{
-			MarkdownDescription: "The identifier of the parent folder",
+			MarkdownDescription: "The identifier of the parent folder. If not specified but `after` is set, this will be automatically inherited from the parent of the folder specified in `after`.",
 			Optional:            true,
 		},
 	}
@@ -96,6 +96,8 @@ resource "port_folder" "child_folder" {
 ### Folder with After
 
 Create a folder after another folder.
+
+**Note:** When using ` + "`after`" + ` without explicitly setting ` + "`parent`" + `, the folder will automatically inherit the parent from the folder specified in ` + "`after`" + `. To create a root-level folder positioned after another folder, explicitly set ` + "`parent`" + ` to an empty string or the desired parent identifier.
 
 ` + "```hcl" + `
 

--- a/port/folder/schema.go
+++ b/port/folder/schema.go
@@ -29,6 +29,7 @@ func FolderSchema() map[string]schema.Attribute {
 		"parent": schema.StringAttribute{
 			MarkdownDescription: "The identifier of the parent folder. If not specified but `after` is set, this will be automatically inherited from the parent of the folder specified in `after`.",
 			Optional:            true,
+			Computed:            true,
 		},
 	}
 }


### PR DESCRIPTION
# Description

What
Fixed "Provider produced inconsistent result after apply" error in port_folder when after is set but parent is null.

Why
The Port API automatically inherits the parent from the after folder when parent is null. The provider didn't know about this behavior, causing Terraform to detect state mismatches.
Example issue:
resource "port_folder" "catalog_list" {  after  = "port_admins"  # port_admins has parent="manage_service_catalog"  parent = null           # User sets null}# Plan: null → API returns: "manage_service_catalog" → Error!

How
Added computeExpectedParent(): Pre-queries the after folder's parent and sets it in state before API call
Fixed null handling: Explicitly use types.StringNull() when parent is empty
Updated docs: Added warnings about automatic parent inheritance
Added test: TestAccPortFolderResourceAutomaticParentInheritance verifies the fix

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)