### PR TITLE
Handle rule_result_target system relations in _rule_result system blueprint merge/state

### DIFF
--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -445,6 +445,7 @@ type (
 		Target      *string `json:"target,omitempty"`
 		Required    *bool   `json:"required,omitempty"`
 		Many        *bool   `json:"many,omitempty"`
+		Type        *string `json:"type,omitempty"`
 	}
 
 	Scorecard struct {

--- a/port/system_blueprint/merge_utils.go
+++ b/port/system_blueprint/merge_utils.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	ruleResultTargetRelationType       = "rule_result_target"
+	ruleResultTargetRelationType        = "rule_result_target"
 	ruleResultSystemBlueprintIdentifier = "_rule_result"
 )
 
@@ -18,15 +18,15 @@ func RelationIsRuleResultTarget(r cli.Relation) bool {
 	return r.Type != nil && *r.Type == ruleResultTargetRelationType
 }
 
-func MergeRelationsForSystemBlueprint(blueprintIdentifier string, live, structure map[string]cli.Relation, state map[string]blueprint.RelationModel) map[string]cli.Relation {
+func MergeRelationsForSystemBlueprint(blueprintIdentifier string, currentRelations, structure map[string]cli.Relation, state map[string]blueprint.RelationModel) map[string]cli.Relation {
 	merged := MergeRelations(structure, state)
 	if blueprintIdentifier != ruleResultSystemBlueprintIdentifier {
 		return merged
 	}
-	if live == nil {
+	if currentRelations == nil {
 		return merged
 	}
-	for k, v := range live {
+	for k, v := range currentRelations {
 		if RelationIsRuleResultTarget(v) {
 			merged[k] = v
 		}

--- a/port/system_blueprint/merge_utils.go
+++ b/port/system_blueprint/merge_utils.go
@@ -9,6 +9,31 @@ import (
 	"github.com/port-labs/terraform-provider-port-labs/v2/port/blueprint"
 )
 
+const (
+	ruleResultTargetRelationType       = "rule_result_target"
+	ruleResultSystemBlueprintIdentifier = "_rule_result"
+)
+
+func RelationIsRuleResultTarget(r cli.Relation) bool {
+	return r.Type != nil && *r.Type == ruleResultTargetRelationType
+}
+
+func MergeRelationsForSystemBlueprint(blueprintIdentifier string, live, structure map[string]cli.Relation, state map[string]blueprint.RelationModel) map[string]cli.Relation {
+	merged := MergeRelations(structure, state)
+	if blueprintIdentifier != ruleResultSystemBlueprintIdentifier {
+		return merged
+	}
+	if live == nil {
+		return merged
+	}
+	for k, v := range live {
+		if RelationIsRuleResultTarget(v) {
+			merged[k] = v
+		}
+	}
+	return merged
+}
+
 func MergeProperties(ctx context.Context, existing map[string]cli.BlueprintProperty, state *blueprint.PropertiesModel) (map[string]cli.BlueprintProperty, []string, error) {
 	merged := make(map[string]cli.BlueprintProperty)
 	for k, v := range existing {

--- a/port/system_blueprint/merge_utils_test.go
+++ b/port/system_blueprint/merge_utils_test.go
@@ -1,0 +1,173 @@
+package system_blueprint
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
+	"github.com/port-labs/terraform-provider-port-labs/v2/port/blueprint"
+)
+
+func ptr(s string) *string { return &s }
+
+func TestRelationIsRuleResultTarget(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		r    cli.Relation
+		want bool
+	}{
+		{name: "nil type", r: cli.Relation{Type: nil}, want: false},
+		{name: "empty type string", r: cli.Relation{Type: ptr("")}, want: false},
+		{name: "other type", r: cli.Relation{Type: ptr("other")}, want: false},
+		{name: "rule_result_target", r: cli.Relation{Type: ptr("rule_result_target")}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := RelationIsRuleResultTarget(tt.r); got != tt.want {
+				t.Fatalf("RelationIsRuleResultTarget(%#v) = %v, want %v", tt.r, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeRelationsForSystemBlueprint_nilLive(t *testing.T) {
+	structure := map[string]cli.Relation{
+		"rule": {Title: ptr("Rule"), Target: ptr("_rule")},
+	}
+	state := map[string]blueprint.RelationModel{
+		"vm": {Target: types.StringValue("microservice"), Title: types.StringValue("VM")},
+	}
+	got := MergeRelationsForSystemBlueprint("_team", nil, structure, state)
+	if got["rule"].Target == nil || *got["rule"].Target != "_rule" {
+		t.Fatalf("rule from structure: %#v", got["rule"])
+	}
+	if got["vm"].Target == nil || *got["vm"].Target != "microservice" {
+		t.Fatalf("vm from state: %#v", got["vm"])
+	}
+}
+
+func TestMergeRelationsForSystemBlueprint_stateAndLiveRuleResultTargets(t *testing.T) {
+	live := map[string]cli.Relation{
+		"_Env": {
+			Title:  ptr("Env"),
+			Target: ptr("Env"),
+			Type:   ptr("rule_result_target"),
+		},
+	}
+	structure := map[string]cli.Relation{
+		"rule": {Title: ptr("Rule"), Target: ptr("_rule")},
+	}
+	state := map[string]blueprint.RelationModel{
+		"vm": {Target: types.StringValue("microservice"), Title: types.StringValue("VM")},
+	}
+	got := MergeRelationsForSystemBlueprint("_rule_result", live, structure, state)
+	if got["_Env"].Type == nil || *got["_Env"].Type != "rule_result_target" {
+		t.Fatalf("expected _Env from live, got %#v", got["_Env"])
+	}
+	if got["vm"].Target == nil || *got["vm"].Target != "microservice" {
+		t.Fatalf("expected vm from state, got %#v", got["vm"])
+	}
+	if got["rule"].Target == nil || *got["rule"].Target != "_rule" {
+		t.Fatalf("expected rule from structure, got %#v", got["rule"])
+	}
+}
+
+func TestMergeRelationsForSystemBlueprint_nonRuleResultBlueprintIgnoresLiveRuleResultTarget(t *testing.T) {
+	live := map[string]cli.Relation{
+		"_Env": {
+			Title:  ptr("Env"),
+			Target: ptr("Env"),
+			Type:   ptr("rule_result_target"),
+		},
+	}
+	structure := map[string]cli.Relation{
+		"rule": {Title: ptr("Rule"), Target: ptr("_rule")},
+	}
+
+	got := MergeRelationsForSystemBlueprint("_team", live, structure, nil)
+	if _, ok := got["_Env"]; ok {
+		t.Fatalf("expected _Env to be ignored for non _rule_result blueprint, got %#v", got["_Env"])
+	}
+}
+
+func TestMergeRelationsForSystemBlueprint_preservesRuleResultTargetRelations(t *testing.T) {
+	live := map[string]cli.Relation{
+		"rule": {
+			Title:  ptr("Rule"),
+			Target: ptr("_rule"),
+		},
+		"service_0b8f289d-2d70-4caa-856b-0af1d5e24f3a": {
+			Title:  ptr("Service"),
+			Target: ptr("service"),
+			Type:   ptr("rule_result_target"),
+		},
+		"artifact": {
+			Title:  ptr("Artifact"),
+			Target: ptr("artifact"),
+			Type:   ptr("rule_result_target"),
+		},
+	}
+	structure := map[string]cli.Relation{
+		"rule": {
+			Title:  ptr("Rule"),
+			Target: ptr("_rule"),
+		},
+	}
+	got := MergeRelationsForSystemBlueprint("_rule_result", live, structure, nil)
+	if got["rule"].Target == nil || *got["rule"].Target != "_rule" {
+		t.Fatalf("expected rule from structure, got %#v", got["rule"])
+	}
+	for _, key := range []string{"service_0b8f289d-2d70-4caa-856b-0af1d5e24f3a", "artifact"} {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("expected live relation %q to be preserved, got keys: %v", key, keysOf(got))
+		}
+		if got[key].Type == nil || *got[key].Type != "rule_result_target" {
+			t.Fatalf("expected type rule_result_target on preserved relation %q", key)
+		}
+	}
+}
+
+func TestMergeRelationsForSystemBlueprint_liveWinsForRuleResultTargetType(t *testing.T) {
+	live := map[string]cli.Relation{
+		"svc_custom_key": {
+			Target: ptr("from-live"),
+			Type:   ptr("rule_result_target"),
+		},
+	}
+	structure := map[string]cli.Relation{
+		"svc_custom_key": {
+			Target: ptr("from-structure"),
+		},
+	}
+	got := MergeRelationsForSystemBlueprint("_rule_result", live, structure, nil)
+	if got["svc_custom_key"].Target == nil || *got["svc_custom_key"].Target != "from-live" {
+		t.Fatalf("expected live relation to overwrite merged for rule_result_target type, got %#v", got["svc_custom_key"])
+	}
+}
+
+func TestMergeRelationsForSystemBlueprint_doesNotPreserveUntypedUUIDKey(t *testing.T) {
+	live := map[string]cli.Relation{
+		"svc_11111111-1111-4111-8111-111111111111": {
+			Target: ptr("from-live"),
+		},
+	}
+	structure := map[string]cli.Relation{
+		"svc_11111111-1111-4111-8111-111111111111": {
+			Target: ptr("from-structure"),
+		},
+	}
+	got := MergeRelationsForSystemBlueprint("_rule_result", live, structure, nil)
+	if got["svc_11111111-1111-4111-8111-111111111111"].Target == nil || *got["svc_11111111-1111-4111-8111-111111111111"].Target != "from-structure" {
+		t.Fatalf("without type rule_result_target, structure merge should win, got %#v", got["svc_11111111-1111-4111-8111-111111111111"])
+	}
+}
+
+func keysOf(m map[string]cli.Relation) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/port/system_blueprint/resource.go
+++ b/port/system_blueprint/resource.go
@@ -249,7 +249,7 @@ func (r *Resource) mergeSystemBlueprint(ctx context.Context, state *SystemBluepr
 		return nil, fmt.Errorf("error merging properties: %w", err)
 	}
 
-	relations := MergeRelations(structure.Relations, state.Relations)
+	relations := MergeRelationsForSystemBlueprint(existingBp.Identifier, existingBp.Relations, structure.Relations, state.Relations)
 	mirrorProps := MergeMirrorProperties(structure.MirrorProperties, state.MirrorProperties)
 	calcProps := MergeCalculationProperties(ctx, structure.CalculationProperties, state.CalculationProperties)
 

--- a/port/system_blueprint/updatePropertiesToState.go
+++ b/port/system_blueprint/updatePropertiesToState.go
@@ -115,6 +115,9 @@ func (r *Resource) updatePropertiesToState(ctx context.Context, b *cli.Blueprint
 
 func addRelationsToState(b *cli.Blueprint, systemBp *cli.Blueprint, bm *SystemBlueprintModel) {
 	for k, v := range b.Relations {
+		if b.Identifier == ruleResultSystemBlueprintIdentifier && RelationIsRuleResultTarget(v) {
+			continue
+		}
 		// Skip if the relation exists in systemBp
 		if systemBp != nil {
 			if _, exists := systemBp.Relations[k]; exists {

--- a/port/system_blueprint/updatePropertiesToState_test.go
+++ b/port/system_blueprint/updatePropertiesToState_test.go
@@ -1,0 +1,63 @@
+package system_blueprint
+
+import (
+	"testing"
+
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
+)
+
+func TestAddRelationsToState_skipsRuleResultTargetRelations(t *testing.T) {
+	envTarget := "Env"
+	vmTarget := "microservice"
+	b := &cli.Blueprint{
+		Identifier: "_rule_result",
+		Relations: map[string]cli.Relation{
+			"_Env": {
+				Title:  ptr("Env"),
+				Target: &envTarget,
+				Type:   ptr("rule_result_target"),
+			},
+			"vm": {
+				Title:  ptr("VM"),
+				Target: &vmTarget,
+			},
+		},
+	}
+	systemBp := &cli.Blueprint{Relations: map[string]cli.Relation{}}
+	bm := &SystemBlueprintModel{}
+
+	addRelationsToState(b, systemBp, bm)
+
+	if _, ok := bm.Relations["_Env"]; ok {
+		t.Fatal("rule_result_target relation _Env must not be written to Terraform state")
+	}
+	rm, ok := bm.Relations["vm"]
+	if !ok {
+		t.Fatal("expected vm relation in state")
+	}
+	if rm.Target.ValueString() != "microservice" {
+		t.Fatalf("vm target: got %q", rm.Target.ValueString())
+	}
+}
+
+func TestAddRelationsToState_nonRuleResultBlueprintKeepsRuleResultTargetRelations(t *testing.T) {
+	envTarget := "Env"
+	b := &cli.Blueprint{
+		Identifier: "_team",
+		Relations: map[string]cli.Relation{
+			"_Env": {
+				Title:  ptr("Env"),
+				Target: &envTarget,
+				Type:   ptr("rule_result_target"),
+			},
+		},
+	}
+	systemBp := &cli.Blueprint{Relations: map[string]cli.Relation{}}
+	bm := &SystemBlueprintModel{}
+
+	addRelationsToState(b, systemBp, bm)
+
+	if _, ok := bm.Relations["_Env"]; !ok {
+		t.Fatal("rule_result_target relation should be kept for non _rule_result blueprints")
+	}
+}


### PR DESCRIPTION

- Added Type to cli.Relation so relation type is parsed from API responses.
- Updated system blueprint relation merge/state logic to treat rule_result_target as Port-managed only for _rule_result:
  - re-inject live rule_result_target relations during merge/apply for _rule_result
  - skip writing those relations to Terraform state for _rule_result
- Added/updated unit tests covering:
  - relation type detection
  - merge behavior with live/structure/state inputs
  - _rule_result-scoped skip/keep behavior in state mapping
 
## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)