### PR TITLE
Add SaaS integration support with async provisioning polling

### DIFF
--- a/internal/cli/integration.go
+++ b/internal/cli/integration.go
@@ -11,7 +11,7 @@ type PortBodyForIntegration struct {
 	Integration Integration `json:"integration"`
 }
 
-func (c *PortClient) GetIntegration(ctx context.Context, id string) (*Integration, error) {
+func (c *PortClient) GetIntegration(ctx context.Context, id string) (*Integration, int, error) {
 	pb := &PortBodyForIntegration{}
 	url := "v1/integration/{identifier}"
 	resp, err := c.Client.R().
@@ -22,12 +22,12 @@ func (c *PortClient) GetIntegration(ctx context.Context, id string) (*Integratio
 		SetQueryParam("byField", "installationId").
 		Get(url)
 	if err != nil {
-		return nil, err
+		return nil, resp.StatusCode(), err
 	}
 	if !pb.OK {
-		return nil, fmt.Errorf("failed to read migration, got: %s", resp.Body())
+		return nil, resp.StatusCode(), fmt.Errorf("failed to read integration, got: %s", resp.Body())
 	}
-	return &pb.Integration, nil
+	return &pb.Integration, resp.StatusCode(), nil
 }
 
 func (c *PortClient) UpdateIntegration(ctx context.Context, id string, integration *Integration) (*Integration, error) {

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -749,12 +749,23 @@ type PortBodyDelete struct {
 }
 
 type Integration struct {
-	InstallationId       string                `json:"installationId"`
-	Title                *string               `json:"title"`
-	InstallationAppType  *string               `json:"installationAppType"`
-	Version              *string               `json:"version"`
-	Config               *map[string]any       `json:"config"`
-	ChangelogDestination *ChangelogDestination `json:"changelogDestination,omitempty"`
+	InstallationId       string                 `json:"installationId"`
+	Title                *string                `json:"title"`
+	InstallationAppType  *string                `json:"installationAppType"`
+	InstallationType     *string                `json:"installationType,omitempty"`
+	Version              *string                `json:"version"`
+	Config               *map[string]any        `json:"config"`
+	ChangelogDestination *ChangelogDestination  `json:"changelogDestination,omitempty"`
+	StatusInfo           *IntegrationStatusInfo `json:"statusInfo,omitempty"`
+}
+
+type IntegrationStatusInfo struct {
+	IntegrationStatus IntegrationStatus `json:"integrationStatus"`
+}
+
+type IntegrationStatus struct {
+	Status  string  `json:"status"`
+	Message *string `json:"message,omitempty"`
 }
 
 type Organization struct {

--- a/internal/consts/provider.go
+++ b/internal/consts/provider.go
@@ -21,4 +21,13 @@ const (
 	RunUpdated           = "RUN_UPDATED"
 	AnyRunChange         = "ANY_RUN_CHANGE"
 	JqCondition          = "JQ"
+
+	InstallationTypeOnPrem = "OnPrem"
+	InstallationTypeSaas   = "Saas"
+
+	IntegrationStatusCreating = "Creating"
+	IntegrationStatusUpdating = "Updating"
+	IntegrationStatusDeleting = "Deleting"
+	IntegrationStatusDeleted  = "Deleted"
+	IntegrationStatusError    = "Error"
 )

--- a/port/integration/integrationToPortBody.go
+++ b/port/integration/integrationToPortBody.go
@@ -31,6 +31,7 @@ func integrationToPortBody(state *IntegrationModel) (*cli.Integration, error) {
 	integration.Title = state.Title.ValueStringPointer()
 	integration.Version = state.Version.ValueStringPointer()
 	integration.InstallationAppType = state.InstallationAppType.ValueStringPointer()
+	integration.InstallationType = state.InstallationType.ValueStringPointer()
 
 	if !state.Config.IsNull() {
 		configStr := state.Config.ValueString()

--- a/port/integration/model.go
+++ b/port/integration/model.go
@@ -11,6 +11,7 @@ type IntegrationModel struct {
 	ID                          types.String                      `tfsdk:"id"`
 	InstallationId              types.String                      `tfsdk:"installation_id"`
 	InstallationAppType         types.String                      `tfsdk:"installation_app_type"`
+	InstallationType            types.String                      `tfsdk:"installation_type"`
 	Title                       types.String                      `tfsdk:"title"`
 	Version                     types.String                      `tfsdk:"version"`
 	Config                      types.String                      `tfsdk:"config"`

--- a/port/integration/refreshIntegrationToState.go
+++ b/port/integration/refreshIntegrationToState.go
@@ -13,6 +13,7 @@ func (r *IntegrationResource) refreshIntegrationState(state *IntegrationModel, a
 
 	state.Title = types.StringPointerValue(a.Title)
 	state.InstallationAppType = types.StringPointerValue(a.InstallationAppType)
+	state.InstallationType = types.StringPointerValue(a.InstallationType)
 	state.Version = types.StringPointerValue(a.Version)
 
 	if a.Config != nil {

--- a/port/integration/resource.go
+++ b/port/integration/resource.go
@@ -2,11 +2,59 @@ package integration
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/consts"
 )
+
+// SaaS-provisioned integrations (installation_type = Saas) run through an async pipeline in
+// Port (the integration record moves Creating/Updating/Deleting -> a terminal status while the
+// underlying Ocean workload is rolled out/torn down). We poll until that settles so `apply`/
+// `destroy` only report success once the integration is actually usable/gone, mirroring the
+// polling Ocean itself does for provisioned defaults.
+const (
+	saasStatusPollInterval = 5 * time.Second
+	saasStatusPollMaxTries = 60 // ~5 minutes
+)
+
+func isSaasInstallation(state *IntegrationModel) bool {
+	return state.InstallationType.ValueString() == consts.InstallationTypeSaas
+}
+
+// waitForSaasIntegrationSettled polls the integration until its status leaves the given
+// in-progress state, returning the final integration or an error if it lands on Error or the
+// poll times out.
+func (r *IntegrationResource) waitForSaasIntegrationSettled(ctx context.Context, installationId string, inProgressStatus string) (*cli.Integration, error) {
+	for i := 0; i < saasStatusPollMaxTries; i++ {
+		integration, statusCode, err := r.portClient.GetIntegration(ctx, installationId)
+		if err != nil {
+			if statusCode == http.StatusNotFound && inProgressStatus == consts.IntegrationStatusDeleting {
+				return nil, nil
+			}
+			return nil, err
+		}
+
+		if integration.StatusInfo == nil || integration.StatusInfo.IntegrationStatus.Status != inProgressStatus {
+			if integration.StatusInfo != nil && integration.StatusInfo.IntegrationStatus.Status == consts.IntegrationStatusError {
+				message := "no additional details"
+				if integration.StatusInfo.IntegrationStatus.Message != nil {
+					message = *integration.StatusInfo.IntegrationStatus.Message
+				}
+				return nil, fmt.Errorf("integration %q entered Error status: %s", installationId, message)
+			}
+			return integration, nil
+		}
+
+		time.Sleep(saasStatusPollInterval)
+	}
+
+	return nil, fmt.Errorf("timed out waiting for integration %q to leave %q status after %s", installationId, inProgressStatus, saasStatusPollMaxTries*saasStatusPollInterval)
+}
 
 var _ resource.Resource = &IntegrationResource{}
 var _ resource.ResourceWithImportState = &IntegrationResource{}
@@ -52,9 +100,14 @@ func (r *IntegrationResource) Read(ctx context.Context, req resource.ReadRequest
 
 	integrationIdentifier := state.InstallationId.ValueString()
 
-	a, err := r.portClient.GetIntegration(ctx, integrationIdentifier)
+	a, statusCode, err := r.portClient.GetIntegration(ctx, integrationIdentifier)
 
 	if err != nil {
+		if statusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("failed to read integration", err.Error())
 		return
 	}
 
@@ -92,6 +145,14 @@ func (r *IntegrationResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
+	if isSaasInstallation(state) {
+		updated, err = r.waitForSaasIntegrationSettled(ctx, integrationIdentifier, consts.IntegrationStatusUpdating)
+		if err != nil {
+			resp.Diagnostics.AddError("failed to update integration", err.Error())
+			return
+		}
+	}
+
 	err = r.refreshIntegrationState(state, updated, integrationIdentifier)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to refresh integration state", err.Error())
@@ -118,6 +179,14 @@ func (r *IntegrationResource) Delete(ctx context.Context, req resource.DeleteReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	if isSaasInstallation(state) {
+		if _, err := r.waitForSaasIntegrationSettled(ctx, integrationIdentifier, consts.IntegrationStatusDeleting); err != nil {
+			resp.Diagnostics.AddError("failed to delete integration", err.Error())
+			return
+		}
+	}
+
 	resp.State.RemoveResource(ctx)
 }
 
@@ -141,6 +210,14 @@ func (r *IntegrationResource) Create(ctx context.Context, req resource.CreateReq
 	if err != nil {
 		resp.Diagnostics.AddError("failed to create integration", err.Error())
 		return
+	}
+
+	if isSaasInstallation(state) {
+		created, err = r.waitForSaasIntegrationSettled(ctx, created.InstallationId, consts.IntegrationStatusCreating)
+		if err != nil {
+			resp.Diagnostics.AddError("failed to create integration", err.Error())
+			return
+		}
 	}
 
 	err = r.refreshIntegrationState(state, created, created.InstallationId)

--- a/port/integration/schema.go
+++ b/port/integration/schema.go
@@ -3,9 +3,16 @@ package integration
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/consts"
 )
 
 func IntegrationSchema() map[string]schema.Attribute {
@@ -14,8 +21,23 @@ func IntegrationSchema() map[string]schema.Attribute {
 			Computed: true,
 		},
 		"installation_id": schema.StringAttribute{
-			MarkdownDescription: "The installation ID of the integration. Must contain only lowercase letters, numbers, and dashes (pattern: `" + installationIdPattern + "`).",
+			MarkdownDescription: "The installation ID of the integration. Must contain only lowercase letters, numbers, and dashes (pattern: `" + installationIdPattern + "`). Changing this forces the integration to be destroyed and recreated under the new ID.",
 			Required:            true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
+		"installation_type": schema.StringAttribute{
+			MarkdownDescription: "Where the integration runs: `OnPrem` (default) registers a self-hosted integration you run yourself (e.g. via Helm/Docker) - Terraform only manages the Port-side record and mapping. `Saas` has Port provision and run a hosted Ocean integration on your behalf; `terraform apply` waits for it to finish provisioning before returning. Other installation types (OAuth-based GitHub App installs, etc.) require a manual browser consent step and are not supported by this resource. Immutable after creation - changing it forces recreation.",
+			Optional:            true,
+			Computed:            true,
+			Default:             stringdefault.StaticString(consts.InstallationTypeOnPrem),
+			Validators: []validator.String{
+				stringvalidator.OneOf(consts.InstallationTypeOnPrem, consts.InstallationTypeSaas),
+			},
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
 		},
 		"version": schema.StringAttribute{
 			Optional: true,
@@ -25,7 +47,8 @@ func IntegrationSchema() map[string]schema.Attribute {
 			Optional: true,
 		},
 		"installation_app_type": schema.StringAttribute{
-			Optional: true,
+			MarkdownDescription: "The name of the integrated tool/platform (e.g. `kubernetes`, `pagerduty`). Required when creating a new integration.",
+			Optional:            true,
 		},
 		"config": schema.StringAttribute{
 			MarkdownDescription: "Integration Config Raw JSON string (use `jsonencode`)",
@@ -64,16 +87,18 @@ var IntegrationResourceMarkdownDescription = `
 
 # Integration resource
 
-**NOTE:** This resource manages existing integration and integration mappings, not for creating new integrations.
+This resource manages the full lifecycle (create/read/update/delete) of a Port integration and its mapping - including creating a brand-new integration, not just adopting one installed by hand.
 
 Docs about integrations can be found [here](https://docs.getport.io/integrations-index/).
 
-Docs about how to import existing integrations and manage their mappings can be found [here](https://docs.getport.io/guides/all/import-and-manage-integration).
+If you have an integration that was installed before you started managing it with Terraform, you can bring it under Terraform management by importing it instead of creating a new one - see [Import and manage an integration](https://docs.getport.io/guides/all/import-and-manage-integration).
 
+## Creating a self-hosted (OnPrem) integration
 
 ` + "```hcl" + `
 resource "port_integration" "my_custom_integration" {
 	installation_id       = "my-custom-integration-id"
+	installation_app_type = "my-custom-kind"
 	title                 = "My Custom Integration"
 	config = jsonencode({
 		createMissingRelatedEntitiesboolean = true
@@ -99,9 +124,25 @@ resource "port_integration" "my_custom_integration" {
 		}]
 	})
 }
-
-
 ` + "```\n" + `
+
+With ` + "`installation_type = \"OnPrem\"`" + ` (the default), Terraform only creates/manages the Port-side registration and mapping - you still need to run the integration's own agent/container (e.g. via Helm or Docker) separately, pointed at the same ` + "`installation_id`" + `.
+
+## Creating a Port-hosted (SaaS) integration
+
+` + "```hcl" + `
+resource "port_integration" "my_hosted_integration" {
+	installation_id       = "my-hosted-integration-id"
+	installation_app_type = "githubOcean"
+	installation_type     = "Saas"
+	title                 = "My Hosted Integration"
+}
+` + "```\n" + `
+
+With ` + "`installation_type = \"Saas\"`" + `, Port provisions and runs the integration for you; ` + "`terraform apply`" + ` waits for provisioning to finish (and ` + "`terraform destroy`" + ` waits for teardown to finish) before returning.
+
+**NOTE:** OAuth-based installation types (e.g. GitHub App installs) require a manual browser consent step and cannot be created through this resource.
+
 ### NOTICE:
 
 The following config properties (` + "`selector.query|entity.mappings.*`" + `) are jq expressions, which means that you need to input either a valid jq expression (E.g ` + "`.title`" + `), or if you want a string value, a qouted escaped string val (E.g ` + "`'my-string'`" + `).


### PR DESCRIPTION
# Description

**What** - Add support for Port-hosted (SaaS) integrations with automatic provisioning/teardown polling, and improve integration lifecycle management.

**Why** - SaaS integrations run through an async pipeline in Port where the integration record transitions through in-progress states (Creating/Updating/Deleting) before reaching a terminal status. Users need `terraform apply`/`destroy` to wait for these operations to complete before returning, matching the behavior of Port's own provisioning pipeline.

**How** - 
- Added `installation_type` field to distinguish between OnPrem (self-hosted, default) and Saas (Port-hosted) integrations
- Implemented `waitForSaasIntegrationSettled()` polling function that monitors integration status until it leaves the in-progress state, with configurable poll interval (5s) and max retries (60, ~5 minutes)
- Integrated polling into Create/Update/Delete operations for SaaS installations
- Updated `GetIntegration()` to return HTTP status code for proper 404 handling
- Added `StatusInfo` fields to Integration model to track provisioning status
- Made `installation_id` immutable (RequiresReplace) since changing it requires recreation
- Enhanced schema documentation to explain OnPrem vs SaaS behavior and provide examples for both
- Improved error handling in Read operation to properly remove resource on 404

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Non-breaking change (fix of existing functionality that will not change current behavior)

https://claude.ai/code/session_01UiEktzx3SAw9ut3js4jFma