### PR TITLE
Update Terraform requirements and installation instructions in docume…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           version: v2.8.0
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: 1.2.6
+          terraform_version: "1.7.0"
           terraform_wrapper: false
       - name: Setup tools
         run: make setup

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,7 @@ _This will create a shell where all required tools are installed._
 If you don't want to use `devbox`:
 
 - Have [golang](https://go.dev/doc/install) installed
+- Have [Terraform](https://developer.hashicorp.com/terraform/install) installed (same minimum as [README](README.md#requirements))
 - Have `wget` installed
 - Run `make dev-setup`
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Port is the Developer Platform meant to supercharge your DevOps and Developers, 
 
 ## Requirements
 
-- [Terraform](https://www.terraform.io/downloads.html)
+- [Terraform](https://www.terraform.io/downloads.html) ≥ 1.7.0, or ≥ 1.6.7 on 1.6.x, or ≥ 1.5.7 on 1.5.x (older patches can panic on `plan -generate-config-out` with imports).
 - [Go](https://golang.org/doc/install) >= 1.24 (to build the provider plugin)
 - [Port Credentials](https://docs.getport.io/build-your-software-catalog/sync-data-to-catalog/api/#find-your-port-credentials)
 


### PR DESCRIPTION
## Summary

Document minimum Terraform CLI versions for stable use of **`terraform plan -generate-config-out`** with **import** workflows, bump CI’s Terraform pin, and point contributors at the same guidance.

## Root cause (upstream)

Older Terraform releases could **panic** (`nil pointer dereference` in `configschema.(*Block).Filter`) while generating configuration for Plugin Framework resources that use **empty nested object** shapes in their schema. This showed up for users onboarding with import blocks and `-generate-config-out`.

- **Bug report:** [hashicorp/terraform#34463 — `terraform plan -generate-config-out` crashed Terraform due to a nil pointer dereference when using import blocks](https://github.com/hashicorp/terraform/issues/34463)
- **Fix:** [hashicorp/terraform#34472 — `Block.Filter` can panic with a nested object which has no attributes](https://github.com/hashicorp/terraform/pull/34472)

## What we document

Use Terraform **≥ 1.7.0**, or **≥ 1.6.7** on the 1.6 line, or **≥ 1.5.7** on the 1.5 line, if you rely on **`plan -generate-config-out` with imports** (older patch releases in those lines may still hit the crash).

## Changes

- **README** — Clarify Terraform version guidance in **Requirements** (no contradictory `required_version` in the install snippet).
- **CONTRIBUTING** — Manual setup links to README **Requirements**.
- **CI** — `setup-terraform` **1.2.6 → 1.7.0** for the lint job.

## Testing

- [ ] CI passes

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)