### PR TITLE
Fix Read() to distinguish 404 from real API errors

### DIFF
--- a/internal/cli/integration.go
+++ b/internal/cli/integration.go
@@ -11,7 +11,7 @@ type PortBodyForIntegration struct {
 	Integration Integration `json:"integration"`
 }
 
-func (c *PortClient) GetIntegration(ctx context.Context, id string) (*Integration, error) {
+func (c *PortClient) GetIntegration(ctx context.Context, id string) (*Integration, int, error) {
 	pb := &PortBodyForIntegration{}
 	url := "v1/integration/{identifier}"
 	resp, err := c.Client.R().
@@ -22,12 +22,12 @@ func (c *PortClient) GetIntegration(ctx context.Context, id string) (*Integratio
 		SetQueryParam("byField", "installationId").
 		Get(url)
 	if err != nil {
-		return nil, err
+		return nil, resp.StatusCode(), err
 	}
 	if !pb.OK {
-		return nil, fmt.Errorf("failed to read migration, got: %s", resp.Body())
+		return nil, resp.StatusCode(), fmt.Errorf("failed to read integration, got: %s", resp.Body())
 	}
-	return &pb.Integration, nil
+	return &pb.Integration, resp.StatusCode(), nil
 }
 
 func (c *PortClient) UpdateIntegration(ctx context.Context, id string, integration *Integration) (*Integration, error) {

--- a/port/integration/resource.go
+++ b/port/integration/resource.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -52,9 +53,14 @@ func (r *IntegrationResource) Read(ctx context.Context, req resource.ReadRequest
 
 	integrationIdentifier := state.InstallationId.ValueString()
 
-	a, err := r.portClient.GetIntegration(ctx, integrationIdentifier)
+	a, statusCode, err := r.portClient.GetIntegration(ctx, integrationIdentifier)
 
 	if err != nil {
+		if statusCode == http.StatusNotFound {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("failed to read integration", err.Error())
 		return
 	}
 


### PR DESCRIPTION
## Description

**What** - `GetIntegration` now returns the HTTP status code alongside the error. `Read()` uses it to tell a genuine 404 (drop the resource from state) apart from a real API failure (surface a diagnostic).

**Why** - Previously `Read()` did `if err != nil { return }` unconditionally: a deleted-out-of-band integration never showed drift (stale state kept silently), and a real failure (auth/network/5xx) also failed silently instead of erroring.

**How** - Changed `PortClient.GetIntegration`'s signature to `(*Integration, int, error)`; updated its one caller in `IntegrationResource.Read()` to branch on `http.StatusNotFound`.

First of a stack of 4 PRs for [Port task `task_tj6yly` / deliverable "Terraform Management of Integrations"](https://app.getport.io/deliverableEntity?identifier=deliverable_tj6yly) (roadmap: https://roadmap.port.io/ideas/p/terraform-management-of-integrations). This one is self-contained and can land independently.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiEktzx3SAw9ut3js4jFma)_