### PR TITLE
Update approval_email_notification documentation for clarity and completeness

### DIFF
--- a/docs/resources/action.md
+++ b/docs/resources/action.md
@@ -394,7 +394,7 @@ resource "port_action" "myAction" {
 ### Optional
 
 - `allow_anyone_to_view_runs` (Boolean) Whether members can view the runs of this action
-- `approval_email_notification` (Object) The email notification of the approval (see [below for nested schema](#nestedatt--approval_email_notification))
+- `approval_email_notification` (Object) The email notification of the approval. This is a presence-based block — defining it enables email notifications for approval; no nested attributes are required. (see [below for nested schema](#nestedatt--approval_email_notification))
 - `approval_webhook_notification` (Attributes) The webhook notification of the approval (see [below for nested schema](#nestedatt--approval_webhook_notification))
 - `automation_trigger` (Attributes) Automation trigger for the action (see [below for nested schema](#nestedatt--automation_trigger))
 - `azure_method` (Attributes) Azure DevOps invocation method (see [below for nested schema](#nestedatt--azure_method))

--- a/port/action/schema.go
+++ b/port/action/schema.go
@@ -620,7 +620,7 @@ func ActionSchema() map[string]schema.Attribute {
 			},
 		},
 		"approval_email_notification": schema.ObjectAttribute{
-			MarkdownDescription: "The email notification of the approval",
+			MarkdownDescription: "The email notification of the approval. This is a presence-based block — defining it enables email notifications for approval; no nested attributes are required.",
 			Optional:            true,
 			AttributeTypes:      map[string]attr.Type{},
 			Validators: []validator.Object{


### PR DESCRIPTION
# Description

What - The `approval_email_notification` nested schema section in Terraform registry docs appears empty/broken, making it look like documentation is missing.

Why - Users see "Nested Schema for `approval_email_notification`" followed by nothing, which is confusing. The block is presence-based (no nested attributes needed), but this isn't communicated.

How - Updated the `MarkdownDescription` in the schema definition to explicitly state that this is a presence-based block requiring no nested attributes, then regenerated docs with `make gen-docs`.

## Type of change

- [x] Documentation (added/updated documentation)