### PR TITLE
Add installation_type field + SaaS async provisioning support

### DIFF
--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -101,7 +101,8 @@ The following config properties (`selector.query|entity.mappings.*`) are jq expr
 ### Optional
 
 - `config` (String) Integration Config Raw JSON string (use `jsonencode`)
-- `installation_app_type` (String)
+- `installation_app_type` (String) The name of the integrated tool/platform (e.g. `kubernetes`, `pagerduty`). Required when creating a new integration.
+- `installation_type` (String) Where the integration runs: `OnPrem` (default) registers a self-hosted integration you run yourself (e.g. via Helm/Docker) - Terraform only manages the Port-side record and mapping. `Saas` has Port provision and run a hosted Ocean integration on your behalf; `terraform apply` waits for it to finish provisioning before returning. Other installation types (OAuth-based GitHub App installs, etc.) require a manual browser consent step and are not supported by this resource. Immutable after creation - changing it forces recreation.
 - `kafka_changelog_destination` (Object) The changelog destination of the blueprint (just an empty `{}`) (see [below for nested schema](#nestedatt--kafka_changelog_destination))
 - `title` (String)
 - `version` (String)

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -749,12 +749,23 @@ type PortBodyDelete struct {
 }
 
 type Integration struct {
-	InstallationId       string                `json:"installationId"`
-	Title                *string               `json:"title"`
-	InstallationAppType  *string               `json:"installationAppType"`
-	Version              *string               `json:"version"`
-	Config               *map[string]any       `json:"config"`
-	ChangelogDestination *ChangelogDestination `json:"changelogDestination,omitempty"`
+	InstallationId       string                 `json:"installationId"`
+	Title                *string                `json:"title"`
+	InstallationAppType  *string                `json:"installationAppType"`
+	InstallationType     *string                `json:"installationType,omitempty"`
+	Version              *string                `json:"version"`
+	Config               *map[string]any        `json:"config"`
+	ChangelogDestination *ChangelogDestination  `json:"changelogDestination,omitempty"`
+	StatusInfo           *IntegrationStatusInfo `json:"statusInfo,omitempty"`
+}
+
+type IntegrationStatusInfo struct {
+	IntegrationStatus IntegrationStatus `json:"integrationStatus"`
+}
+
+type IntegrationStatus struct {
+	Status  string  `json:"status"`
+	Message *string `json:"message,omitempty"`
 }
 
 type Organization struct {

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -752,12 +752,23 @@ type PortBodyDelete struct {
 }
 
 type Integration struct {
-	InstallationId       string                `json:"installationId"`
-	Title                *string               `json:"title"`
-	InstallationAppType  *string               `json:"installationAppType"`
-	Version              *string               `json:"version"`
-	Config               *map[string]any       `json:"config"`
-	ChangelogDestination *ChangelogDestination `json:"changelogDestination,omitempty"`
+	InstallationId       string                 `json:"installationId"`
+	Title                *string                `json:"title"`
+	InstallationAppType  *string                `json:"installationAppType"`
+	InstallationType     *string                `json:"installationType,omitempty"`
+	Version              *string                `json:"version"`
+	Config               *map[string]any        `json:"config"`
+	ChangelogDestination *ChangelogDestination  `json:"changelogDestination,omitempty"`
+	StatusInfo           *IntegrationStatusInfo `json:"statusInfo,omitempty"`
+}
+
+type IntegrationStatusInfo struct {
+	IntegrationStatus IntegrationStatus `json:"integrationStatus"`
+}
+
+type IntegrationStatus struct {
+	Status  string  `json:"status"`
+	Message *string `json:"message,omitempty"`
 }
 
 type Organization struct {

--- a/internal/consts/provider.go
+++ b/internal/consts/provider.go
@@ -40,4 +40,13 @@ const (
 	// Workflow self serve trigger context types
 	CreateEntityContext = "CREATE_ENTITY"
 	EntityContext       = "ENTITY"
+
+	InstallationTypeOnPrem = "OnPrem"
+	InstallationTypeSaas   = "Saas"
+
+	IntegrationStatusCreating = "Creating"
+	IntegrationStatusUpdating = "Updating"
+	IntegrationStatusDeleting = "Deleting"
+	IntegrationStatusDeleted  = "Deleted"
+	IntegrationStatusError    = "Error"
 )

--- a/internal/consts/provider.go
+++ b/internal/consts/provider.go
@@ -21,4 +21,13 @@ const (
 	RunUpdated           = "RUN_UPDATED"
 	AnyRunChange         = "ANY_RUN_CHANGE"
 	JqCondition          = "JQ"
+
+	InstallationTypeOnPrem = "OnPrem"
+	InstallationTypeSaas   = "Saas"
+
+	IntegrationStatusCreating = "Creating"
+	IntegrationStatusUpdating = "Updating"
+	IntegrationStatusDeleting = "Deleting"
+	IntegrationStatusDeleted  = "Deleted"
+	IntegrationStatusError    = "Error"
 )

--- a/port/integration/integrationToPortBody.go
+++ b/port/integration/integrationToPortBody.go
@@ -31,6 +31,7 @@ func integrationToPortBody(state *IntegrationModel) (*cli.Integration, error) {
 	integration.Title = state.Title.ValueStringPointer()
 	integration.Version = state.Version.ValueStringPointer()
 	integration.InstallationAppType = state.InstallationAppType.ValueStringPointer()
+	integration.InstallationType = state.InstallationType.ValueStringPointer()
 
 	if !state.Config.IsNull() {
 		configStr := state.Config.ValueString()

--- a/port/integration/model.go
+++ b/port/integration/model.go
@@ -11,6 +11,7 @@ type IntegrationModel struct {
 	ID                          types.String                      `tfsdk:"id"`
 	InstallationId              types.String                      `tfsdk:"installation_id"`
 	InstallationAppType         types.String                      `tfsdk:"installation_app_type"`
+	InstallationType            types.String                      `tfsdk:"installation_type"`
 	Title                       types.String                      `tfsdk:"title"`
 	Version                     types.String                      `tfsdk:"version"`
 	Config                      types.String                      `tfsdk:"config"`

--- a/port/integration/refreshIntegrationToState.go
+++ b/port/integration/refreshIntegrationToState.go
@@ -13,6 +13,7 @@ func (r *IntegrationResource) refreshIntegrationState(state *IntegrationModel, a
 
 	state.Title = types.StringPointerValue(a.Title)
 	state.InstallationAppType = types.StringPointerValue(a.InstallationAppType)
+	state.InstallationType = types.StringPointerValue(a.InstallationType)
 	state.Version = types.StringPointerValue(a.Version)
 
 	if a.Config != nil {

--- a/port/integration/resource.go
+++ b/port/integration/resource.go
@@ -2,12 +2,59 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/consts"
 )
+
+// SaaS-provisioned integrations (installation_type = Saas) run through an async pipeline in
+// Port (the integration record moves Creating/Updating/Deleting -> a terminal status while the
+// underlying Ocean workload is rolled out/torn down). We poll until that settles so `apply`/
+// `destroy` only report success once the integration is actually usable/gone, mirroring the
+// polling Ocean itself does for provisioned defaults.
+const (
+	saasStatusPollInterval = 5 * time.Second
+	saasStatusPollMaxTries = 60 // ~5 minutes
+)
+
+func isSaasInstallation(state *IntegrationModel) bool {
+	return state.InstallationType.ValueString() == consts.InstallationTypeSaas
+}
+
+// waitForSaasIntegrationSettled polls the integration until its status leaves the given
+// in-progress state, returning the final integration or an error if it lands on Error or the
+// poll times out.
+func (r *IntegrationResource) waitForSaasIntegrationSettled(ctx context.Context, installationId string, inProgressStatus string) (*cli.Integration, error) {
+	for i := 0; i < saasStatusPollMaxTries; i++ {
+		integration, statusCode, err := r.portClient.GetIntegration(ctx, installationId)
+		if err != nil {
+			if statusCode == http.StatusNotFound && inProgressStatus == consts.IntegrationStatusDeleting {
+				return nil, nil
+			}
+			return nil, err
+		}
+
+		if integration.StatusInfo == nil || integration.StatusInfo.IntegrationStatus.Status != inProgressStatus {
+			if integration.StatusInfo != nil && integration.StatusInfo.IntegrationStatus.Status == consts.IntegrationStatusError {
+				message := "no additional details"
+				if integration.StatusInfo.IntegrationStatus.Message != nil {
+					message = *integration.StatusInfo.IntegrationStatus.Message
+				}
+				return nil, fmt.Errorf("integration %q entered Error status: %s", installationId, message)
+			}
+			return integration, nil
+		}
+
+		time.Sleep(saasStatusPollInterval)
+	}
+
+	return nil, fmt.Errorf("timed out waiting for integration %q to leave %q status after %s", installationId, inProgressStatus, saasStatusPollMaxTries*saasStatusPollInterval)
+}
 
 var _ resource.Resource = &IntegrationResource{}
 var _ resource.ResourceWithImportState = &IntegrationResource{}
@@ -98,6 +145,14 @@ func (r *IntegrationResource) Update(ctx context.Context, req resource.UpdateReq
 		return
 	}
 
+	if isSaasInstallation(state) {
+		updated, err = r.waitForSaasIntegrationSettled(ctx, integrationIdentifier, consts.IntegrationStatusUpdating)
+		if err != nil {
+			resp.Diagnostics.AddError("failed to update integration", err.Error())
+			return
+		}
+	}
+
 	err = r.refreshIntegrationState(state, updated, integrationIdentifier)
 	if err != nil {
 		resp.Diagnostics.AddError("failed to refresh integration state", err.Error())
@@ -124,6 +179,14 @@ func (r *IntegrationResource) Delete(ctx context.Context, req resource.DeleteReq
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	if isSaasInstallation(state) {
+		if _, err := r.waitForSaasIntegrationSettled(ctx, integrationIdentifier, consts.IntegrationStatusDeleting); err != nil {
+			resp.Diagnostics.AddError("failed to delete integration", err.Error())
+			return
+		}
+	}
+
 	resp.State.RemoveResource(ctx)
 }
 
@@ -147,6 +210,14 @@ func (r *IntegrationResource) Create(ctx context.Context, req resource.CreateReq
 	if err != nil {
 		resp.Diagnostics.AddError("failed to create integration", err.Error())
 		return
+	}
+
+	if isSaasInstallation(state) {
+		created, err = r.waitForSaasIntegrationSettled(ctx, created.InstallationId, consts.IntegrationStatusCreating)
+		if err != nil {
+			resp.Diagnostics.AddError("failed to create integration", err.Error())
+			return
+		}
 	}
 
 	err = r.refreshIntegrationState(state, created, created.InstallationId)

--- a/port/integration/schema.go
+++ b/port/integration/schema.go
@@ -3,11 +3,16 @@ package integration
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/consts"
 )
 
 func IntegrationSchema() map[string]schema.Attribute {
@@ -22,6 +27,18 @@ func IntegrationSchema() map[string]schema.Attribute {
 				stringplanmodifier.RequiresReplace(),
 			},
 		},
+		"installation_type": schema.StringAttribute{
+			MarkdownDescription: "Where the integration runs: `OnPrem` (default) registers a self-hosted integration you run yourself (e.g. via Helm/Docker) - Terraform only manages the Port-side record and mapping. `Saas` has Port provision and run a hosted Ocean integration on your behalf; `terraform apply` waits for it to finish provisioning before returning. Other installation types (OAuth-based GitHub App installs, etc.) require a manual browser consent step and are not supported by this resource. Immutable after creation - changing it forces recreation.",
+			Optional:            true,
+			Computed:            true,
+			Default:             stringdefault.StaticString(consts.InstallationTypeOnPrem),
+			Validators: []validator.String{
+				stringvalidator.OneOf(consts.InstallationTypeOnPrem, consts.InstallationTypeSaas),
+			},
+			PlanModifiers: []planmodifier.String{
+				stringplanmodifier.RequiresReplace(),
+			},
+		},
 		"version": schema.StringAttribute{
 			Optional: true,
 			Computed: true,
@@ -30,7 +47,8 @@ func IntegrationSchema() map[string]schema.Attribute {
 			Optional: true,
 		},
 		"installation_app_type": schema.StringAttribute{
-			Optional: true,
+			MarkdownDescription: "The name of the integrated tool/platform (e.g. `kubernetes`, `pagerduty`). Required when creating a new integration.",
+			Optional:            true,
 		},
 		"config": schema.StringAttribute{
 			MarkdownDescription: "Integration Config Raw JSON string (use `jsonencode`)",


### PR DESCRIPTION
## Description

**What** - Adds `installation_type` (`OnPrem` default / `Saas`, validated, `RequiresReplace`-immutable) to `port_integration`, and polls integration status on Create/Update/Delete for `Saas` installations until Port's async provisioning/teardown settles.

**Why** - This is the core of the roadmap request (https://roadmap.port.io/ideas/p/terraform-management-of-integrations, 20 votes): today `port_integration` can only manage integrations already installed by hand (import-then-manage). There's no way to have Terraform create a brand-new integration, self-hosted or Port-hosted. SaaS creation/deletion in Port is asynchronous (Port provisions/tears down the actual Ocean workload behind the scenes), so a naive field without polling would return from `apply`/`destroy` before the integration is actually usable/gone.

**How** - New `installation_type` schema attribute + `consts` for installation-type/status strings; `Integration` struct gained `InstallationType` and `StatusInfo`; new `waitForSaasIntegrationSettled` helper polls `GetIntegration` (interval 5s, ~5 min timeout) and errors clearly on an `Error` status or timeout.

Third of a stack of 4 PRs for [Port task `task_tj6yly` / deliverable "Terraform Management of Integrations"](https://app.getport.io/deliverableEntity?identifier=deliverable_tj6yly). This is the one most worth reviewing carefully (poll interval/timeout tuning, error surfacing). Stacked on the `installation_id` RequiresReplace PR.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiEktzx3SAw9ut3js4jFma)_