### PR TITLE
fix: bump _ai_agent prompt maxLength from 2500 to 5000

### DIFF
--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -16,6 +16,11 @@ jobs:
           go-version: '1.25'
           cache: true
       
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
       - name: Install tfplugindocs
         run: make setup
 

--- a/internal/consts/ai_agent.go
+++ b/internal/consts/ai_agent.go
@@ -1,0 +1,13 @@
+package consts
+
+const (
+	// SystemBlueprintAIAgentIdentifier is the Port system blueprint for AI agents.
+	SystemBlueprintAIAgentIdentifier = "_ai_agent"
+
+	// LegacyAIAgentPromptMaxLength was the previous maxLength shipped for long prompt
+	// fields on the AI agent blueprint before the API raised the limit.
+	LegacyAIAgentPromptMaxLength = 2500
+
+	// AIAgentPromptMaxLength matches the current Port API limit for AI agent prompt text.
+	AIAgentPromptMaxLength = 5000
+)

--- a/port/blueprint/ai_agent_prompt.go
+++ b/port/blueprint/ai_agent_prompt.go
@@ -1,0 +1,29 @@
+package blueprint
+
+import (
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/consts"
+)
+
+// NormalizeAIAgentPromptMaxLengths upgrades legacy maxLength on the _ai_agent
+// blueprint from 2500 to 5000 when sending updates to Port. The system blueprint
+// structure payload can still include the old cap while the API already accepts
+// longer prompts; without this, applies that only touch other fields can keep
+// resubmitting maxLength 2500 and block prompt values between 2501 and 5000 bytes.
+func NormalizeAIAgentPromptMaxLengths(blueprintIdentifier string, props map[string]cli.BlueprintProperty) {
+	if blueprintIdentifier != consts.SystemBlueprintAIAgentIdentifier || len(props) == 0 {
+		return
+	}
+	for id := range props {
+		prop := props[id]
+		if prop.Type != "" && prop.Type != "string" {
+			continue
+		}
+		if prop.MaxLength == nil || *prop.MaxLength != consts.LegacyAIAgentPromptMaxLength {
+			continue
+		}
+		ml := consts.AIAgentPromptMaxLength
+		prop.MaxLength = &ml
+		props[id] = prop
+	}
+}

--- a/port/blueprint/ai_agent_prompt_test.go
+++ b/port/blueprint/ai_agent_prompt_test.go
@@ -1,0 +1,47 @@
+package blueprint
+
+import (
+	"testing"
+
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/consts"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeAIAgentPromptMaxLengths(t *testing.T) {
+	t.Run("no op for other blueprints", func(t *testing.T) {
+		ml := consts.LegacyAIAgentPromptMaxLength
+		props := map[string]cli.BlueprintProperty{
+			"prompt": {Type: "string", MaxLength: &ml},
+		}
+		NormalizeAIAgentPromptMaxLengths("service", props)
+		require.Equal(t, consts.LegacyAIAgentPromptMaxLength, *props["prompt"].MaxLength)
+	})
+
+	t.Run("bumps legacy string maxLength on _ai_agent", func(t *testing.T) {
+		ml := consts.LegacyAIAgentPromptMaxLength
+		props := map[string]cli.BlueprintProperty{
+			"prompt": {Type: "string", MaxLength: &ml},
+		}
+		NormalizeAIAgentPromptMaxLengths(consts.SystemBlueprintAIAgentIdentifier, props)
+		require.Equal(t, consts.AIAgentPromptMaxLength, *props["prompt"].MaxLength)
+	})
+
+	t.Run("skips non string types", func(t *testing.T) {
+		ml := consts.LegacyAIAgentPromptMaxLength
+		props := map[string]cli.BlueprintProperty{
+			"count": {Type: "number", MaxLength: &ml},
+		}
+		NormalizeAIAgentPromptMaxLengths(consts.SystemBlueprintAIAgentIdentifier, props)
+		require.Equal(t, consts.LegacyAIAgentPromptMaxLength, *props["count"].MaxLength)
+	})
+
+	t.Run("does not change other maxLength values", func(t *testing.T) {
+		ml := 4096
+		props := map[string]cli.BlueprintProperty{
+			"other": {Type: "string", MaxLength: &ml},
+		}
+		NormalizeAIAgentPromptMaxLengths(consts.SystemBlueprintAIAgentIdentifier, props)
+		require.Equal(t, 4096, *props["other"].MaxLength)
+	})
+}

--- a/port/blueprint/resource.go
+++ b/port/blueprint/resource.go
@@ -422,6 +422,7 @@ func blueprintResourceToPortRequest(ctx context.Context, state *BlueprintModel) 
 			return nil, err
 		}
 	}
+	NormalizeAIAgentPromptMaxLengths(state.Identifier.ValueString(), props)
 
 	properties := props
 

--- a/port/system_blueprint/resource.go
+++ b/port/system_blueprint/resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/flex"
+	"github.com/port-labs/terraform-provider-port-labs/v2/port/blueprint"
 )
 
 func writeBlueprintComputedFieldsToState(b *cli.Blueprint, state *SystemBlueprintModel) {
@@ -248,6 +249,7 @@ func (r *Resource) mergeSystemBlueprint(ctx context.Context, state *SystemBluepr
 	if err != nil {
 		return nil, fmt.Errorf("error merging properties: %w", err)
 	}
+	blueprint.NormalizeAIAgentPromptMaxLengths(state.Identifier.ValueString(), props)
 
 	relations := MergeRelations(structure.Relations, state.Relations)
 	mirrorProps := MergeMirrorProperties(structure.MirrorProperties, state.MirrorProperties)


### PR DESCRIPTION
# Description

What - Bumps the `maxLength` for `_ai_agent` system blueprint string properties from the legacy value of 2500 to the current Port API limit of 5000.

Why - The Port API already accepts prompt values up to 5000 bytes, but the system blueprint structure can still carry the old `maxLength: 2500`. Any apply that re-sends this value will silently block prompts between 2501 and 5000 bytes. This fix normalises the value before the request is sent.

How - Adds `NormalizeAIAgentPromptMaxLengths` (called in both `blueprintResourceToPortRequest` and `mergeSystemBlueprint`) which rewrites `maxLength` 2500 → 5000 on string properties of the `_ai_agent` blueprint. Constants are centralised in `internal/consts/ai_agent.go`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

Made with [Cursor](https://cursor.com)