### PR TITLE
Fix broken documentation links

### DIFF
--- a/docs/resources/folder.md
+++ b/docs/resources/folder.md
@@ -4,7 +4,7 @@ page_title: "port_folder Resource - port"
 subcategory: ""
 description: |-
   Folder resource
-  A full list of the available folder types and their identifiers can be found here https://docs.getport.io/customize-pages-dashboards-and-plugins/folder/catalog-folder.
+  For more information about folders, see the Port documentation https://docs.port.io/customize-pages-dashboards-and-plugins/page/folders#folder-identifiers.
   ~> WARNING
   The folder resource is currently in beta and is subject to change in future versions.
   Use it by setting the Environment Variable PORT_BETA_FEATURES_ENABLED=true.
@@ -45,7 +45,7 @@ description: |-
 
 # Folder resource
 
-A full list of the available folder types and their identifiers can be found [here](https://docs.getport.io/customize-pages-dashboards-and-plugins/folder/catalog-folder).
+For more information about folders, see the [Port documentation](https://docs.port.io/customize-pages-dashboards-and-plugins/page/folders#folder-identifiers).
 
 ~> **WARNING**
 The folder resource is currently in beta and is subject to change in future versions.

--- a/docs/resources/page.md
+++ b/docs/resources/page.md
@@ -5,7 +5,7 @@ subcategory: ""
 description: |-
   Page resource
   A full list of the available page types and their identifiers can be found here https://docs.getport.io/customize-pages-dashboards-and-plugins/page/catalog-page.
-  A full list of widget types and their identifiers can be found here https://docs.getport.io/customize-pages-dashboards-and-plugins/dashboards/#widget-type-identifiers-terraform.
+  Widget type identifiers are divided by type: Data widgets https://docs.port.io/customize-pages-dashboards-and-plugins/dashboards/data-widgets#widget-type-identifiers-terraform, Custom widgets https://docs.port.io/customize-pages-dashboards-and-plugins/dashboards/custom-widgets#widget-type-identifiers-terraform, and Personal widgets https://docs.port.io/customize-pages-dashboards-and-plugins/dashboards/personal-widgets#widget-type-identifiers-terraform.
   ~> WARNING
   The page resource is currently in beta and is subject to change in future versions.
   Use it by setting the Environment Variable PORT_BETA_FEATURES_ENABLED=true.
@@ -223,7 +223,7 @@ description: |-
 
 A full list of the available page types and their identifiers can be found [here](https://docs.getport.io/customize-pages-dashboards-and-plugins/page/catalog-page).
 
-A full list of widget types and their identifiers can be found [here](https://docs.getport.io/customize-pages-dashboards-and-plugins/dashboards/#widget-type-identifiers-terraform).
+Widget type identifiers are divided by type: [Data widgets](https://docs.port.io/customize-pages-dashboards-and-plugins/dashboards/data-widgets#widget-type-identifiers-terraform), [Custom widgets](https://docs.port.io/customize-pages-dashboards-and-plugins/dashboards/custom-widgets#widget-type-identifiers-terraform), and [Personal widgets](https://docs.port.io/customize-pages-dashboards-and-plugins/dashboards/personal-widgets#widget-type-identifiers-terraform).
 
 ~> **WARNING**
 The page resource is currently in beta and is subject to change in future versions.

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -142,7 +142,7 @@ description: |-
   
   
   Notes
-  When using object format for relations, combinator, property and operator fields should be enclosed in single quotes, while value should not have quotes as it's a JQ expression. The single quotes are required because these fields contain literal string values that must be passed as-is to the Port API, whereas value contains a JQ expression that should be evaluated dynamically.The identifier field supports both simple JQ expressions (strings) and complex search query objects. When using search query objects, the structure must include combinator and rules fields, and each rule must have property, operator, and value fields. For all available operators, see the Port comparison operators documentation https://docs.port.io/search-and-query/operators/comparison-operators.
+  When using object format for relations, combinator, property and operator fields should be enclosed in single quotes, while value should not have quotes as it's a JQ expression. The single quotes are required because these fields contain literal string values that must be passed as-is to the Port API, whereas value contains a JQ expression that should be evaluated dynamically.The identifier field supports both simple JQ expressions (strings) and complex search query objects. When using search query objects, the structure must include combinator and rules fields, and each rule must have property, operator, and value fields.For all available operators, see the Port comparison operators documentation https://docs.port.io/search-and-query/operators/comparison-operators.
 ---
 
 # port_webhook (Resource)

--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -142,7 +142,7 @@ description: |-
   
   
   Notes
-  When using object format for relations, combinator, property and operator fields should be enclosed in single quotes, while value should not have quotes as it's a JQ expression. The single quotes are required because these fields contain literal string values that must be passed as-is to the Port API, whereas value contains a JQ expression that should be evaluated dynamically.The identifier field supports both simple JQ expressions (strings) and complex search query objects. When using search query objects, the structure must include combinator and rules fields, and each rule must have property, operator, and value fields.For all available operators, see the Port comparison operators documentation https://docs.port.io/search-and-query/comparison-operators.
+  When using object format for relations, combinator, property and operator fields should be enclosed in single quotes, while value should not have quotes as it's a JQ expression. The single quotes are required because these fields contain literal string values that must be passed as-is to the Port API, whereas value contains a JQ expression that should be evaluated dynamically.The identifier field supports both simple JQ expressions (strings) and complex search query objects. When using search query objects, the structure must include combinator and rules fields, and each rule must have property, operator, and value fields. For all available operators, see the Port comparison operators documentation https://docs.port.io/search-and-query/operators/comparison-operators.
 ---
 
 # port_webhook (Resource)
@@ -292,7 +292,7 @@ resource "port_blueprint" "author" {
 
 - When using object format for relations, `combinator`, `property` and `operator` fields should be enclosed in single quotes, while `value` should not have quotes as it's a JQ expression. The single quotes are required because these fields contain literal string values that must be passed as-is to the Port API, whereas `value` contains a JQ expression that should be evaluated dynamically.
 - The `identifier` field supports both simple JQ expressions (strings) and complex search query objects. When using search query objects, the structure must include `combinator` and `rules` fields, and each rule must have `property`, `operator`, and `value` fields.
-- For all available operators, see the [Port comparison operators documentation](https://docs.port.io/search-and-query/comparison-operators).
+- For all available operators, see the [Port comparison operators documentation](https://docs.port.io/search-and-query/operators/comparison-operators).
 
 
 

--- a/port/folder/schema.go
+++ b/port/folder/schema.go
@@ -60,7 +60,7 @@ var FolderResourceMarkdownDescription = `
 
 # Folder resource
 
-A full list of the available folder types and their identifiers can be found [here](https://docs.getport.io/customize-pages-dashboards-and-plugins/folder/catalog-folder).
+For more information about folders, see the [Port documentation](https://docs.port.io/customize-pages-dashboards-and-plugins/page/folders#folder-identifiers).
 
 ~> **WARNING**
 The folder resource is currently in beta and is subject to change in future versions.

--- a/port/page/schema.go
+++ b/port/page/schema.go
@@ -124,7 +124,7 @@ var PageResourceMarkdownDescription = `
 
 A full list of the available page types and their identifiers can be found [here](https://docs.getport.io/customize-pages-dashboards-and-plugins/page/catalog-page).
 
-A full list of widget types and their identifiers can be found [here](https://docs.getport.io/customize-pages-dashboards-and-plugins/dashboards/#widget-type-identifiers-terraform).
+Widget type identifiers are divided by type: [Data widgets](https://docs.port.io/customize-pages-dashboards-and-plugins/dashboards/data-widgets#widget-type-identifiers-terraform), [Custom widgets](https://docs.port.io/customize-pages-dashboards-and-plugins/dashboards/custom-widgets#widget-type-identifiers-terraform), and [Personal widgets](https://docs.port.io/customize-pages-dashboards-and-plugins/dashboards/personal-widgets#widget-type-identifiers-terraform).
 
 ~> **WARNING**
 The page resource is currently in beta and is subject to change in future versions.

--- a/port/webhook/schema.go
+++ b/port/webhook/schema.go
@@ -333,6 +333,6 @@ resource "port_blueprint" "author" {
 
 - When using object format for relations, ` + "`combinator`, `property`" + ` and ` + "`operator`" + ` fields should be enclosed in single quotes, while ` + "`value`" + ` should not have quotes as it's a JQ expression. The single quotes are required because these fields contain literal string values that must be passed as-is to the Port API, whereas ` + "`value`" + ` contains a JQ expression that should be evaluated dynamically.
 - The ` + "`identifier`" + ` field supports both simple JQ expressions (strings) and complex search query objects. When using search query objects, the structure must include ` + "`combinator`" + ` and ` + "`rules`" + ` fields, and each rule must have ` + "`property`" + `, ` + "`operator`" + `, and ` + "`value`" + ` fields.
-- For all available operators, see the [Port comparison operators documentation](https://docs.port.io/search-and-query/comparison-operators).
+- For all available operators, see the [Port comparison operators documentation](https://docs.port.io/search-and-query/operators/comparison-operators).
 
 `


### PR DESCRIPTION
Replace outdated/broken docs.getport.io links with correct docs.port.io URLs for widget type identifiers (now split by type), comparison operators, and folders. Also update the folder resource description to be more accurate.

# Description

What -
Why -
How -

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)