### PR TITLE
feat: expand port_organization resource with full API settings support

### DIFF
--- a/docs/resources/organization.md
+++ b/docs/resources/organization.md
@@ -17,7 +17,22 @@ Organization resource to manage organization-level settings such as name and hid
 
 ### Optional
 
+- `announcement_color` (String) The color of the organization announcement (e.g. blue)
+- `announcement_content` (String) The content of the organization announcement
+- `announcement_enabled` (Boolean) Whether the organization announcement is enabled
+- `announcement_link` (String) A link for the organization announcement
+- `federated_logout` (Boolean) Enable or disable federated logout
+- `hidden_blueprints` (List of String) A list of blueprint identifiers to hide from the portal
+- `include_blueprints_in_global_search_by_default` (Boolean) Whether to include blueprints in global search by default
+- `is_onboarded` (Boolean) Whether the organization has completed onboarding
 - `name` (String) The name of the organization
+- `port_agent_streamer_name` (String) The name of the Port agent streamer (e.g. KAFKA)
+- `portal_icon` (String) The icon URI for the portal (must be a valid URI)
+- `portal_title` (String) The title for the portal
+- `support_user_expires_at` (String) The expiration date for support user access (ISO 8601 format)
+- `support_user_permission` (String) The support user permission level (e.g. OPT_OUT)
+- `support_user_ttl` (String) The TTL for support user access (e.g. ONE_DAY)
+- `tool_selection_provisioning_status` (String) The status of tool selection provisioning (e.g. IN_PROGRESS)
 
 ### Read-Only
 

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -754,13 +754,44 @@ type Integration struct {
 	ChangelogDestination *ChangelogDestination `json:"changelogDestination,omitempty"`
 }
 
+type OrganizationSettings struct {
+	HiddenBlueprints                         []string `json:"hiddenBlueprints,omitempty"`
+	FederatedLogout                          *bool    `json:"federatedLogout,omitempty"`
+	PortalIcon                               *string  `json:"portalIcon,omitempty"`
+	PortalTitle                              *string  `json:"portalTitle,omitempty"`
+	SupportUserPermission                    *string  `json:"supportUserPermission,omitempty"`
+	SupportUserTTL                           *string  `json:"supportUserTTL,omitempty"`
+	SupportUserExpiresAt                     *string  `json:"supportUserExpiresAt,omitempty"`
+	PortAgentStreamerName                    *string  `json:"portAgentStreamerName,omitempty"`
+	IncludeBlueprintsInGlobalSearchByDefault *bool    `json:"includeBlueprintsInGlobalSearchByDefault,omitempty"`
+}
+
+type OrganizationAnnouncement struct {
+	Enabled *bool   `json:"enabled,omitempty"`
+	Content *string `json:"content,omitempty"`
+	Link    *string `json:"link,omitempty"`
+	Color   *string `json:"color,omitempty"`
+}
+
+type OrganizationToolSelectionProvisioning struct {
+	Status *string `json:"status,omitempty"`
+}
+
 type Organization struct {
-	Name         string   `json:"name"`
-	FeatureFlags []string `json:"featureFlags"`
+	Name                      string                                 `json:"name"`
+	FeatureFlags              []string                               `json:"featureFlags"`
+	Settings                  *OrganizationSettings                  `json:"settings,omitempty"`
+	IsOnboarded               *bool                                  `json:"isOnboarded,omitempty"`
+	Announcement              *OrganizationAnnouncement              `json:"announcement,omitempty"`
+	ToolSelectionProvisioning *OrganizationToolSelectionProvisioning `json:"toolSelectionProvisioning,omitempty"`
 }
 
 type OrganizationUpdate struct {
-	Name *string `json:"name,omitempty"`
+	Name                      *string                                `json:"name,omitempty"`
+	Settings                  *OrganizationSettings                  `json:"settings,omitempty"`
+	IsOnboarded               *bool                                  `json:"isOnboarded,omitempty"`
+	Announcement              *OrganizationAnnouncement              `json:"announcement,omitempty"`
+	ToolSelectionProvisioning *OrganizationToolSelectionProvisioning `json:"toolSelectionProvisioning,omitempty"`
 }
 
 type OrganizationSecret struct {

--- a/port/organization/organizationModel.go
+++ b/port/organization/organizationModel.go
@@ -5,6 +5,21 @@ import (
 )
 
 type OrganizationModel struct {
-	ID   types.String `tfsdk:"id"`
-	Name types.String `tfsdk:"name"`
+	ID                                       types.String `tfsdk:"id"`
+	Name                                     types.String `tfsdk:"name"`
+	HiddenBlueprints                         types.List   `tfsdk:"hidden_blueprints"`
+	FederatedLogout                          types.Bool   `tfsdk:"federated_logout"`
+	PortalIcon                               types.String `tfsdk:"portal_icon"`
+	PortalTitle                              types.String `tfsdk:"portal_title"`
+	SupportUserPermission                    types.String `tfsdk:"support_user_permission"`
+	SupportUserTTL                           types.String `tfsdk:"support_user_ttl"`
+	SupportUserExpiresAt                     types.String `tfsdk:"support_user_expires_at"`
+	PortAgentStreamerName                    types.String `tfsdk:"port_agent_streamer_name"`
+	IncludeBlueprintsInGlobalSearchByDefault types.Bool   `tfsdk:"include_blueprints_in_global_search_by_default"`
+	IsOnboarded                              types.Bool   `tfsdk:"is_onboarded"`
+	ToolSelectionProvisioningStatus          types.String `tfsdk:"tool_selection_provisioning_status"`
+	AnnouncementEnabled                      types.Bool   `tfsdk:"announcement_enabled"`
+	AnnouncementContent                      types.String `tfsdk:"announcement_content"`
+	AnnouncementLink                         types.String `tfsdk:"announcement_link"`
+	AnnouncementColor                        types.String `tfsdk:"announcement_color"`
 }

--- a/port/organization/organizationResourceToPortBody.go
+++ b/port/organization/organizationResourceToPortBody.go
@@ -12,113 +12,91 @@ func organizationResourceToPortBody(ctx context.Context, state *OrganizationMode
 	update := &cli.OrganizationUpdate{}
 
 	if !state.Name.IsNull() && !state.Name.IsUnknown() {
-		name := state.Name.ValueString()
-		update.Name = &name
+		update.Name = state.Name.ValueStringPointer()
 	}
 
-	// Settings fields
+	// Settings: fill a local struct and assign once. If we set update.Settings to a non-nil
+	// pointer up front, encoding/json still emits "settings":{} (omitempty only drops nil
+	// pointers), which can differ from omitting the key entirely.
+	settings := &cli.OrganizationSettings{}
+	settingsSet := false
+
 	if !state.HiddenBlueprints.IsNull() && !state.HiddenBlueprints.IsUnknown() {
 		var blueprints []string
 		diags := state.HiddenBlueprints.ElementsAs(ctx, &blueprints, false)
 		if diags.HasError() {
 			return nil, fmt.Errorf("%s", diags.Errors()[0].Detail())
 		}
-		if update.Settings == nil {
-			update.Settings = &cli.OrganizationSettings{}
-		}
-		update.Settings.HiddenBlueprints = blueprints
+		settings.HiddenBlueprints = blueprints
+		settingsSet = true
 	}
 	if !state.FederatedLogout.IsNull() && !state.FederatedLogout.IsUnknown() {
-		if update.Settings == nil {
-			update.Settings = &cli.OrganizationSettings{}
-		}
-		v := state.FederatedLogout.ValueBool()
-		update.Settings.FederatedLogout = &v
+		settings.FederatedLogout = state.FederatedLogout.ValueBoolPointer()
+		settingsSet = true
 	}
 	if !state.PortalIcon.IsNull() && !state.PortalIcon.IsUnknown() {
-		if update.Settings == nil {
-			update.Settings = &cli.OrganizationSettings{}
-		}
-		v := state.PortalIcon.ValueString()
-		update.Settings.PortalIcon = &v
+		settings.PortalIcon = state.PortalIcon.ValueStringPointer()
+		settingsSet = true
 	}
 	if !state.PortalTitle.IsNull() && !state.PortalTitle.IsUnknown() {
-		if update.Settings == nil {
-			update.Settings = &cli.OrganizationSettings{}
-		}
-		v := state.PortalTitle.ValueString()
-		update.Settings.PortalTitle = &v
+		settings.PortalTitle = state.PortalTitle.ValueStringPointer()
+		settingsSet = true
 	}
 	if !state.SupportUserPermission.IsNull() && !state.SupportUserPermission.IsUnknown() {
-		if update.Settings == nil {
-			update.Settings = &cli.OrganizationSettings{}
-		}
-		v := state.SupportUserPermission.ValueString()
-		update.Settings.SupportUserPermission = &v
+		settings.SupportUserPermission = state.SupportUserPermission.ValueStringPointer()
+		settingsSet = true
 	}
 	if !state.SupportUserTTL.IsNull() && !state.SupportUserTTL.IsUnknown() {
-		if update.Settings == nil {
-			update.Settings = &cli.OrganizationSettings{}
-		}
-		v := state.SupportUserTTL.ValueString()
-		update.Settings.SupportUserTTL = &v
+		settings.SupportUserTTL = state.SupportUserTTL.ValueStringPointer()
+		settingsSet = true
 	}
 	if !state.SupportUserExpiresAt.IsNull() && !state.SupportUserExpiresAt.IsUnknown() {
-		if update.Settings == nil {
-			update.Settings = &cli.OrganizationSettings{}
-		}
-		v := state.SupportUserExpiresAt.ValueString()
-		update.Settings.SupportUserExpiresAt = &v
+		settings.SupportUserExpiresAt = state.SupportUserExpiresAt.ValueStringPointer()
+		settingsSet = true
 	}
 	if !state.PortAgentStreamerName.IsNull() && !state.PortAgentStreamerName.IsUnknown() {
-		if update.Settings == nil {
-			update.Settings = &cli.OrganizationSettings{}
-		}
-		v := state.PortAgentStreamerName.ValueString()
-		update.Settings.PortAgentStreamerName = &v
+		settings.PortAgentStreamerName = state.PortAgentStreamerName.ValueStringPointer()
+		settingsSet = true
 	}
 	if !state.IncludeBlueprintsInGlobalSearchByDefault.IsNull() && !state.IncludeBlueprintsInGlobalSearchByDefault.IsUnknown() {
-		if update.Settings == nil {
-			update.Settings = &cli.OrganizationSettings{}
-		}
-		v := state.IncludeBlueprintsInGlobalSearchByDefault.ValueBool()
-		update.Settings.IncludeBlueprintsInGlobalSearchByDefault = &v
+		settings.IncludeBlueprintsInGlobalSearchByDefault = state.IncludeBlueprintsInGlobalSearchByDefault.ValueBoolPointer()
+		settingsSet = true
+	}
+	if settingsSet {
+		update.Settings = settings
 	}
 
 	// Top-level fields
 	if !state.IsOnboarded.IsNull() && !state.IsOnboarded.IsUnknown() {
-		v := state.IsOnboarded.ValueBool()
-		update.IsOnboarded = &v
+		update.IsOnboarded = state.IsOnboarded.ValueBoolPointer()
 	}
 
 	// Tool selection provisioning
 	if !state.ToolSelectionProvisioningStatus.IsNull() && !state.ToolSelectionProvisioningStatus.IsUnknown() {
-		v := state.ToolSelectionProvisioningStatus.ValueString()
-		update.ToolSelectionProvisioning = &cli.OrganizationToolSelectionProvisioning{Status: &v}
+		update.ToolSelectionProvisioning = &cli.OrganizationToolSelectionProvisioning{
+			Status: state.ToolSelectionProvisioningStatus.ValueStringPointer(),
+		}
 	}
 
-	// Announcement
-	hasAnnouncement := (!state.AnnouncementEnabled.IsNull() && !state.AnnouncementEnabled.IsUnknown()) ||
-		(!state.AnnouncementContent.IsNull() && !state.AnnouncementContent.IsUnknown()) ||
-		(!state.AnnouncementLink.IsNull() && !state.AnnouncementLink.IsUnknown()) ||
-		(!state.AnnouncementColor.IsNull() && !state.AnnouncementColor.IsUnknown())
-	if hasAnnouncement {
-		update.Announcement = &cli.OrganizationAnnouncement{}
+	// Announcement: default enabled to false when any announcement attribute is set, then apply
+	// known values from state (so content/link/color without an explicit enabled still disables by default).
+	if state.AnnouncementEnabled.ValueBoolPointer() != nil ||
+		state.AnnouncementContent.ValueStringPointer() != nil ||
+		state.AnnouncementLink.ValueStringPointer() != nil ||
+		state.AnnouncementColor.ValueStringPointer() != nil {
+		enabledFalse := false
+		update.Announcement = &cli.OrganizationAnnouncement{Enabled: &enabledFalse}
 		if !state.AnnouncementEnabled.IsNull() && !state.AnnouncementEnabled.IsUnknown() {
-			v := state.AnnouncementEnabled.ValueBool()
-			update.Announcement.Enabled = &v
+			update.Announcement.Enabled = state.AnnouncementEnabled.ValueBoolPointer()
 		}
 		if !state.AnnouncementContent.IsNull() && !state.AnnouncementContent.IsUnknown() {
-			v := state.AnnouncementContent.ValueString()
-			update.Announcement.Content = &v
+			update.Announcement.Content = state.AnnouncementContent.ValueStringPointer()
 		}
 		if !state.AnnouncementLink.IsNull() && !state.AnnouncementLink.IsUnknown() {
-			v := state.AnnouncementLink.ValueString()
-			update.Announcement.Link = &v
+			update.Announcement.Link = state.AnnouncementLink.ValueStringPointer()
 		}
 		if !state.AnnouncementColor.IsNull() && !state.AnnouncementColor.IsUnknown() {
-			v := state.AnnouncementColor.ValueString()
-			update.Announcement.Color = &v
+			update.Announcement.Color = state.AnnouncementColor.ValueStringPointer()
 		}
 	}
 

--- a/port/organization/organizationResourceToPortBody.go
+++ b/port/organization/organizationResourceToPortBody.go
@@ -2,7 +2,9 @@ package organization
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
 )
 
@@ -14,5 +16,123 @@ func organizationResourceToPortBody(ctx context.Context, state *OrganizationMode
 		update.Name = &name
 	}
 
+	// Settings fields
+	if !state.HiddenBlueprints.IsNull() && !state.HiddenBlueprints.IsUnknown() {
+		var blueprints []string
+		diags := state.HiddenBlueprints.ElementsAs(ctx, &blueprints, false)
+		if diags.HasError() {
+			return nil, fmt.Errorf("%s", diags.Errors()[0].Detail())
+		}
+		if update.Settings == nil {
+			update.Settings = &cli.OrganizationSettings{}
+		}
+		update.Settings.HiddenBlueprints = blueprints
+	}
+	if !state.FederatedLogout.IsNull() && !state.FederatedLogout.IsUnknown() {
+		if update.Settings == nil {
+			update.Settings = &cli.OrganizationSettings{}
+		}
+		v := state.FederatedLogout.ValueBool()
+		update.Settings.FederatedLogout = &v
+	}
+	if !state.PortalIcon.IsNull() && !state.PortalIcon.IsUnknown() {
+		if update.Settings == nil {
+			update.Settings = &cli.OrganizationSettings{}
+		}
+		v := state.PortalIcon.ValueString()
+		update.Settings.PortalIcon = &v
+	}
+	if !state.PortalTitle.IsNull() && !state.PortalTitle.IsUnknown() {
+		if update.Settings == nil {
+			update.Settings = &cli.OrganizationSettings{}
+		}
+		v := state.PortalTitle.ValueString()
+		update.Settings.PortalTitle = &v
+	}
+	if !state.SupportUserPermission.IsNull() && !state.SupportUserPermission.IsUnknown() {
+		if update.Settings == nil {
+			update.Settings = &cli.OrganizationSettings{}
+		}
+		v := state.SupportUserPermission.ValueString()
+		update.Settings.SupportUserPermission = &v
+	}
+	if !state.SupportUserTTL.IsNull() && !state.SupportUserTTL.IsUnknown() {
+		if update.Settings == nil {
+			update.Settings = &cli.OrganizationSettings{}
+		}
+		v := state.SupportUserTTL.ValueString()
+		update.Settings.SupportUserTTL = &v
+	}
+	if !state.SupportUserExpiresAt.IsNull() && !state.SupportUserExpiresAt.IsUnknown() {
+		if update.Settings == nil {
+			update.Settings = &cli.OrganizationSettings{}
+		}
+		v := state.SupportUserExpiresAt.ValueString()
+		update.Settings.SupportUserExpiresAt = &v
+	}
+	if !state.PortAgentStreamerName.IsNull() && !state.PortAgentStreamerName.IsUnknown() {
+		if update.Settings == nil {
+			update.Settings = &cli.OrganizationSettings{}
+		}
+		v := state.PortAgentStreamerName.ValueString()
+		update.Settings.PortAgentStreamerName = &v
+	}
+	if !state.IncludeBlueprintsInGlobalSearchByDefault.IsNull() && !state.IncludeBlueprintsInGlobalSearchByDefault.IsUnknown() {
+		if update.Settings == nil {
+			update.Settings = &cli.OrganizationSettings{}
+		}
+		v := state.IncludeBlueprintsInGlobalSearchByDefault.ValueBool()
+		update.Settings.IncludeBlueprintsInGlobalSearchByDefault = &v
+	}
+
+	// Top-level fields
+	if !state.IsOnboarded.IsNull() && !state.IsOnboarded.IsUnknown() {
+		v := state.IsOnboarded.ValueBool()
+		update.IsOnboarded = &v
+	}
+
+	// Tool selection provisioning
+	if !state.ToolSelectionProvisioningStatus.IsNull() && !state.ToolSelectionProvisioningStatus.IsUnknown() {
+		v := state.ToolSelectionProvisioningStatus.ValueString()
+		update.ToolSelectionProvisioning = &cli.OrganizationToolSelectionProvisioning{Status: &v}
+	}
+
+	// Announcement
+	hasAnnouncement := (!state.AnnouncementEnabled.IsNull() && !state.AnnouncementEnabled.IsUnknown()) ||
+		(!state.AnnouncementContent.IsNull() && !state.AnnouncementContent.IsUnknown()) ||
+		(!state.AnnouncementLink.IsNull() && !state.AnnouncementLink.IsUnknown()) ||
+		(!state.AnnouncementColor.IsNull() && !state.AnnouncementColor.IsUnknown())
+	if hasAnnouncement {
+		update.Announcement = &cli.OrganizationAnnouncement{}
+		if !state.AnnouncementEnabled.IsNull() && !state.AnnouncementEnabled.IsUnknown() {
+			v := state.AnnouncementEnabled.ValueBool()
+			update.Announcement.Enabled = &v
+		}
+		if !state.AnnouncementContent.IsNull() && !state.AnnouncementContent.IsUnknown() {
+			v := state.AnnouncementContent.ValueString()
+			update.Announcement.Content = &v
+		}
+		if !state.AnnouncementLink.IsNull() && !state.AnnouncementLink.IsUnknown() {
+			v := state.AnnouncementLink.ValueString()
+			update.Announcement.Link = &v
+		}
+		if !state.AnnouncementColor.IsNull() && !state.AnnouncementColor.IsUnknown() {
+			v := state.AnnouncementColor.ValueString()
+			update.Announcement.Color = &v
+		}
+	}
+
 	return update, nil
+}
+
+func hiddenBlueprintsToList(ctx context.Context, blueprints []string) (types.List, error) {
+	if len(blueprints) == 0 {
+		return types.ListNull(types.StringType), nil
+	}
+
+	list, diags := types.ListValueFrom(ctx, types.StringType, blueprints)
+	if diags.HasError() {
+		return types.ListNull(types.StringType), fmt.Errorf("%s", diags.Errors()[0].Detail())
+	}
+	return list, nil
 }

--- a/port/organization/organizationSchema.go
+++ b/port/organization/organizationSchema.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 func OrganizationSchema() map[string]schema.Attribute {
@@ -15,6 +16,81 @@ func OrganizationSchema() map[string]schema.Attribute {
 		},
 		"name": schema.StringAttribute{
 			MarkdownDescription: "The name of the organization",
+			Optional:            true,
+			Computed:            true,
+		},
+		"hidden_blueprints": schema.ListAttribute{
+			MarkdownDescription: "A list of blueprint identifiers to hide from the portal",
+			Optional:            true,
+			ElementType:         types.StringType,
+		},
+		"federated_logout": schema.BoolAttribute{
+			MarkdownDescription: "Enable or disable federated logout",
+			Optional:            true,
+			Computed:            true,
+		},
+		"portal_icon": schema.StringAttribute{
+			MarkdownDescription: "The icon URI for the portal (must be a valid URI)",
+			Optional:            true,
+			Computed:            true,
+		},
+		"portal_title": schema.StringAttribute{
+			MarkdownDescription: "The title for the portal",
+			Optional:            true,
+			Computed:            true,
+		},
+		"support_user_permission": schema.StringAttribute{
+			MarkdownDescription: "The support user permission level (e.g. OPT_OUT)",
+			Optional:            true,
+			Computed:            true,
+		},
+		"support_user_ttl": schema.StringAttribute{
+			MarkdownDescription: "The TTL for support user access (e.g. ONE_DAY)",
+			Optional:            true,
+			Computed:            true,
+		},
+		"support_user_expires_at": schema.StringAttribute{
+			MarkdownDescription: "The expiration date for support user access (ISO 8601 format)",
+			Optional:            true,
+			Computed:            true,
+		},
+		"port_agent_streamer_name": schema.StringAttribute{
+			MarkdownDescription: "The name of the Port agent streamer (e.g. KAFKA)",
+			Optional:            true,
+			Computed:            true,
+		},
+		"include_blueprints_in_global_search_by_default": schema.BoolAttribute{
+			MarkdownDescription: "Whether to include blueprints in global search by default",
+			Optional:            true,
+			Computed:            true,
+		},
+		"is_onboarded": schema.BoolAttribute{
+			MarkdownDescription: "Whether the organization has completed onboarding",
+			Optional:            true,
+			Computed:            true,
+		},
+		"tool_selection_provisioning_status": schema.StringAttribute{
+			MarkdownDescription: "The status of tool selection provisioning (e.g. IN_PROGRESS)",
+			Optional:            true,
+			Computed:            true,
+		},
+		"announcement_enabled": schema.BoolAttribute{
+			MarkdownDescription: "Whether the organization announcement is enabled",
+			Optional:            true,
+			Computed:            true,
+		},
+		"announcement_content": schema.StringAttribute{
+			MarkdownDescription: "The content of the organization announcement",
+			Optional:            true,
+			Computed:            true,
+		},
+		"announcement_link": schema.StringAttribute{
+			MarkdownDescription: "A link for the organization announcement",
+			Optional:            true,
+			Computed:            true,
+		},
+		"announcement_color": schema.StringAttribute{
+			MarkdownDescription: "The color of the organization announcement (e.g. blue)",
 			Optional:            true,
 			Computed:            true,
 		},

--- a/port/organization/organization_resource_test.go
+++ b/port/organization/organization_resource_test.go
@@ -63,6 +63,154 @@ func TestAccPortOrganizationUpdate(t *testing.T) {
 	})
 }
 
+func TestAccPortOrganizationWithHiddenBlueprints(t *testing.T) {
+	orgName := utils.GenID()
+	bp1 := utils.GenID()
+	bp2 := utils.GenID()
+	var testAccOrganizationConfigCreate = fmt.Sprintf(`
+	resource "port_blueprint" "bp1" {
+		identifier = "%s"
+		title      = "BP1"
+		icon       = "Microservice"
+	}
+	resource "port_blueprint" "bp2" {
+		identifier = "%s"
+		title      = "BP2"
+		icon       = "Microservice"
+	}
+	resource "port_organization" "test" {
+		name              = "%s"
+		hidden_blueprints = [port_blueprint.bp1.identifier, port_blueprint.bp2.identifier]
+	}`, bp1, bp2, orgName)
+
+	var testAccOrganizationConfigUpdate = fmt.Sprintf(`
+	resource "port_blueprint" "bp1" {
+		identifier = "%s"
+		title      = "BP1"
+		icon       = "Microservice"
+	}
+	resource "port_blueprint" "bp2" {
+		identifier = "%s"
+		title      = "BP2"
+		icon       = "Microservice"
+	}
+	resource "port_organization" "test" {
+		name              = "%s"
+		hidden_blueprints = [port_blueprint.bp1.identifier]
+	}`, bp1, bp2, orgName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + testAccOrganizationConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_organization.test", "name", orgName),
+					resource.TestCheckResourceAttr("port_organization.test", "hidden_blueprints.#", "2"),
+				),
+			},
+			{
+				Config: acctest.ProviderConfig + testAccOrganizationConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_organization.test", "name", orgName),
+					resource.TestCheckResourceAttr("port_organization.test", "hidden_blueprints.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPortOrganizationWithSettings(t *testing.T) {
+	orgName := utils.GenID()
+	var testAccOrganizationConfigCreate = fmt.Sprintf(`
+	resource "port_organization" "test" {
+		name          = "%s"
+		portal_title  = "My Dev Portal"
+		portal_icon   = "https://example.com/icon.png"
+		include_blueprints_in_global_search_by_default = true
+	}`, orgName)
+
+	var testAccOrganizationConfigUpdate = fmt.Sprintf(`
+	resource "port_organization" "test" {
+		name          = "%s"
+		portal_title  = "Updated Portal"
+		portal_icon   = "https://example.com/icon2.png"
+		include_blueprints_in_global_search_by_default = false
+	}`, orgName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + testAccOrganizationConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_organization.test", "name", orgName),
+					resource.TestCheckResourceAttr("port_organization.test", "portal_title", "My Dev Portal"),
+					resource.TestCheckResourceAttr("port_organization.test", "portal_icon", "https://example.com/icon.png"),
+					resource.TestCheckResourceAttr("port_organization.test", "include_blueprints_in_global_search_by_default", "true"),
+				),
+			},
+			{
+				Config: acctest.ProviderConfig + testAccOrganizationConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_organization.test", "name", orgName),
+					resource.TestCheckResourceAttr("port_organization.test", "portal_title", "Updated Portal"),
+					resource.TestCheckResourceAttr("port_organization.test", "portal_icon", "https://example.com/icon2.png"),
+					resource.TestCheckResourceAttr("port_organization.test", "include_blueprints_in_global_search_by_default", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPortOrganizationWithAnnouncement(t *testing.T) {
+	orgName := utils.GenID()
+	var testAccOrganizationConfigCreate = fmt.Sprintf(`
+	resource "port_organization" "test" {
+		name                  = "%s"
+		announcement_enabled  = true
+		announcement_content  = "Welcome to the portal"
+		announcement_link     = "https://example.com"
+		announcement_color    = "blue"
+	}`, orgName)
+
+	var testAccOrganizationConfigUpdate = fmt.Sprintf(`
+	resource "port_organization" "test" {
+		name                  = "%s"
+		announcement_enabled  = false
+		announcement_content  = "Portal under maintenance"
+		announcement_color    = "red"
+	}`, orgName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + testAccOrganizationConfigCreate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_organization.test", "name", orgName),
+					resource.TestCheckResourceAttr("port_organization.test", "announcement_enabled", "true"),
+					resource.TestCheckResourceAttr("port_organization.test", "announcement_content", "Welcome to the portal"),
+					resource.TestCheckResourceAttr("port_organization.test", "announcement_link", "https://example.com"),
+					resource.TestCheckResourceAttr("port_organization.test", "announcement_color", "blue"),
+				),
+			},
+			{
+				Config: acctest.ProviderConfig + testAccOrganizationConfigUpdate,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_organization.test", "name", orgName),
+					resource.TestCheckResourceAttr("port_organization.test", "announcement_enabled", "false"),
+					resource.TestCheckResourceAttr("port_organization.test", "announcement_content", "Portal under maintenance"),
+					resource.TestCheckResourceAttr("port_organization.test", "announcement_color", "red"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccPortOrganizationImport(t *testing.T) {
 	orgName := utils.GenID()
 	var testAccOrganizationConfigCreate = fmt.Sprintf(`

--- a/port/organization/refreshOrganizationState.go
+++ b/port/organization/refreshOrganizationState.go
@@ -11,5 +11,69 @@ func refreshOrganizationState(ctx context.Context, state *OrganizationModel, org
 	state.ID = types.StringValue(org.Name)
 	state.Name = types.StringValue(org.Name)
 
+	// Settings
+	if org.Settings != nil {
+		list, err := hiddenBlueprintsToList(ctx, org.Settings.HiddenBlueprints)
+		if err != nil {
+			return err
+		}
+		state.HiddenBlueprints = list
+		state.FederatedLogout = optionalBoolValue(org.Settings.FederatedLogout)
+		state.PortalIcon = optionalStringValue(org.Settings.PortalIcon)
+		state.PortalTitle = optionalStringValue(org.Settings.PortalTitle)
+		state.SupportUserPermission = optionalStringValue(org.Settings.SupportUserPermission)
+		state.SupportUserTTL = optionalStringValue(org.Settings.SupportUserTTL)
+		state.SupportUserExpiresAt = optionalStringValue(org.Settings.SupportUserExpiresAt)
+		state.PortAgentStreamerName = optionalStringValue(org.Settings.PortAgentStreamerName)
+		state.IncludeBlueprintsInGlobalSearchByDefault = optionalBoolValue(org.Settings.IncludeBlueprintsInGlobalSearchByDefault)
+	} else {
+		state.HiddenBlueprints = types.ListNull(types.StringType)
+		state.FederatedLogout = types.BoolNull()
+		state.PortalIcon = types.StringNull()
+		state.PortalTitle = types.StringNull()
+		state.SupportUserPermission = types.StringNull()
+		state.SupportUserTTL = types.StringNull()
+		state.SupportUserExpiresAt = types.StringNull()
+		state.PortAgentStreamerName = types.StringNull()
+		state.IncludeBlueprintsInGlobalSearchByDefault = types.BoolNull()
+	}
+
+	// IsOnboarded
+	state.IsOnboarded = optionalBoolValue(org.IsOnboarded)
+
+	// Tool selection provisioning
+	if org.ToolSelectionProvisioning != nil {
+		state.ToolSelectionProvisioningStatus = optionalStringValue(org.ToolSelectionProvisioning.Status)
+	} else {
+		state.ToolSelectionProvisioningStatus = types.StringNull()
+	}
+
+	// Announcement
+	if org.Announcement != nil {
+		state.AnnouncementEnabled = optionalBoolValue(org.Announcement.Enabled)
+		state.AnnouncementContent = optionalStringValue(org.Announcement.Content)
+		state.AnnouncementLink = optionalStringValue(org.Announcement.Link)
+		state.AnnouncementColor = optionalStringValue(org.Announcement.Color)
+	} else {
+		state.AnnouncementEnabled = types.BoolNull()
+		state.AnnouncementContent = types.StringNull()
+		state.AnnouncementLink = types.StringNull()
+		state.AnnouncementColor = types.StringNull()
+	}
+
 	return nil
+}
+
+func optionalStringValue(v *string) types.String {
+	if v == nil {
+		return types.StringNull()
+	}
+	return types.StringValue(*v)
+}
+
+func optionalBoolValue(v *bool) types.Bool {
+	if v == nil {
+		return types.BoolNull()
+	}
+	return types.BoolValue(*v)
 }

--- a/port/organization/refreshOrganizationState.go
+++ b/port/organization/refreshOrganizationState.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/flex"
 )
 
 func refreshOrganizationState(ctx context.Context, state *OrganizationModel, org *cli.Organization) error {
@@ -12,68 +13,43 @@ func refreshOrganizationState(ctx context.Context, state *OrganizationModel, org
 	state.Name = types.StringValue(org.Name)
 
 	// Settings
-	if org.Settings != nil {
-		list, err := hiddenBlueprintsToList(ctx, org.Settings.HiddenBlueprints)
-		if err != nil {
-			return err
-		}
-		state.HiddenBlueprints = list
-		state.FederatedLogout = optionalBoolValue(org.Settings.FederatedLogout)
-		state.PortalIcon = optionalStringValue(org.Settings.PortalIcon)
-		state.PortalTitle = optionalStringValue(org.Settings.PortalTitle)
-		state.SupportUserPermission = optionalStringValue(org.Settings.SupportUserPermission)
-		state.SupportUserTTL = optionalStringValue(org.Settings.SupportUserTTL)
-		state.SupportUserExpiresAt = optionalStringValue(org.Settings.SupportUserExpiresAt)
-		state.PortAgentStreamerName = optionalStringValue(org.Settings.PortAgentStreamerName)
-		state.IncludeBlueprintsInGlobalSearchByDefault = optionalBoolValue(org.Settings.IncludeBlueprintsInGlobalSearchByDefault)
-	} else {
-		state.HiddenBlueprints = types.ListNull(types.StringType)
-		state.FederatedLogout = types.BoolNull()
-		state.PortalIcon = types.StringNull()
-		state.PortalTitle = types.StringNull()
-		state.SupportUserPermission = types.StringNull()
-		state.SupportUserTTL = types.StringNull()
-		state.SupportUserExpiresAt = types.StringNull()
-		state.PortAgentStreamerName = types.StringNull()
-		state.IncludeBlueprintsInGlobalSearchByDefault = types.BoolNull()
+	orgSettings := org.Settings
+	if orgSettings == nil {
+		orgSettings = &cli.OrganizationSettings{}
 	}
+	list, err := hiddenBlueprintsToList(ctx, orgSettings.HiddenBlueprints)
+	if err != nil {
+		return err
+	}
+	state.HiddenBlueprints = list
+	state.FederatedLogout = flex.GoBoolToFramework(orgSettings.FederatedLogout)
+	state.PortalIcon = flex.GoStringToFramework(orgSettings.PortalIcon)
+	state.PortalTitle = flex.GoStringToFramework(orgSettings.PortalTitle)
+	state.SupportUserPermission = flex.GoStringToFramework(orgSettings.SupportUserPermission)
+	state.SupportUserTTL = flex.GoStringToFramework(orgSettings.SupportUserTTL)
+	state.SupportUserExpiresAt = flex.GoStringToFramework(orgSettings.SupportUserExpiresAt)
+	state.PortAgentStreamerName = flex.GoStringToFramework(orgSettings.PortAgentStreamerName)
+	state.IncludeBlueprintsInGlobalSearchByDefault = flex.GoBoolToFramework(orgSettings.IncludeBlueprintsInGlobalSearchByDefault)
 
 	// IsOnboarded
-	state.IsOnboarded = optionalBoolValue(org.IsOnboarded)
+	state.IsOnboarded = flex.GoBoolToFramework(org.IsOnboarded)
 
 	// Tool selection provisioning
 	if org.ToolSelectionProvisioning != nil {
-		state.ToolSelectionProvisioningStatus = optionalStringValue(org.ToolSelectionProvisioning.Status)
+		state.ToolSelectionProvisioningStatus = flex.GoStringToFramework(org.ToolSelectionProvisioning.Status)
 	} else {
 		state.ToolSelectionProvisioningStatus = types.StringNull()
 	}
 
 	// Announcement
-	if org.Announcement != nil {
-		state.AnnouncementEnabled = optionalBoolValue(org.Announcement.Enabled)
-		state.AnnouncementContent = optionalStringValue(org.Announcement.Content)
-		state.AnnouncementLink = optionalStringValue(org.Announcement.Link)
-		state.AnnouncementColor = optionalStringValue(org.Announcement.Color)
-	} else {
-		state.AnnouncementEnabled = types.BoolNull()
-		state.AnnouncementContent = types.StringNull()
-		state.AnnouncementLink = types.StringNull()
-		state.AnnouncementColor = types.StringNull()
+	orgAnnouncement := org.Announcement
+	if orgAnnouncement == nil {
+		orgAnnouncement = &cli.OrganizationAnnouncement{}
 	}
+	state.AnnouncementEnabled = flex.GoBoolToFramework(orgAnnouncement.Enabled)
+	state.AnnouncementContent = flex.GoStringToFramework(orgAnnouncement.Content)
+	state.AnnouncementLink = flex.GoStringToFramework(orgAnnouncement.Link)
+	state.AnnouncementColor = flex.GoStringToFramework(orgAnnouncement.Color)
 
 	return nil
-}
-
-func optionalStringValue(v *string) types.String {
-	if v == nil {
-		return types.StringNull()
-	}
-	return types.StringValue(*v)
-}
-
-func optionalBoolValue(v *bool) types.Bool {
-	if v == nil {
-		return types.BoolNull()
-	}
-	return types.BoolValue(*v)
 }


### PR DESCRIPTION
- Add settings fields: hidden_blueprints, federated_logout, portal_icon, portal_title, support_user_permission, support_user_ttl, support_user_expires_at, port_agent_streamer_name, include_blueprints_in_global_search_by_default
- Add announcement fields: enabled, content, link, color
- Add top-level fields: is_onboarded, tool_selection_provisioning_status
- Nest hiddenBlueprints under settings object to match API contract
- Add acceptance tests for settings and announcement
- Regenerate docs with all 16 attributes

# Description

What -
Why -
How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)