### PR TITLE
Rewrite resource docs: creation is now supported (OnPrem + SaaS)

### DIFF
--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -4,12 +4,13 @@ page_title: "port_integration Resource - port"
 subcategory: ""
 description: |-
   Integration resource
-  NOTE: This resource manages existing integration and integration mappings, not for creating new integrations.
+  This resource manages the full lifecycle (create/read/update/delete) of a Port integration and its mapping - including creating a brand-new integration, not just adopting one installed by hand.
   Docs about integrations can be found here https://docs.getport.io/integrations-index/.
-  Docs about how to import existing integrations and manage their mappings can be found here https://docs.getport.io/guides/all/import-and-manage-integration.
-  
+  If you have an integration that was installed before you started managing it with Terraform, you can bring it under Terraform management by importing it instead of creating a new one - see Import and manage an integration https://docs.getport.io/guides/all/import-and-manage-integration.
+  Creating a self-hosted (OnPrem) integration
   resource "port_integration" "my_custom_integration" {
   	installation_id       = "my-custom-integration-id"
+  	installation_app_type = "my-custom-kind"
   	title                 = "My Custom Integration"
   	config = jsonencode({
   		createMissingRelatedEntitiesboolean = true
@@ -36,8 +37,17 @@ description: |-
   	})
   }
   
+  With installation_type = "OnPrem" (the default), Terraform only creates/manages the Port-side registration and mapping - you still need to run the integration's own agent/container (e.g. via Helm or Docker) separately, pointed at the same installation_id.
+  Creating a Port-hosted (SaaS) integration
+  resource "port_integration" "my_hosted_integration" {
+  	installation_id       = "my-hosted-integration-id"
+  	installation_app_type = "githubOcean"
+  	installation_type     = "Saas"
+  	title                 = "My Hosted Integration"
+  }
   
-  
+  With installation_type = "Saas", Port provisions and runs the integration for you; terraform apply waits for provisioning to finish (and terraform destroy waits for teardown to finish) before returning.
+  NOTE: OAuth-based installation types (e.g. GitHub App installs) require a manual browser consent step and cannot be created through this resource.
   NOTICE:
   The following config properties (selector.query|entity.mappings.*) are jq expressions, which means that you need to input either a valid jq expression (E.g .title), or if you want a string value, a qouted escaped string val (E.g 'my-string').
 ---
@@ -46,16 +56,18 @@ description: |-
 
 # Integration resource
 
-**NOTE:** This resource manages existing integration and integration mappings, not for creating new integrations.
+This resource manages the full lifecycle (create/read/update/delete) of a Port integration and its mapping - including creating a brand-new integration, not just adopting one installed by hand.
 
 Docs about integrations can be found [here](https://docs.getport.io/integrations-index/).
 
-Docs about how to import existing integrations and manage their mappings can be found [here](https://docs.getport.io/guides/all/import-and-manage-integration).
+If you have an integration that was installed before you started managing it with Terraform, you can bring it under Terraform management by importing it instead of creating a new one - see [Import and manage an integration](https://docs.getport.io/guides/all/import-and-manage-integration).
 
+## Creating a self-hosted (OnPrem) integration
 
 ```hcl
 resource "port_integration" "my_custom_integration" {
 	installation_id       = "my-custom-integration-id"
+	installation_app_type = "my-custom-kind"
 	title                 = "My Custom Integration"
 	config = jsonencode({
 		createMissingRelatedEntitiesboolean = true
@@ -81,9 +93,24 @@ resource "port_integration" "my_custom_integration" {
 		}]
 	})
 }
-
-
 ```
+
+With `installation_type = "OnPrem"` (the default), Terraform only creates/manages the Port-side registration and mapping - you still need to run the integration's own agent/container (e.g. via Helm or Docker) separately, pointed at the same `installation_id`.
+
+## Creating a Port-hosted (SaaS) integration
+
+```hcl
+resource "port_integration" "my_hosted_integration" {
+	installation_id       = "my-hosted-integration-id"
+	installation_app_type = "githubOcean"
+	installation_type     = "Saas"
+	title                 = "My Hosted Integration"
+}
+```
+
+With `installation_type = "Saas"`, Port provisions and runs the integration for you; `terraform apply` waits for provisioning to finish (and `terraform destroy` waits for teardown to finish) before returning.
+
+**NOTE:** OAuth-based installation types (e.g. GitHub App installs) require a manual browser consent step and cannot be created through this resource.
 
 ### NOTICE:
 

--- a/docs/resources/integration.md
+++ b/docs/resources/integration.md
@@ -8,6 +8,7 @@ description: |-
   Docs about integrations can be found here https://docs.getport.io/integrations-index/.
   If you have an integration that was installed before you started managing it with Terraform, you can bring it under Terraform management by importing it instead of creating a new one - see Import and manage an integration https://docs.getport.io/guides/all/import-and-manage-integration.
   Creating a self-hosted (OnPrem) integration
+  
   resource "port_integration" "my_custom_integration" {
   	installation_id       = "my-custom-integration-id"
   	installation_app_type = "my-custom-kind"
@@ -39,6 +40,7 @@ description: |-
   
   With installation_type = "OnPrem" (the default), Terraform only creates/manages the Port-side registration and mapping - you still need to run the integration's own agent/container (e.g. via Helm or Docker) separately, pointed at the same installation_id.
   Creating a Port-hosted (SaaS) integration
+  
   resource "port_integration" "my_hosted_integration" {
   	installation_id       = "my-hosted-integration-id"
   	installation_app_type = "githubOcean"
@@ -95,6 +97,7 @@ resource "port_integration" "my_custom_integration" {
 }
 ```
 
+
 With `installation_type = "OnPrem"` (the default), Terraform only creates/manages the Port-side registration and mapping - you still need to run the integration's own agent/container (e.g. via Helm or Docker) separately, pointed at the same `installation_id`.
 
 ## Creating a Port-hosted (SaaS) integration
@@ -107,6 +110,7 @@ resource "port_integration" "my_hosted_integration" {
 	title                 = "My Hosted Integration"
 }
 ```
+
 
 With `installation_type = "Saas"`, Port provisions and runs the integration for you; `terraform apply` waits for provisioning to finish (and `terraform destroy` waits for teardown to finish) before returning.
 

--- a/port/integration/schema.go
+++ b/port/integration/schema.go
@@ -87,16 +87,18 @@ var IntegrationResourceMarkdownDescription = `
 
 # Integration resource
 
-**NOTE:** This resource manages existing integration and integration mappings, not for creating new integrations.
+This resource manages the full lifecycle (create/read/update/delete) of a Port integration and its mapping - including creating a brand-new integration, not just adopting one installed by hand.
 
 Docs about integrations can be found [here](https://docs.getport.io/integrations-index/).
 
-Docs about how to import existing integrations and manage their mappings can be found [here](https://docs.getport.io/guides/all/import-and-manage-integration).
+If you have an integration that was installed before you started managing it with Terraform, you can bring it under Terraform management by importing it instead of creating a new one - see [Import and manage an integration](https://docs.getport.io/guides/all/import-and-manage-integration).
 
+## Creating a self-hosted (OnPrem) integration
 
 ` + "```hcl" + `
 resource "port_integration" "my_custom_integration" {
 	installation_id       = "my-custom-integration-id"
+	installation_app_type = "my-custom-kind"
 	title                 = "My Custom Integration"
 	config = jsonencode({
 		createMissingRelatedEntitiesboolean = true
@@ -122,9 +124,25 @@ resource "port_integration" "my_custom_integration" {
 		}]
 	})
 }
-
-
 ` + "```\n" + `
+
+With ` + "`installation_type = \"OnPrem\"`" + ` (the default), Terraform only creates/manages the Port-side registration and mapping - you still need to run the integration's own agent/container (e.g. via Helm or Docker) separately, pointed at the same ` + "`installation_id`" + `.
+
+## Creating a Port-hosted (SaaS) integration
+
+` + "```hcl" + `
+resource "port_integration" "my_hosted_integration" {
+	installation_id       = "my-hosted-integration-id"
+	installation_app_type = "githubOcean"
+	installation_type     = "Saas"
+	title                 = "My Hosted Integration"
+}
+` + "```\n" + `
+
+With ` + "`installation_type = \"Saas\"`" + `, Port provisions and runs the integration for you; ` + "`terraform apply`" + ` waits for provisioning to finish (and ` + "`terraform destroy`" + ` waits for teardown to finish) before returning.
+
+**NOTE:** OAuth-based installation types (e.g. GitHub App installs) require a manual browser consent step and cannot be created through this resource.
+
 ### NOTICE:
 
 The following config properties (` + "`selector.query|entity.mappings.*`" + `) are jq expressions, which means that you need to input either a valid jq expression (E.g ` + "`.title`" + `), or if you want a string value, a qouted escaped string val (E.g ` + "`'my-string'`" + `).


### PR DESCRIPTION
## Description

**What** - Replaces the "NOTE: this resource ... not for creating new integrations" warning in the resource docs with create-from-scratch guidance and runnable examples for both `OnPrem` and `Saas`, and documents the new `installation_type`/`installation_app_type` fields.

**Why** - Once creation is actually supported, the old warning actively discourages the users this deliverable is meant to unblock from ever trying `terraform apply` to create an integration.

**How** - Updated `IntegrationResourceMarkdownDescription` in `schema.go`; hand-regenerated `docs/resources/integration.md` to match (`tfplugindocs`/`make gen-docs` needs to download the Terraform CLI binary, which this sandbox's network policy blocks - worth re-running `make gen-docs` for real once this merges, to confirm the hand-edit matches byte-for-byte).

Last of a stack of 4 PRs for [Port task `task_tj6yly` / deliverable "Terraform Management of Integrations"](https://app.getport.io/deliverableEntity?identifier=deliverable_tj6yly). Stacked on the core `installation_type` feature PR.

## Type of change

- [x] Documentation (added/updated documentation)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UiEktzx3SAw9ut3js4jFma)_