### PR TITLE
fix: refresh widgets and page_filters into state after Create/Update

### DIFF
--- a/port/page/refreshPageToState.go
+++ b/port/page/refreshPageToState.go
@@ -25,6 +25,7 @@ func (r *PageResource) refreshPageToState(pm *PageModel, b *cli.Page) error {
 
 	if b.Widgets != nil {
 		widgetAttrs := make([]attr.Value, len(*b.Widgets))
+		// go over each widget and convert it to a string and store it in the widgets array
 		for i, widget := range *b.Widgets {
 			bWidget, err := utils.GoObjectToTerraformString(widget, r.portClient.JSONEscapeHTML)
 			if err != nil {
@@ -39,6 +40,7 @@ func (r *PageResource) refreshPageToState(pm *PageModel, b *cli.Page) error {
 
 	if b.PageFilters != nil {
 		filterAttrs := make([]attr.Value, len(*b.PageFilters))
+		// go over each page filter and convert it to a string and store it in the page filters array
 		for i, pageFilter := range *b.PageFilters {
 			bFilter, err := utils.GoObjectToTerraformString(pageFilter, r.portClient.JSONEscapeHTML)
 			if err != nil {

--- a/port/page/refreshPageToState.go
+++ b/port/page/refreshPageToState.go
@@ -18,10 +18,13 @@ func (r *PageResource) refreshPageToState(pm *PageModel, b *cli.Page) error {
 	pm.Locked = types.BoolPointerValue(b.Locked)
 	pm.Blueprint = types.StringPointerValue(b.Blueprint)
 	pm.Description = types.StringPointerValue(b.Description)
+	pm.CreatedAt = types.StringValue(b.CreatedAt.String())
+	pm.CreatedBy = types.StringValue(b.CreatedBy)
+	pm.UpdatedAt = types.StringValue(b.UpdatedAt.String())
+	pm.UpdatedBy = types.StringValue(b.UpdatedBy)
 
 	if b.Widgets != nil {
 		widgetAttrs := make([]attr.Value, len(*b.Widgets))
-		// go over each widget and convert it to a string and store it in the widgets array
 		for i, widget := range *b.Widgets {
 			bWidget, err := utils.GoObjectToTerraformString(widget, r.portClient.JSONEscapeHTML)
 			if err != nil {
@@ -36,7 +39,6 @@ func (r *PageResource) refreshPageToState(pm *PageModel, b *cli.Page) error {
 
 	if b.PageFilters != nil {
 		filterAttrs := make([]attr.Value, len(*b.PageFilters))
-		// go over each page filter and convert it to a string and store it in the page filters array
 		for i, pageFilter := range *b.PageFilters {
 			bFilter, err := utils.GoObjectToTerraformString(pageFilter, r.portClient.JSONEscapeHTML)
 			if err != nil {

--- a/port/page/resource.go
+++ b/port/page/resource.go
@@ -149,11 +149,12 @@ func (r *PageResource) Create(ctx context.Context, req resource.CreateRequest, r
 		}
 
 		state.ID = types.StringValue(p.Identifier)
-		state.CreatedAt = types.StringValue(updatedPage.CreatedAt.String())
-		state.CreatedBy = types.StringValue(updatedPage.CreatedBy)
-		state.UpdatedAt = types.StringValue(updatedPage.UpdatedAt.String())
-		state.UpdatedBy = types.StringValue(updatedPage.UpdatedBy)
-		state.Description = types.StringPointerValue(updatedPage.Description)
+
+		err = r.refreshPageToState(state, updatedPage)
+		if err != nil {
+			resp.Diagnostics.AddError("failed to write updated page fields to resource", err.Error())
+			return
+		}
 
 		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
 		return
@@ -226,12 +227,12 @@ func (r *PageResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	state.ID = types.StringValue(p.Identifier)
-	state.CreatedAt = types.StringValue(updatedPage.CreatedAt.String())
-	state.CreatedBy = types.StringValue(updatedPage.CreatedBy)
-	state.UpdatedAt = types.StringValue(updatedPage.UpdatedAt.String())
-	state.UpdatedBy = types.StringValue(updatedPage.UpdatedBy)
-	state.Description = types.StringPointerValue(updatedPage.Description)
+
+	err = r.refreshPageToState(state, updatedPage)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to write updated page fields to resource", err.Error())
+		return
+	}
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
-
 }


### PR DESCRIPTION
## Problem

After a `Create` or `Update`, the provider fetches the page back from Port (`GetPage`) but only copies metadata fields (`CreatedAt`, `UpdatedBy`, etc.) into state — `widgets` and `page_filters` are left as the plan values (what Terraform sent). Port may normalize the JSON key/array ordering of these fields on write, so state diverges from what Port actually stored. The next `terraform plan` compares the config against Port's normalized response and always shows a diff, even though no real change occurred — causing perpetual drift.

## Root cause

Both `Update()` and the entity-page path of `Create()` already call `GetPage` after writing and store the response in `updatedPage`, but then only copy a handful of metadata fields and discard the widget content:

```go
// existing code — widgets from updatedPage are ignored
state.CreatedAt = types.StringValue(updatedPage.CreatedAt.String())
// ...
resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
```

`Read()` already correctly calls `refreshPageToState(state, p)` which handles all fields including `widgets` and `page_filters`. This fix applies the same pattern in `Update` and the entity-page path of `Create`.

## Fix

Replace the manual metadata-only copy in `Update()` and the entity-page `Create()` path with `refreshPageToState(state, updatedPage)`, which already exists and correctly serializes all fields from the Port API response into state.

This ensures state always reflects what Port actually stored after a write, so the next plan compares config against Port's own normalized form rather than the original plan values.

## Impact

- No change to what is sent to Port — only what is stored in Terraform state after a write
- Makes `Update` and `Create` consistent with `Read`, which already does this correctly
- Fixes perpetual diffs on `widgets` and `page_filters` caused by Port normalizing JSON ordering on write