### PR TITLE
Add RequiresReplace on installation_id (closes #174)

### DIFF
--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -96,7 +96,7 @@ The following config properties (`selector.query|entity.mappings.*`) are jq expr
 
 ### Required
 
-- `installation_id` (String) The installation ID of the integration. Must contain only lowercase letters, numbers, and dashes (pattern: `^[a-z0-9-]+$`).
+- `installation_id` (String) The installation ID of the integration. Must contain only lowercase letters, numbers, and dashes (pattern: `^[a-z0-9-]+$`). Changing this forces the integration to be destroyed and recreated under the new ID.
 
 ### Optional
 

--- a/port/integration/schema.go
+++ b/port/integration/schema.go
@@ -6,6 +6,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 )
 
 func IntegrationSchema() map[string]schema.Attribute {
@@ -14,8 +16,11 @@ func IntegrationSchema() map[string]schema.Attribute {
 			Computed: true,
 		},
 		"installation_id": schema.StringAttribute{
-			MarkdownDescription: "The installation ID of the integration. Must contain only lowercase letters, numbers, and dashes (pattern: `" + installationIdPattern + "`).",
+			MarkdownDescription: "The installation ID of the integration. Must contain only lowercase letters, numbers, and dashes (pattern: `" + installationIdPattern + "`). Changing this forces the integration to be destroyed and recreated under the new ID.",
 			Required:            true,
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
 		},
 		"version": schema.StringAttribute{
 			Optional: true,


### PR DESCRIPTION
## Description

**What** - Adds `stringplanmodifier.RequiresReplace()` to `installation_id` on `port_integration`.

**Why** - `installation_id` is Port's immutable primary identifier for an integration - it can't be renamed via `PATCH`. Without this, Terraform plans a changed `installation_id` as an in-place update, which PATCHes using the new id as the URL identifier and 404s against the still-existing old integration instead of destroying and recreating it. Closes #174.

**How** - Schema-only change in `port/integration/schema.go`.

Second of a stack of 4 PRs for [Port task `task_tj6yly` / deliverable "Terraform Management of Integrations"](https://app.getport.io/deliverableEntity?identifier=deliverable_tj6yly). Stacked on top of the `Read()` fix PR - base branch will move to `main` once that one merges.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiEktzx3SAw9ut3js4jFma)_