### PR TITLE
task_th2pss/terraform_support_for_workflows-1

### DIFF
--- a/docs/resources/workflow.md
+++ b/docs/resources/workflow.md
@@ -263,6 +263,7 @@ Optional:
 - `steps` (Attributes List) Splits the form into steps. Cannot be combined with `order_properties`. (see [below for nested schema](#nestedatt--node--input--user_inputs--steps))
 - `titles` (Attributes Map) Static titles rendered between the inputs of the form. (see [below for nested schema](#nestedatt--node--input--user_inputs--titles))
 - `user_properties` (Attributes) The user inputs the form collects. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties))
+- `validations` (Attributes List) Validation rules evaluated against the whole form when it is submitted. Cannot be combined with `steps`, add the rules to the individual steps instead. Up to 10 rules are allowed. (see [below for nested schema](#nestedatt--node--input--user_inputs--validations))
 
 <a id="nestedatt--node--input--user_inputs--buttons"></a>
 ### Nested Schema for `node.input.user_inputs.buttons`
@@ -288,8 +289,18 @@ Required:
 
 Optional:
 
+- `validations` (Attributes List) Validation rules evaluated when the step is submitted. Up to 10 rules are allowed. (see [below for nested schema](#nestedatt--node--input--user_inputs--steps--validations))
 - `visible` (Boolean) The visibility of the step.
 - `visible_jq_query` (String) The visibility condition jq query of the step.
+
+<a id="nestedatt--node--input--user_inputs--steps--validations"></a>
+### Nested Schema for `node.input.user_inputs.steps.validations`
+
+Required:
+
+- `constraint` (String) A jq expression that has to evaluate to `true` for the form to be valid.
+- `message` (String) The error message shown when the constraint evaluates to `false` (max 100 characters).
+
 
 
 <a id="nestedatt--node--input--user_inputs--titles"></a>
@@ -311,53 +322,48 @@ Optional:
 
 Optional:
 
-- `array_props` (Attributes Map) The array property of the action (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--array_props))
-- `boolean_props` (Attributes Map) The boolean property of the action (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--boolean_props))
-- `number_props` (Attributes Map) The number property of the action (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--number_props))
-- `object_props` (Attributes Map) The object property of the action (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--object_props))
-- `string_props` (Attributes Map) The string property of the action (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props))
+- `array_props` (Attributes Map) The array inputs of the form. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--array_props))
+- `boolean_props` (Attributes Map) The boolean inputs of the form. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--boolean_props))
+- `number_props` (Attributes Map) The number inputs of the form. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--number_props))
+- `object_props` (Attributes Map) The object inputs of the form. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--object_props))
+- `string_props` (Attributes Map) The string inputs of the form. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props))
 
 <a id="nestedatt--node--input--user_inputs--user_properties--array_props"></a>
 ### Nested Schema for `node.input.user_inputs.user_properties.array_props`
 
 Optional:
 
-- `boolean_items` (Attributes) An array of boolean items within the property (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--array_props--boolean_items))
-- `default_jq_query` (String) The default jq query of the array property
-- `depends_on` (List of String) The properties that this property depends on
-- `description` (String) The description of the property
-- `disabled` (Boolean) The disabled state of the array property
-- `disabled_jq_query` (String) The disabled state jq query of the array property
-- `icon` (String) The icon of the property
-- `max_items` (Number) The max items of the array property
-- `max_items_jq_query` (String) The max items jq query of the array property
-- `min_items` (Number) The min items of the array property
-- `min_items_jq_query` (String) The min items jq query of the array property
-- `number_items` (Attributes) An array of number items within the property (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--array_props--number_items))
-- `object_items` (Attributes) An array of object items within the property (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--array_props--object_items))
-- `required` (Boolean) Whether the property is required, by default not required, this property can't be set at the same time if `required_jq_query` is set, and only supports true as value
-- `sort` (Attributes) How to sort entities when in the self service action form in the UI (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--array_props--sort))
-- `string_items` (Attributes) An array of string items within the property (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--array_props--string_items))
-- `title` (String) The title of the property
-- `visible` (Boolean) The visibility of the array property
-- `visible_jq_query` (String) The visibility condition jq query of the array property
-
-<a id="nestedatt--node--input--user_inputs--user_properties--array_props--boolean_items"></a>
-### Nested Schema for `node.input.user_inputs.user_properties.array_props.boolean_items`
-
-Optional:
-
-- `default` (List of Boolean) The default values for the boolean items
-
+- `default_jq_query` (String) The default jq query of the array input.
+- `depends_on` (List of String) The inputs this input depends on.
+- `description` (String) The description of the array input.
+- `disabled` (Boolean) Greys out the array input. A disabled input is excluded from the submitted data and from `required` validation, which makes it a way to drop an input from the form based on the other answers. Use `read_only` to keep the value in the submission.
+- `disabled_jq_query` (String) The disabled condition jq query of the array input.
+- `icon` (String) The icon of the array input.
+- `max_items` (Number) The max items of the array input.
+- `max_items_jq_query` (String) The max items jq query of the array input.
+- `min_items` (Number) The min items of the array input.
+- `min_items_jq_query` (String) The min items jq query of the array input.
+- `number_items` (Attributes) The number items of the array input. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--array_props--number_items))
+- `object_items` (Attributes) The object items of the array input. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--array_props--object_items))
+- `read_only` (Boolean) Shows the value of the array input without letting the user change it. The value is still submitted with the form, unlike `disabled`.
+- `read_only_jq_query` (String) The read only condition jq query of the array input.
+- `required` (Boolean) Whether the input has to be filled in. Only `true` is accepted, and it cannot be combined with `required_jq_query`.
+- `sort` (Attributes) How the entities are sorted in the form. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--array_props--sort))
+- `string_items` (Attributes) The string items of the array input. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--array_props--string_items))
+- `title` (String) The title of the array input.
+- `unique_items` (Boolean) Whether the values of the array have to be unique.
+- `visible` (Boolean) The visibility of the array input.
+- `visible_jq_query` (String) The visibility condition jq query of the array input.
 
 <a id="nestedatt--node--input--user_inputs--user_properties--array_props--number_items"></a>
 ### Nested Schema for `node.input.user_inputs.user_properties.array_props.number_items`
 
 Optional:
 
-- `default` (List of Number) The default values for the number items
-- `enum` (List of Number) The enum of possible values for the number items
-- `enum_jq_query` (String) The jq query for the enum number items
+- `default` (List of Number) The default value of the items.
+- `enum` (List of Number) The values the user can pick from.
+- `enum_colors` (Map of String) The colors of the enum values.
+- `enum_jq_query` (String) A jq query resolving the values the user can pick from.
 
 
 <a id="nestedatt--node--input--user_inputs--user_properties--array_props--object_items"></a>
@@ -365,7 +371,8 @@ Optional:
 
 Optional:
 
-- `default` (List of Map of String) The default values for the object items
+- `default` (List of Map of String) The default value of the items.
+- `format` (String) The format of each item.
 
 
 <a id="nestedatt--node--input--user_inputs--user_properties--array_props--sort"></a>
@@ -373,11 +380,11 @@ Optional:
 
 Required:
 
-- `property` (String) The property to sort the entities by
+- `property` (String) The property to sort the entities by.
 
 Optional:
 
-- `order` (String) The order to sort the entities in
+- `order` (String) The order to sort the entities in.
 
 
 <a id="nestedatt--node--input--user_inputs--user_properties--array_props--string_items"></a>
@@ -385,12 +392,13 @@ Optional:
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier related to each string item
-- `dataset` (String) The dataset of the entity-format items
-- `default` (List of String) The default value of the items
-- `enum` (List of String) The enum of possible values for the string items
-- `enum_jq_query` (String) The jq query for the enum of string items
-- `format` (String) The format of the string property, Accepted values include `date-time`, `url`, `email`, `ipv4`, `ipv6`, `yaml`, `entity`, `user`, `team`, `proto`, `markdown`
+- `blueprint` (String) The blueprint the entities are taken from. Required when `format` is `entity`.
+- `dataset` (String) The dataset filtering the entities of the items, as a JSON encoded string.
+- `default` (List of String) The default value of the items.
+- `enum` (List of String) The values the user can pick from.
+- `enum_colors` (Map of String) The colors of the enum values.
+- `enum_jq_query` (String) A jq query resolving the values the user can pick from.
+- `format` (String) The format of each item.
 
 
 
@@ -399,17 +407,19 @@ Optional:
 
 Optional:
 
-- `default` (Boolean) The default of the boolean property
-- `default_jq_query` (String) The default jq query of the boolean property
-- `depends_on` (List of String) The properties that this property depends on
-- `description` (String) The description of the property
-- `disabled` (Boolean) The disabled state of the boolean property
-- `disabled_jq_query` (String) The disabled state jq query of the boolean property
-- `icon` (String) The icon of the property
-- `required` (Boolean) Whether the property is required, by default not required, this property can't be set at the same time if `required_jq_query` is set, and only supports true as value
-- `title` (String) The title of the property
-- `visible` (Boolean) The visibility of the boolean property
-- `visible_jq_query` (String) The visibility condition jq query of the boolean property
+- `default` (Boolean) The default of the boolean input.
+- `default_jq_query` (String) The default jq query of the boolean input.
+- `depends_on` (List of String) The inputs this input depends on.
+- `description` (String) The description of the boolean input.
+- `disabled` (Boolean) Greys out the boolean input. A disabled input is excluded from the submitted data and from `required` validation, which makes it a way to drop an input from the form based on the other answers. Use `read_only` to keep the value in the submission.
+- `disabled_jq_query` (String) The disabled condition jq query of the boolean input.
+- `icon` (String) The icon of the boolean input.
+- `read_only` (Boolean) Shows the value of the boolean input without letting the user change it. The value is still submitted with the form, unlike `disabled`.
+- `read_only_jq_query` (String) The read only condition jq query of the boolean input.
+- `required` (Boolean) Whether the input has to be filled in. Only `true` is accepted, and it cannot be combined with `required_jq_query`.
+- `title` (String) The title of the boolean input.
+- `visible` (Boolean) The visibility of the boolean input.
+- `visible_jq_query` (String) The visibility condition jq query of the boolean input.
 
 
 <a id="nestedatt--node--input--user_inputs--user_properties--number_props"></a>
@@ -417,22 +427,25 @@ Optional:
 
 Optional:
 
-- `default` (Number) The default of the number property
-- `default_jq_query` (String) The default jq query of the number property
-- `depends_on` (List of String) The properties that this property depends on
-- `description` (String) The description of the property
-- `disabled` (Boolean) The disabled state of the number property
-- `disabled_jq_query` (String) The disabled state jq query of the number property
-- `enum` (List of Number) The enum of the number property
-- `enum_colors` (Map of String) The enum colors of the number property
-- `enum_jq_query` (String) The enum jq query of the string property
-- `icon` (String) The icon of the property
-- `maximum` (Number) The min of the number property
-- `minimum` (Number) The max of the number property
-- `required` (Boolean) Whether the property is required, by default not required, this property can't be set at the same time if `required_jq_query` is set, and only supports true as value
-- `title` (String) The title of the property
-- `visible` (Boolean) The visibility of the number property
-- `visible_jq_query` (String) The visibility condition jq query of the number property
+- `default` (Number) The default of the number input.
+- `default_jq_query` (String) The default jq query of the number input.
+- `depends_on` (List of String) The inputs this input depends on.
+- `description` (String) The description of the number input.
+- `disabled` (Boolean) Greys out the number input. A disabled input is excluded from the submitted data and from `required` validation, which makes it a way to drop an input from the form based on the other answers. Use `read_only` to keep the value in the submission.
+- `disabled_jq_query` (String) The disabled condition jq query of the number input.
+- `enum` (List of Number) The values the user can pick from.
+- `enum_jq_query` (String) A jq query resolving the values the user can pick from.
+- `exclusive_maximum` (Number) The value the input has to be strictly smaller than.
+- `exclusive_minimum` (Number) The value the input has to be strictly greater than.
+- `icon` (String) The icon of the number input.
+- `maximum` (Number) The largest value the input accepts.
+- `minimum` (Number) The smallest value the input accepts.
+- `read_only` (Boolean) Shows the value of the number input without letting the user change it. The value is still submitted with the form, unlike `disabled`.
+- `read_only_jq_query` (String) The read only condition jq query of the number input.
+- `required` (Boolean) Whether the input has to be filled in. Only `true` is accepted, and it cannot be combined with `required_jq_query`.
+- `title` (String) The title of the number input.
+- `visible` (Boolean) The visibility of the number input.
+- `visible_jq_query` (String) The visibility condition jq query of the number input.
 
 
 <a id="nestedatt--node--input--user_inputs--user_properties--object_props"></a>
@@ -440,28 +453,20 @@ Optional:
 
 Optional:
 
-- `client_side_encryption` (Attributes) Client-side encryption configuration for the property. The value will be encrypted on the client side before being sent to Port. Cannot be used with `encryption`. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--object_props--client_side_encryption))
-- `default` (String) The default of the object property
-- `default_jq_query` (String) The default jq query of the object property
-- `depends_on` (List of String) The properties that this property depends on
-- `description` (String) The description of the property
-- `disabled` (Boolean) The disabled state of the object property
-- `disabled_jq_query` (String) The disabled state jq query of the object property
-- `encryption` (String) The algorithm to encrypt the property with for server-side encryption. Accepted value: `aes256-gcm`. Cannot be used with `client_side_encryption`.
-- `icon` (String) The icon of the property
-- `required` (Boolean) Whether the property is required, by default not required, this property can't be set at the same time if `required_jq_query` is set, and only supports true as value
-- `title` (String) The title of the property
-- `visible` (Boolean) The visibility of the object property
-- `visible_jq_query` (String) The visibility condition jq query of the object property
-
-<a id="nestedatt--node--input--user_inputs--user_properties--object_props--client_side_encryption"></a>
-### Nested Schema for `node.input.user_inputs.user_properties.object_props.client_side_encryption`
-
-Required:
-
-- `algorithm` (String) The encryption algorithm. Accepted value: `client-side`
-- `key` (String) The public key (PEM format) to use for encryption
-
+- `default` (String) The default of the object input, as a JSON encoded string.
+- `default_jq_query` (String) The default jq query of the object input.
+- `depends_on` (List of String) The inputs this input depends on.
+- `description` (String) The description of the object input.
+- `disabled` (Boolean) Greys out the object input. A disabled input is excluded from the submitted data and from `required` validation, which makes it a way to drop an input from the form based on the other answers. Use `read_only` to keep the value in the submission.
+- `disabled_jq_query` (String) The disabled condition jq query of the object input.
+- `format` (String) The format of the object input. `labeled-url` renders a url with a display text. Leave it out for a free form object.
+- `icon` (String) The icon of the object input.
+- `read_only` (Boolean) Shows the value of the object input without letting the user change it. The value is still submitted with the form, unlike `disabled`.
+- `read_only_jq_query` (String) The read only condition jq query of the object input.
+- `required` (Boolean) Whether the input has to be filled in. Only `true` is accepted, and it cannot be combined with `required_jq_query`.
+- `title` (String) The title of the object input.
+- `visible` (Boolean) The visibility of the object input.
+- `visible_jq_query` (String) The visibility condition jq query of the object input.
 
 
 <a id="nestedatt--node--input--user_inputs--user_properties--string_props"></a>
@@ -469,178 +474,180 @@ Required:
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier the string property relates to
-- `client_side_encryption` (Attributes) Client-side encryption configuration for the property. The value will be encrypted on the client side before being sent to Port. Cannot be used with `encryption`. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--client_side_encryption))
-- `dataset` (Attributes) The dataset of an the entity-format property. Supports nested rules with combinator groups. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset))
-- `default` (String) The default of the string property
-- `default_jq_query` (String) The default jq query of the string property
-- `depends_on` (List of String) The properties that this property depends on
-- `description` (String) The description of the property
-- `disabled` (Boolean) The disabled state of the string property
-- `disabled_jq_query` (String) The disabled state jq query of the string property
-- `encryption` (String) The algorithm to encrypt the property with for server-side encryption. Accepted value: `aes256-gcm`. Cannot be used with `client_side_encryption`.
-- `enum` (List of String) The enum of the string property
-- `enum_colors` (Map of String) The enum colors of the string property
-- `enum_jq_query` (String) The enum jq query of the string property
-- `format` (String) The format of the string property, Accepted values include `date-time`, `url`, `email`, `ipv4`, `ipv6`, `yaml`, `entity`, `user`, `team`, `proto`, `markdown`
-- `icon` (String) The icon of the property
-- `max_length` (Number) The max length of the string property
-- `min_length` (Number) The min length of the string property
-- `pattern` (String) The pattern of the string property
-- `pattern_jq_query` (String) The pattern jq query of the string property. This field accepts a JQ expression to dynamically generate either a regex pattern (as a string) or a list of allowed values (as an array). Cannot be used with `pattern`. Empty values are not allowed. Examples: `"if .env == \"prod\" then \"^[a-z]+$\" else \"^[a-zA-Z]+$\" end"` for dynamic regex patterns, or `"[\"value1\", \"value2\"]"` for a fixed list of allowed values.
-- `required` (Boolean) Whether the property is required, by default not required, this property can't be set at the same time if `required_jq_query` is set, and only supports true as value
-- `sort` (Attributes) How to sort entities when in the self service action form in the UI (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--sort))
-- `title` (String) The title of the property
-- `visible` (Boolean) The visibility of the string property
-- `visible_jq_query` (String) The visibility condition jq query of the string property
-
-<a id="nestedatt--node--input--user_inputs--user_properties--string_props--client_side_encryption"></a>
-### Nested Schema for `node.input.user_inputs.user_properties.string_props.client_side_encryption`
-
-Required:
-
-- `algorithm` (String) The encryption algorithm. Accepted value: `client-side`
-- `key` (String) The public key (PEM format) to use for encryption
-
+- `blueprint` (String) The blueprint the entities are taken from. Required when `format` is `entity`.
+- `dataset` (Attributes) The dataset filtering the entities the user can pick from. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset))
+- `default` (String) The default of the string input.
+- `default_jq_query` (String) The default jq query of the string input.
+- `depends_on` (List of String) The inputs this input depends on.
+- `description` (String) The description of the string input.
+- `disabled` (Boolean) Greys out the string input. A disabled input is excluded from the submitted data and from `required` validation, which makes it a way to drop an input from the form based on the other answers. Use `read_only` to keep the value in the submission.
+- `disabled_jq_query` (String) The disabled condition jq query of the string input.
+- `enum` (List of String) The values the user can pick from.
+- `enum_colors` (Map of String) The colors of the enum values.
+- `enum_jq_query` (String) A jq query resolving the values the user can pick from.
+- `format` (String) The format of the string input.
+- `icon` (String) The icon of the string input.
+- `max_length` (Number) The max length of the string input.
+- `min_length` (Number) The min length of the string input.
+- `pattern` (String) The regex pattern the value has to match.
+- `pattern_jq_query` (String) A jq query resolving the pattern of the string input, either a regex string or a list of allowed values.
+- `read_only` (Boolean) Shows the value of the string input without letting the user change it. The value is still submitted with the form, unlike `disabled`.
+- `read_only_jq_query` (String) The read only condition jq query of the string input.
+- `required` (Boolean) Whether the input has to be filled in. Only `true` is accepted, and it cannot be combined with `required_jq_query`.
+- `sort` (Attributes) How the entities are sorted in the form. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--sort))
+- `title` (String) The title of the string input.
+- `visible` (Boolean) The visibility of the string input.
+- `visible_jq_query` (String) The visibility condition jq query of the string input.
 
 <a id="nestedatt--node--input--user_inputs--user_properties--string_props--dataset"></a>
 ### Nested Schema for `node.input.user_inputs.user_properties.string_props.dataset`
 
 Required:
 
-- `combinator` (String) The combinator of the dataset
-- `rules` (Attributes List) The rules of the dataset. Can be leaf rules (with operator) or group rules (with combinator and nested rules). (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules))
+- `combinator` (String) How the rules are combined.
+- `rules` (Attributes List) The rules of the dataset. A rule either filters on a property or groups nested rules under a combinator. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules))
 
 <a id="nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules"></a>
 ### Nested Schema for `node.input.user_inputs.user_properties.string_props.dataset.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules"></a>
 ### Nested Schema for `node.input.user_inputs.user_properties.string_props.dataset.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules"></a>
 ### Nested Schema for `node.input.user_inputs.user_properties.string_props.dataset.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules"></a>
 ### Nested Schema for `node.input.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules"></a>
 ### Nested Schema for `node.input.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules"></a>
 ### Nested Schema for `node.input.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules"></a>
 ### Nested Schema for `node.input.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules"></a>
 ### Nested Schema for `node.input.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules.rules.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules"></a>
 ### Nested Schema for `node.input.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules.rules.rules.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules"></a>
 ### Nested Schema for `node.input.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules.rules.rules.rules.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules"></a>
 ### Nested Schema for `node.input.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules.rules.rules.rules.rules.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--input--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--value"></a>
 ### Nested Schema for `node.input.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules.rules.rules.rules.rules.rules.rules.rules.value`
@@ -747,13 +754,22 @@ Optional:
 
 Required:
 
-- `property` (String) The property to sort the entities by
+- `property` (String) The property to sort the entities by.
 
 Optional:
 
-- `order` (String) The order to sort the entities in
+- `order` (String) The order to sort the entities in.
 
 
+
+
+<a id="nestedatt--node--input--user_inputs--validations"></a>
+### Nested Schema for `node.input.user_inputs.validations`
+
+Required:
+
+- `constraint` (String) A jq expression that has to evaluate to `true` for the form to be valid.
+- `message` (String) The error message shown when the constraint evaluates to `false` (max 100 characters).
 
 
 
@@ -835,6 +851,7 @@ Optional:
 - `steps` (Attributes List) Splits the form into steps. Cannot be combined with `order_properties`. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--steps))
 - `titles` (Attributes Map) Static titles rendered between the inputs of the form. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--titles))
 - `user_properties` (Attributes) The user inputs the form collects. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties))
+- `validations` (Attributes List) Validation rules evaluated against the whole form when it is submitted. Cannot be combined with `steps`, add the rules to the individual steps instead. Up to 10 rules are allowed. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--validations))
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--steps"></a>
 ### Nested Schema for `node.self_serve_trigger.user_inputs.steps`
@@ -846,8 +863,18 @@ Required:
 
 Optional:
 
+- `validations` (Attributes List) Validation rules evaluated when the step is submitted. Up to 10 rules are allowed. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--steps--validations))
 - `visible` (Boolean) The visibility of the step.
 - `visible_jq_query` (String) The visibility condition jq query of the step.
+
+<a id="nestedatt--node--self_serve_trigger--user_inputs--steps--validations"></a>
+### Nested Schema for `node.self_serve_trigger.user_inputs.steps.validations`
+
+Required:
+
+- `constraint` (String) A jq expression that has to evaluate to `true` for the form to be valid.
+- `message` (String) The error message shown when the constraint evaluates to `false` (max 100 characters).
+
 
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--titles"></a>
@@ -869,53 +896,48 @@ Optional:
 
 Optional:
 
-- `array_props` (Attributes Map) The array property of the action (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props))
-- `boolean_props` (Attributes Map) The boolean property of the action (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--boolean_props))
-- `number_props` (Attributes Map) The number property of the action (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--number_props))
-- `object_props` (Attributes Map) The object property of the action (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--object_props))
-- `string_props` (Attributes Map) The string property of the action (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props))
+- `array_props` (Attributes Map) The array inputs of the form. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props))
+- `boolean_props` (Attributes Map) The boolean inputs of the form. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--boolean_props))
+- `number_props` (Attributes Map) The number inputs of the form. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--number_props))
+- `object_props` (Attributes Map) The object inputs of the form. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--object_props))
+- `string_props` (Attributes Map) The string inputs of the form. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props))
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props"></a>
 ### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.array_props`
 
 Optional:
 
-- `boolean_items` (Attributes) An array of boolean items within the property (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props--boolean_items))
-- `default_jq_query` (String) The default jq query of the array property
-- `depends_on` (List of String) The properties that this property depends on
-- `description` (String) The description of the property
-- `disabled` (Boolean) The disabled state of the array property
-- `disabled_jq_query` (String) The disabled state jq query of the array property
-- `icon` (String) The icon of the property
-- `max_items` (Number) The max items of the array property
-- `max_items_jq_query` (String) The max items jq query of the array property
-- `min_items` (Number) The min items of the array property
-- `min_items_jq_query` (String) The min items jq query of the array property
-- `number_items` (Attributes) An array of number items within the property (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props--number_items))
-- `object_items` (Attributes) An array of object items within the property (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props--object_items))
-- `required` (Boolean) Whether the property is required, by default not required, this property can't be set at the same time if `required_jq_query` is set, and only supports true as value
-- `sort` (Attributes) How to sort entities when in the self service action form in the UI (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props--sort))
-- `string_items` (Attributes) An array of string items within the property (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props--string_items))
-- `title` (String) The title of the property
-- `visible` (Boolean) The visibility of the array property
-- `visible_jq_query` (String) The visibility condition jq query of the array property
-
-<a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props--boolean_items"></a>
-### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.array_props.boolean_items`
-
-Optional:
-
-- `default` (List of Boolean) The default values for the boolean items
-
+- `default_jq_query` (String) The default jq query of the array input.
+- `depends_on` (List of String) The inputs this input depends on.
+- `description` (String) The description of the array input.
+- `disabled` (Boolean) Greys out the array input. A disabled input is excluded from the submitted data and from `required` validation, which makes it a way to drop an input from the form based on the other answers. Use `read_only` to keep the value in the submission.
+- `disabled_jq_query` (String) The disabled condition jq query of the array input.
+- `icon` (String) The icon of the array input.
+- `max_items` (Number) The max items of the array input.
+- `max_items_jq_query` (String) The max items jq query of the array input.
+- `min_items` (Number) The min items of the array input.
+- `min_items_jq_query` (String) The min items jq query of the array input.
+- `number_items` (Attributes) The number items of the array input. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props--number_items))
+- `object_items` (Attributes) The object items of the array input. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props--object_items))
+- `read_only` (Boolean) Shows the value of the array input without letting the user change it. The value is still submitted with the form, unlike `disabled`.
+- `read_only_jq_query` (String) The read only condition jq query of the array input.
+- `required` (Boolean) Whether the input has to be filled in. Only `true` is accepted, and it cannot be combined with `required_jq_query`.
+- `sort` (Attributes) How the entities are sorted in the form. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props--sort))
+- `string_items` (Attributes) The string items of the array input. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props--string_items))
+- `title` (String) The title of the array input.
+- `unique_items` (Boolean) Whether the values of the array have to be unique.
+- `visible` (Boolean) The visibility of the array input.
+- `visible_jq_query` (String) The visibility condition jq query of the array input.
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props--number_items"></a>
 ### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.array_props.number_items`
 
 Optional:
 
-- `default` (List of Number) The default values for the number items
-- `enum` (List of Number) The enum of possible values for the number items
-- `enum_jq_query` (String) The jq query for the enum number items
+- `default` (List of Number) The default value of the items.
+- `enum` (List of Number) The values the user can pick from.
+- `enum_colors` (Map of String) The colors of the enum values.
+- `enum_jq_query` (String) A jq query resolving the values the user can pick from.
 
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props--object_items"></a>
@@ -923,7 +945,8 @@ Optional:
 
 Optional:
 
-- `default` (List of Map of String) The default values for the object items
+- `default` (List of Map of String) The default value of the items.
+- `format` (String) The format of each item.
 
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props--sort"></a>
@@ -931,11 +954,11 @@ Optional:
 
 Required:
 
-- `property` (String) The property to sort the entities by
+- `property` (String) The property to sort the entities by.
 
 Optional:
 
-- `order` (String) The order to sort the entities in
+- `order` (String) The order to sort the entities in.
 
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--array_props--string_items"></a>
@@ -943,12 +966,13 @@ Optional:
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier related to each string item
-- `dataset` (String) The dataset of the entity-format items
-- `default` (List of String) The default value of the items
-- `enum` (List of String) The enum of possible values for the string items
-- `enum_jq_query` (String) The jq query for the enum of string items
-- `format` (String) The format of the string property, Accepted values include `date-time`, `url`, `email`, `ipv4`, `ipv6`, `yaml`, `entity`, `user`, `team`, `proto`, `markdown`
+- `blueprint` (String) The blueprint the entities are taken from. Required when `format` is `entity`.
+- `dataset` (String) The dataset filtering the entities of the items, as a JSON encoded string.
+- `default` (List of String) The default value of the items.
+- `enum` (List of String) The values the user can pick from.
+- `enum_colors` (Map of String) The colors of the enum values.
+- `enum_jq_query` (String) A jq query resolving the values the user can pick from.
+- `format` (String) The format of each item.
 
 
 
@@ -957,17 +981,19 @@ Optional:
 
 Optional:
 
-- `default` (Boolean) The default of the boolean property
-- `default_jq_query` (String) The default jq query of the boolean property
-- `depends_on` (List of String) The properties that this property depends on
-- `description` (String) The description of the property
-- `disabled` (Boolean) The disabled state of the boolean property
-- `disabled_jq_query` (String) The disabled state jq query of the boolean property
-- `icon` (String) The icon of the property
-- `required` (Boolean) Whether the property is required, by default not required, this property can't be set at the same time if `required_jq_query` is set, and only supports true as value
-- `title` (String) The title of the property
-- `visible` (Boolean) The visibility of the boolean property
-- `visible_jq_query` (String) The visibility condition jq query of the boolean property
+- `default` (Boolean) The default of the boolean input.
+- `default_jq_query` (String) The default jq query of the boolean input.
+- `depends_on` (List of String) The inputs this input depends on.
+- `description` (String) The description of the boolean input.
+- `disabled` (Boolean) Greys out the boolean input. A disabled input is excluded from the submitted data and from `required` validation, which makes it a way to drop an input from the form based on the other answers. Use `read_only` to keep the value in the submission.
+- `disabled_jq_query` (String) The disabled condition jq query of the boolean input.
+- `icon` (String) The icon of the boolean input.
+- `read_only` (Boolean) Shows the value of the boolean input without letting the user change it. The value is still submitted with the form, unlike `disabled`.
+- `read_only_jq_query` (String) The read only condition jq query of the boolean input.
+- `required` (Boolean) Whether the input has to be filled in. Only `true` is accepted, and it cannot be combined with `required_jq_query`.
+- `title` (String) The title of the boolean input.
+- `visible` (Boolean) The visibility of the boolean input.
+- `visible_jq_query` (String) The visibility condition jq query of the boolean input.
 
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--number_props"></a>
@@ -975,22 +1001,25 @@ Optional:
 
 Optional:
 
-- `default` (Number) The default of the number property
-- `default_jq_query` (String) The default jq query of the number property
-- `depends_on` (List of String) The properties that this property depends on
-- `description` (String) The description of the property
-- `disabled` (Boolean) The disabled state of the number property
-- `disabled_jq_query` (String) The disabled state jq query of the number property
-- `enum` (List of Number) The enum of the number property
-- `enum_colors` (Map of String) The enum colors of the number property
-- `enum_jq_query` (String) The enum jq query of the string property
-- `icon` (String) The icon of the property
-- `maximum` (Number) The min of the number property
-- `minimum` (Number) The max of the number property
-- `required` (Boolean) Whether the property is required, by default not required, this property can't be set at the same time if `required_jq_query` is set, and only supports true as value
-- `title` (String) The title of the property
-- `visible` (Boolean) The visibility of the number property
-- `visible_jq_query` (String) The visibility condition jq query of the number property
+- `default` (Number) The default of the number input.
+- `default_jq_query` (String) The default jq query of the number input.
+- `depends_on` (List of String) The inputs this input depends on.
+- `description` (String) The description of the number input.
+- `disabled` (Boolean) Greys out the number input. A disabled input is excluded from the submitted data and from `required` validation, which makes it a way to drop an input from the form based on the other answers. Use `read_only` to keep the value in the submission.
+- `disabled_jq_query` (String) The disabled condition jq query of the number input.
+- `enum` (List of Number) The values the user can pick from.
+- `enum_jq_query` (String) A jq query resolving the values the user can pick from.
+- `exclusive_maximum` (Number) The value the input has to be strictly smaller than.
+- `exclusive_minimum` (Number) The value the input has to be strictly greater than.
+- `icon` (String) The icon of the number input.
+- `maximum` (Number) The largest value the input accepts.
+- `minimum` (Number) The smallest value the input accepts.
+- `read_only` (Boolean) Shows the value of the number input without letting the user change it. The value is still submitted with the form, unlike `disabled`.
+- `read_only_jq_query` (String) The read only condition jq query of the number input.
+- `required` (Boolean) Whether the input has to be filled in. Only `true` is accepted, and it cannot be combined with `required_jq_query`.
+- `title` (String) The title of the number input.
+- `visible` (Boolean) The visibility of the number input.
+- `visible_jq_query` (String) The visibility condition jq query of the number input.
 
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--object_props"></a>
@@ -998,28 +1027,20 @@ Optional:
 
 Optional:
 
-- `client_side_encryption` (Attributes) Client-side encryption configuration for the property. The value will be encrypted on the client side before being sent to Port. Cannot be used with `encryption`. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--object_props--client_side_encryption))
-- `default` (String) The default of the object property
-- `default_jq_query` (String) The default jq query of the object property
-- `depends_on` (List of String) The properties that this property depends on
-- `description` (String) The description of the property
-- `disabled` (Boolean) The disabled state of the object property
-- `disabled_jq_query` (String) The disabled state jq query of the object property
-- `encryption` (String) The algorithm to encrypt the property with for server-side encryption. Accepted value: `aes256-gcm`. Cannot be used with `client_side_encryption`.
-- `icon` (String) The icon of the property
-- `required` (Boolean) Whether the property is required, by default not required, this property can't be set at the same time if `required_jq_query` is set, and only supports true as value
-- `title` (String) The title of the property
-- `visible` (Boolean) The visibility of the object property
-- `visible_jq_query` (String) The visibility condition jq query of the object property
-
-<a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--object_props--client_side_encryption"></a>
-### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.object_props.client_side_encryption`
-
-Required:
-
-- `algorithm` (String) The encryption algorithm. Accepted value: `client-side`
-- `key` (String) The public key (PEM format) to use for encryption
-
+- `default` (String) The default of the object input, as a JSON encoded string.
+- `default_jq_query` (String) The default jq query of the object input.
+- `depends_on` (List of String) The inputs this input depends on.
+- `description` (String) The description of the object input.
+- `disabled` (Boolean) Greys out the object input. A disabled input is excluded from the submitted data and from `required` validation, which makes it a way to drop an input from the form based on the other answers. Use `read_only` to keep the value in the submission.
+- `disabled_jq_query` (String) The disabled condition jq query of the object input.
+- `format` (String) The format of the object input. `labeled-url` renders a url with a display text. Leave it out for a free form object.
+- `icon` (String) The icon of the object input.
+- `read_only` (Boolean) Shows the value of the object input without letting the user change it. The value is still submitted with the form, unlike `disabled`.
+- `read_only_jq_query` (String) The read only condition jq query of the object input.
+- `required` (Boolean) Whether the input has to be filled in. Only `true` is accepted, and it cannot be combined with `required_jq_query`.
+- `title` (String) The title of the object input.
+- `visible` (Boolean) The visibility of the object input.
+- `visible_jq_query` (String) The visibility condition jq query of the object input.
 
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props"></a>
@@ -1027,178 +1048,180 @@ Required:
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier the string property relates to
-- `client_side_encryption` (Attributes) Client-side encryption configuration for the property. The value will be encrypted on the client side before being sent to Port. Cannot be used with `encryption`. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--client_side_encryption))
-- `dataset` (Attributes) The dataset of an the entity-format property. Supports nested rules with combinator groups. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset))
-- `default` (String) The default of the string property
-- `default_jq_query` (String) The default jq query of the string property
-- `depends_on` (List of String) The properties that this property depends on
-- `description` (String) The description of the property
-- `disabled` (Boolean) The disabled state of the string property
-- `disabled_jq_query` (String) The disabled state jq query of the string property
-- `encryption` (String) The algorithm to encrypt the property with for server-side encryption. Accepted value: `aes256-gcm`. Cannot be used with `client_side_encryption`.
-- `enum` (List of String) The enum of the string property
-- `enum_colors` (Map of String) The enum colors of the string property
-- `enum_jq_query` (String) The enum jq query of the string property
-- `format` (String) The format of the string property, Accepted values include `date-time`, `url`, `email`, `ipv4`, `ipv6`, `yaml`, `entity`, `user`, `team`, `proto`, `markdown`
-- `icon` (String) The icon of the property
-- `max_length` (Number) The max length of the string property
-- `min_length` (Number) The min length of the string property
-- `pattern` (String) The pattern of the string property
-- `pattern_jq_query` (String) The pattern jq query of the string property. This field accepts a JQ expression to dynamically generate either a regex pattern (as a string) or a list of allowed values (as an array). Cannot be used with `pattern`. Empty values are not allowed. Examples: `"if .env == \"prod\" then \"^[a-z]+$\" else \"^[a-zA-Z]+$\" end"` for dynamic regex patterns, or `"[\"value1\", \"value2\"]"` for a fixed list of allowed values.
-- `required` (Boolean) Whether the property is required, by default not required, this property can't be set at the same time if `required_jq_query` is set, and only supports true as value
-- `sort` (Attributes) How to sort entities when in the self service action form in the UI (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--sort))
-- `title` (String) The title of the property
-- `visible` (Boolean) The visibility of the string property
-- `visible_jq_query` (String) The visibility condition jq query of the string property
-
-<a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--client_side_encryption"></a>
-### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.string_props.client_side_encryption`
-
-Required:
-
-- `algorithm` (String) The encryption algorithm. Accepted value: `client-side`
-- `key` (String) The public key (PEM format) to use for encryption
-
+- `blueprint` (String) The blueprint the entities are taken from. Required when `format` is `entity`.
+- `dataset` (Attributes) The dataset filtering the entities the user can pick from. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset))
+- `default` (String) The default of the string input.
+- `default_jq_query` (String) The default jq query of the string input.
+- `depends_on` (List of String) The inputs this input depends on.
+- `description` (String) The description of the string input.
+- `disabled` (Boolean) Greys out the string input. A disabled input is excluded from the submitted data and from `required` validation, which makes it a way to drop an input from the form based on the other answers. Use `read_only` to keep the value in the submission.
+- `disabled_jq_query` (String) The disabled condition jq query of the string input.
+- `enum` (List of String) The values the user can pick from.
+- `enum_colors` (Map of String) The colors of the enum values.
+- `enum_jq_query` (String) A jq query resolving the values the user can pick from.
+- `format` (String) The format of the string input.
+- `icon` (String) The icon of the string input.
+- `max_length` (Number) The max length of the string input.
+- `min_length` (Number) The min length of the string input.
+- `pattern` (String) The regex pattern the value has to match.
+- `pattern_jq_query` (String) A jq query resolving the pattern of the string input, either a regex string or a list of allowed values.
+- `read_only` (Boolean) Shows the value of the string input without letting the user change it. The value is still submitted with the form, unlike `disabled`.
+- `read_only_jq_query` (String) The read only condition jq query of the string input.
+- `required` (Boolean) Whether the input has to be filled in. Only `true` is accepted, and it cannot be combined with `required_jq_query`.
+- `sort` (Attributes) How the entities are sorted in the form. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--sort))
+- `title` (String) The title of the string input.
+- `visible` (Boolean) The visibility of the string input.
+- `visible_jq_query` (String) The visibility condition jq query of the string input.
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset"></a>
 ### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.string_props.dataset`
 
 Required:
 
-- `combinator` (String) The combinator of the dataset
-- `rules` (Attributes List) The rules of the dataset. Can be leaf rules (with operator) or group rules (with combinator and nested rules). (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules))
+- `combinator` (String) How the rules are combined.
+- `rules` (Attributes List) The rules of the dataset. A rule either filters on a property or groups nested rules under a combinator. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules))
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules"></a>
 ### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.string_props.dataset.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules"></a>
 ### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.string_props.dataset.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules"></a>
 ### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.string_props.dataset.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules"></a>
 ### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules"></a>
 ### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules"></a>
 ### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules"></a>
 ### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules"></a>
 ### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules.rules.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules"></a>
 ### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules.rules.rules.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules"></a>
 ### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules.rules.rules.rules.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `rules` (Attributes List) Nested rules for a group rule. Used with combinator for logical grouping. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules))
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `rules` (Attributes List) The nested rules of a group rule. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules))
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules"></a>
 ### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules.rules.rules.rules.rules.rules.rules.rules`
 
 Optional:
 
-- `blueprint` (String) The blueprint identifier of the rule
-- `combinator` (String) The combinator for a group rule (and/or). Used with nested rules instead of operator.
-- `operator` (String) The operator of the rule. Required for leaf rules, should not be set for group rules.
-- `property` (String) The property identifier of the rule
-- `value` (Object) The value of the rule (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--value))
+- `blueprint` (String) The blueprint identifier of the rule.
+- `combinator` (String) How the nested rules of a group rule are combined.
+- `operator` (String) The operator of the rule. Set on filtering rules and left out on group rules.
+- `property` (String) The property identifier of the rule.
+- `value` (Object) A value resolved from the form or the trigger when the form is rendered. (see [below for nested schema](#nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--value))
+- `value_json` (String) A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.
 
 <a id="nestedatt--node--self_serve_trigger--user_inputs--user_properties--string_props--dataset--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--rules--value"></a>
 ### Nested Schema for `node.self_serve_trigger.user_inputs.user_properties.string_props.dataset.rules.rules.rules.rules.rules.rules.rules.rules.rules.rules.rules.value`
@@ -1305,13 +1328,22 @@ Optional:
 
 Required:
 
-- `property` (String) The property to sort the entities by
+- `property` (String) The property to sort the entities by.
 
 Optional:
 
-- `order` (String) The order to sort the entities in
+- `order` (String) The order to sort the entities in.
 
 
+
+
+<a id="nestedatt--node--self_serve_trigger--user_inputs--validations"></a>
+### Nested Schema for `node.self_serve_trigger.user_inputs.validations`
+
+Required:
+
+- `constraint` (String) A jq expression that has to evaluate to `true` for the form to be valid.
+- `message` (String) The error message shown when the constraint evaluates to `false` (max 100 characters).
 
 
 

--- a/examples/resources/port_workflow/main.tf
+++ b/examples/resources/port_workflow/main.tf
@@ -21,12 +21,25 @@ resource "port_workflow" "deploy_service" {
             }
           }
           number_props = {
-            "replicas" = {
-              title   = "Replicas"
+            "min_replicas" = {
+              title   = "Minimum replicas"
               default = 1
+            }
+            "max_replicas" = {
+              title   = "Maximum replicas"
+              default = 3
             }
           }
         }
+
+        # Checked when the form is submitted. Move the rules into the individual
+        # steps when the form is split with `steps`.
+        validations = [
+          {
+            constraint = ".form.max_replicas >= .form.min_replicas"
+            message    = "Maximum replicas must be greater than or equal to minimum replicas"
+          },
+        ]
       }
 
       permissions {
@@ -83,8 +96,9 @@ resource "port_workflow" "deploy_service" {
       url    = "https://ci.example.com/deploy"
       method = "POST"
       body = jsonencode({
-        service  = "{{ .outputs.trigger.inputs.service }}"
-        replicas = "{{ .outputs.trigger.inputs.replicas }}"
+        service      = "{{ .outputs.trigger.inputs.service }}"
+        min_replicas = "{{ .outputs.trigger.inputs.min_replicas }}"
+        max_replicas = "{{ .outputs.trigger.inputs.max_replicas }}"
       })
     }
   }

--- a/internal/cli/workflowModels.go
+++ b/internal/cli/workflowModels.go
@@ -135,9 +135,6 @@ type WorkflowUserInputs struct {
 	Buttons *[]WorkflowInputButton `json:"buttons,omitempty"`
 }
 
-// WorkflowInputProperty is a single input of a workflow form. It is kept apart
-// from ActionProperty because the workflow service accepts `readOnly` and
-// rejects action only attributes such as encryption.
 type WorkflowInputProperty struct {
 	Type             string             `json:"type,omitempty"`
 	Title            *string            `json:"title,omitempty"`
@@ -167,27 +164,20 @@ type WorkflowInputProperty struct {
 	Disabled         any                `json:"disabled,omitempty"`
 }
 
-// WorkflowDataset filters the entities an entity input offers. It is kept apart
-// from Dataset because a workflow rule value is either a fixed value or a
-// `{jqQuery}` object resolved against the form, and Dataset flattens both into a
-// single string.
 type WorkflowDataset struct {
 	Combinator string                `json:"combinator"`
 	Rules      []WorkflowDatasetRule `json:"rules"`
 }
 
 type WorkflowDatasetRule struct {
-	Blueprint *string `json:"blueprint,omitempty"`
-	Property  *string `json:"property,omitempty"`
-	Operator  string  `json:"operator,omitempty"`
-	Value     any     `json:"value,omitempty"`
-	// Group rules carry a combinator and nested rules instead of an operator.
+	Blueprint  *string               `json:"blueprint,omitempty"`
+	Property   *string               `json:"property,omitempty"`
+	Operator   string                `json:"operator,omitempty"`
+	Value      any                   `json:"value,omitempty"`
 	Combinator *string               `json:"combinator,omitempty"`
 	Rules      []WorkflowDatasetRule `json:"rules,omitempty"`
 }
 
-// WorkflowUserInputsStep mirrors cli.Step but carries the step level validations
-// that only workflow forms support.
 type WorkflowUserInputsStep struct {
 	Title       string                    `json:"title"`
 	Order       []string                  `json:"order"`
@@ -195,9 +185,6 @@ type WorkflowUserInputsStep struct {
 	Validations []WorkflowInputValidation `json:"validations,omitempty"`
 }
 
-// WorkflowInputValidation is a jq constraint evaluated against the form data when
-// the form is submitted. The engine is omitted because jq is the only one the
-// service accepts, and it defaults to jq server side.
 type WorkflowInputValidation struct {
 	Constraint string `json:"constraint"`
 	Message    string `json:"message"`

--- a/internal/cli/workflowModels.go
+++ b/internal/cli/workflowModels.go
@@ -124,14 +124,83 @@ type WorkflowNodePermissions struct {
 }
 
 type WorkflowUserInputs struct {
-	Properties map[string]ActionProperty `json:"properties"`
-	Required   any                       `json:"required,omitempty"`
-	Order      []string                  `json:"order,omitempty"`
-	Steps      []Step                    `json:"steps,omitempty"`
-	Titles     map[string]ActionTitle    `json:"titles,omitempty"`
+	Properties  map[string]WorkflowInputProperty `json:"properties"`
+	Required    any                              `json:"required,omitempty"`
+	Order       []string                         `json:"order,omitempty"`
+	Steps       []WorkflowUserInputsStep         `json:"steps,omitempty"`
+	Titles      map[string]ActionTitle           `json:"titles,omitempty"`
+	Validations []WorkflowInputValidation        `json:"validations,omitempty"`
 	// Required on an input node and absent on a self serve trigger, so this is a
 	// pointer for the same reason as WorkflowNodeConfig.Outlets.
 	Buttons *[]WorkflowInputButton `json:"buttons,omitempty"`
+}
+
+// WorkflowInputProperty is a single input of a workflow form. It is kept apart
+// from ActionProperty because the workflow service accepts `readOnly` and
+// rejects action only attributes such as encryption.
+type WorkflowInputProperty struct {
+	Type             string             `json:"type,omitempty"`
+	Title            *string            `json:"title,omitempty"`
+	Description      *string            `json:"description,omitempty"`
+	Icon             *string            `json:"icon,omitempty"`
+	Format           *string            `json:"format,omitempty"`
+	Blueprint        *string            `json:"blueprint,omitempty"`
+	Default          any                `json:"default,omitempty"`
+	DependsOn        []string           `json:"dependsOn,omitempty"`
+	Dataset          *WorkflowDataset   `json:"dataset,omitempty"`
+	Sort             *EntitiesSortModel `json:"sort,omitempty"`
+	Enum             any                `json:"enum,omitempty"`
+	EnumColors       map[string]string  `json:"enumColors,omitempty"`
+	Pattern          any                `json:"pattern,omitempty"`
+	MinLength        *int               `json:"minLength,omitempty"`
+	MaxLength        *int               `json:"maxLength,omitempty"`
+	Minimum          *float64           `json:"minimum,omitempty"`
+	Maximum          *float64           `json:"maximum,omitempty"`
+	ExclusiveMinimum *float64           `json:"exclusiveMinimum,omitempty"`
+	ExclusiveMaximum *float64           `json:"exclusiveMaximum,omitempty"`
+	MinItems         any                `json:"minItems,omitempty"`
+	MaxItems         any                `json:"maxItems,omitempty"`
+	UniqueItems      *bool              `json:"uniqueItems,omitempty"`
+	Items            map[string]any     `json:"items,omitempty"`
+	Visible          any                `json:"visible,omitempty"`
+	ReadOnly         any                `json:"readOnly,omitempty"`
+	Disabled         any                `json:"disabled,omitempty"`
+}
+
+// WorkflowDataset filters the entities an entity input offers. It is kept apart
+// from Dataset because a workflow rule value is either a fixed value or a
+// `{jqQuery}` object resolved against the form, and Dataset flattens both into a
+// single string.
+type WorkflowDataset struct {
+	Combinator string                `json:"combinator"`
+	Rules      []WorkflowDatasetRule `json:"rules"`
+}
+
+type WorkflowDatasetRule struct {
+	Blueprint *string `json:"blueprint,omitempty"`
+	Property  *string `json:"property,omitempty"`
+	Operator  string  `json:"operator,omitempty"`
+	Value     any     `json:"value,omitempty"`
+	// Group rules carry a combinator and nested rules instead of an operator.
+	Combinator *string               `json:"combinator,omitempty"`
+	Rules      []WorkflowDatasetRule `json:"rules,omitempty"`
+}
+
+// WorkflowUserInputsStep mirrors cli.Step but carries the step level validations
+// that only workflow forms support.
+type WorkflowUserInputsStep struct {
+	Title       string                    `json:"title"`
+	Order       []string                  `json:"order"`
+	Visible     any                       `json:"visible,omitempty"`
+	Validations []WorkflowInputValidation `json:"validations,omitempty"`
+}
+
+// WorkflowInputValidation is a jq constraint evaluated against the form data when
+// the form is submitted. The engine is omitted because jq is the only one the
+// service accepts, and it defaults to jq server side.
+type WorkflowInputValidation struct {
+	Constraint string `json:"constraint"`
+	Message    string `json:"message"`
 }
 
 type WorkflowInputButton struct {

--- a/port/action/userinputs.go
+++ b/port/action/userinputs.go
@@ -50,35 +50,6 @@ func UserInputTitlesToBody(ctx context.Context, titles map[string]ActionTitle) (
 	return trigger.UserInputs.Titles, nil
 }
 
-func UserInputStepsToBody(steps []Step) []cli.Step {
-	if steps == nil {
-		return nil
-	}
-
-	result := make([]cli.Step, 0, len(steps))
-	for _, s := range steps {
-		order := make([]string, 0, len(s.Order))
-		for _, p := range s.Order {
-			order = append(order, p.ValueString())
-		}
-
-		step := cli.Step{
-			Title: s.Title.ValueString(),
-			Order: order,
-		}
-
-		if !s.VisibleJqQuery.IsNull() {
-			step.Visible = map[string]string{"jqQuery": s.VisibleJqQuery.ValueString()}
-		} else if !s.Visible.IsNull() {
-			step.Visible = s.Visible.ValueBool()
-		}
-
-		result = append(result, step)
-	}
-
-	return result
-}
-
 // configured reports whether a user_properties block was declared, which decides
 // whether an empty result becomes an empty model or nil.
 func (m *UserInputsMapper) UserPropertiesToState(ctx context.Context, userInputs *cli.ActionUserInputs, configured bool) (*UserPropertiesModel, error) {
@@ -101,37 +72,6 @@ func (m *UserInputsMapper) UserInputTitlesToState(userInputs *cli.ActionUserInpu
 	}
 
 	return m.resource.buildActionTitles(&cli.Action{Trigger: &cli.Trigger{UserInputs: userInputs}})
-}
-
-func UserInputStepsToState(steps []cli.Step) []Step {
-	if len(steps) == 0 {
-		return nil
-	}
-
-	result := make([]Step, 0, len(steps))
-	for _, step := range steps {
-		order := make([]types.String, 0, len(step.Order))
-		for _, p := range step.Order {
-			order = append(order, types.StringValue(p))
-		}
-
-		s := Step{
-			Title: types.StringValue(step.Title),
-			Order: order,
-		}
-
-		visible, visibleJq := buildBoolOrJq(step.Visible)
-		if !visible.IsNull() {
-			s.Visible = visible
-		}
-		if !visibleJq.IsNull() {
-			s.VisibleJqQuery = visibleJq
-		}
-
-		result = append(result, s)
-	}
-
-	return result
 }
 
 func UserInputsRequiredToState(userInputs *cli.ActionUserInputs) types.String {

--- a/port/workflow/model.go
+++ b/port/workflow/model.go
@@ -2,7 +2,6 @@ package workflow
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/port-labs/terraform-provider-port-labs/v2/port/action"
 )
 
 type WorkflowModel struct {
@@ -51,11 +50,33 @@ type SelfServeTriggerModel struct {
 }
 
 type SelfServeUserInputsModel struct {
-	UserProperties  *action.UserPropertiesModel   `tfsdk:"user_properties"`
-	Titles          map[string]action.ActionTitle `tfsdk:"titles"`
-	RequiredJqQuery types.String                  `tfsdk:"required_jq_query"`
-	OrderProperties types.List                    `tfsdk:"order_properties"`
-	Steps           []action.Step                 `tfsdk:"steps"`
+	UserProperties  *UserPropertiesModel     `tfsdk:"user_properties"`
+	Titles          map[string]UserInputText `tfsdk:"titles"`
+	RequiredJqQuery types.String             `tfsdk:"required_jq_query"`
+	OrderProperties types.List               `tfsdk:"order_properties"`
+	Steps           []UserInputsStepModel    `tfsdk:"steps"`
+	Validations     []InputValidationModel   `tfsdk:"validations"`
+}
+
+// UserInputText is a static title rendered between the inputs of the form.
+type UserInputText struct {
+	Title          types.String `tfsdk:"title"`
+	Description    types.String `tfsdk:"description"`
+	Visible        types.Bool   `tfsdk:"visible"`
+	VisibleJqQuery types.String `tfsdk:"visible_jq_query"`
+}
+
+type UserInputsStepModel struct {
+	Title          types.String           `tfsdk:"title"`
+	Order          []types.String         `tfsdk:"order"`
+	Visible        types.Bool             `tfsdk:"visible"`
+	VisibleJqQuery types.String           `tfsdk:"visible_jq_query"`
+	Validations    []InputValidationModel `tfsdk:"validations"`
+}
+
+type InputValidationModel struct {
+	Constraint types.String `tfsdk:"constraint"`
+	Message    types.String `tfsdk:"message"`
 }
 
 type TriggerContextModel struct {
@@ -169,12 +190,13 @@ type InputModel struct {
 }
 
 type InputUserInputsModel struct {
-	UserProperties  *action.UserPropertiesModel   `tfsdk:"user_properties"`
-	Titles          map[string]action.ActionTitle `tfsdk:"titles"`
-	RequiredJqQuery types.String                  `tfsdk:"required_jq_query"`
-	OrderProperties types.List                    `tfsdk:"order_properties"`
-	Steps           []action.Step                 `tfsdk:"steps"`
-	Buttons         []InputButtonModel            `tfsdk:"buttons"`
+	UserProperties  *UserPropertiesModel     `tfsdk:"user_properties"`
+	Titles          map[string]UserInputText `tfsdk:"titles"`
+	RequiredJqQuery types.String             `tfsdk:"required_jq_query"`
+	OrderProperties types.List               `tfsdk:"order_properties"`
+	Steps           []UserInputsStepModel    `tfsdk:"steps"`
+	Validations     []InputValidationModel   `tfsdk:"validations"`
+	Buttons         []InputButtonModel       `tfsdk:"buttons"`
 }
 
 type InputButtonModel struct {

--- a/port/workflow/model.go
+++ b/port/workflow/model.go
@@ -58,7 +58,6 @@ type SelfServeUserInputsModel struct {
 	Validations     []InputValidationModel   `tfsdk:"validations"`
 }
 
-// UserInputText is a static title rendered between the inputs of the form.
 type UserInputText struct {
 	Title          types.String `tfsdk:"title"`
 	Description    types.String `tfsdk:"description"`

--- a/port/workflow/refreshWorkflowState.go
+++ b/port/workflow/refreshWorkflowState.go
@@ -9,7 +9,6 @@ import (
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/consts"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/flex"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/utils"
-	"github.com/port-labs/terraform-provider-port-labs/v2/port/action"
 )
 
 func (r *WorkflowResource) refreshWorkflowState(ctx context.Context, state *WorkflowModel, w *cli.Workflow) error {
@@ -83,7 +82,9 @@ func (r *WorkflowResource) nodeToModel(ctx context.Context, apiNode cli.Workflow
 		}
 
 		if config.UserInputs != nil {
-			configured := prior.SelfServeTrigger != nil && prior.SelfServeTrigger.UserInputs != nil
+			configured := prior.SelfServeTrigger != nil &&
+				prior.SelfServeTrigger.UserInputs != nil &&
+				prior.SelfServeTrigger.UserInputs.UserProperties != nil
 			userInputs, err := r.userInputsToModel(ctx, config.UserInputs, configured)
 			if err != nil {
 				return node, err
@@ -94,6 +95,7 @@ func (r *WorkflowResource) nodeToModel(ctx context.Context, apiNode cli.Workflow
 				RequiredJqQuery: userInputs.RequiredJqQuery,
 				OrderProperties: userInputs.OrderProperties,
 				Steps:           userInputs.Steps,
+				Validations:     userInputs.Validations,
 			}
 		}
 
@@ -242,7 +244,9 @@ func (r *WorkflowResource) nodeToModel(ctx context.Context, apiNode cli.Workflow
 		}
 
 		if config.UserInputs != nil {
-			configured := prior.Input != nil && prior.Input.UserInputs != nil
+			configured := prior.Input != nil &&
+				prior.Input.UserInputs != nil &&
+				prior.Input.UserInputs.UserProperties != nil
 			userInputs, err := r.userInputsToModel(ctx, config.UserInputs, configured)
 			if err != nil {
 				return node, err
@@ -253,6 +257,7 @@ func (r *WorkflowResource) nodeToModel(ctx context.Context, apiNode cli.Workflow
 				RequiredJqQuery: userInputs.RequiredJqQuery,
 				OrderProperties: userInputs.OrderProperties,
 				Steps:           userInputs.Steps,
+				Validations:     userInputs.Validations,
 			}
 			for _, b := range derefSlice(config.UserInputs.Buttons) {
 				input.UserInputs.Buttons = append(input.UserInputs.Buttons, InputButtonModel{
@@ -296,41 +301,106 @@ func (r *WorkflowResource) nodeToModel(ctx context.Context, apiNode cli.Workflow
 }
 
 type userInputsModel struct {
-	UserProperties  *action.UserPropertiesModel
-	Titles          map[string]action.ActionTitle
+	UserProperties  *UserPropertiesModel
+	Titles          map[string]UserInputText
 	RequiredJqQuery types.String
 	OrderProperties types.List
-	Steps           []action.Step
+	Steps           []UserInputsStepModel
+	Validations     []InputValidationModel
 }
 
 func (r *WorkflowResource) userInputsToModel(ctx context.Context, userInputs *cli.WorkflowUserInputs, configured bool) (*userInputsModel, error) {
-	apiUserInputs := &cli.ActionUserInputs{
-		Properties: userInputs.Properties,
-		Required:   userInputs.Required,
-		Order:      userInputs.Order,
-		Steps:      userInputs.Steps,
-		Titles:     userInputs.Titles,
-	}
-
-	mapper := action.NewUserInputsMapper(r.portClient)
-
-	userProperties, err := mapper.UserPropertiesToState(ctx, apiUserInputs, configured)
+	userProperties, err := r.userPropertiesToState(ctx, userInputs, configured)
 	if err != nil {
 		return nil, err
 	}
 
-	titles, err := mapper.UserInputTitlesToState(apiUserInputs)
-	if err != nil {
-		return nil, err
+	requiredJqQuery, _ := requiredToState(userInputs.Required)
+
+	orderProperties := types.ListNull(types.StringType)
+	if len(userInputs.Order) > 0 {
+		orderProperties = flex.GoArrayStringToTerraformList(ctx, userInputs.Order)
 	}
 
 	return &userInputsModel{
 		UserProperties:  userProperties,
-		Titles:          titles,
-		RequiredJqQuery: action.UserInputsRequiredToState(apiUserInputs),
-		OrderProperties: action.UserInputsOrderToState(ctx, apiUserInputs.Order),
-		Steps:           action.UserInputStepsToState(apiUserInputs.Steps),
+		Titles:          userInputTitlesToModel(userInputs.Titles),
+		RequiredJqQuery: requiredJqQuery,
+		OrderProperties: orderProperties,
+		Steps:           userInputStepsToModel(userInputs.Steps),
+		Validations:     validationsToModel(userInputs.Validations),
 	}, nil
+}
+
+func userInputTitlesToModel(titles map[string]cli.ActionTitle) map[string]UserInputText {
+	if titles == nil {
+		return nil
+	}
+
+	result := make(map[string]UserInputText, len(titles))
+	for identifier, title := range titles {
+		converted := UserInputText{
+			Title:       types.StringValue(title.Title),
+			Description: flex.GoStringToFramework(title.Description),
+		}
+		converted.Visible, converted.VisibleJqQuery = boolOrJqToState(title.Visible)
+		result[identifier] = converted
+	}
+
+	return result
+}
+
+func userInputStepsToModel(steps []cli.WorkflowUserInputsStep) []UserInputsStepModel {
+	if len(steps) == 0 {
+		return nil
+	}
+
+	result := make([]UserInputsStepModel, 0, len(steps))
+	for _, step := range steps {
+		order := make([]types.String, 0, len(step.Order))
+		for _, p := range step.Order {
+			order = append(order, types.StringValue(p))
+		}
+
+		s := UserInputsStepModel{
+			Title:       types.StringValue(step.Title),
+			Order:       order,
+			Validations: validationsToModel(step.Validations),
+		}
+
+		switch visible := step.Visible.(type) {
+		case bool:
+			s.Visible = types.BoolValue(visible)
+		case map[string]any:
+			if jqQuery, ok := visible["jqQuery"].(string); ok {
+				s.VisibleJqQuery = types.StringValue(jqQuery)
+			}
+		case map[string]string:
+			if jqQuery, ok := visible["jqQuery"]; ok {
+				s.VisibleJqQuery = types.StringValue(jqQuery)
+			}
+		}
+
+		result = append(result, s)
+	}
+
+	return result
+}
+
+func validationsToModel(validations []cli.WorkflowInputValidation) []InputValidationModel {
+	if len(validations) == 0 {
+		return nil
+	}
+
+	result := make([]InputValidationModel, 0, len(validations))
+	for _, v := range validations {
+		result = append(result, InputValidationModel{
+			Constraint: types.StringValue(v.Constraint),
+			Message:    types.StringValue(v.Message),
+		})
+	}
+
+	return result
 }
 
 func upsertMappingToModel(ctx context.Context, mapping *cli.WorkflowUpsertMapping, jsonEscapeHTML bool) (*UpsertMappingModel, error) {

--- a/port/workflow/schema.go
+++ b/port/workflow/schema.go
@@ -250,8 +250,6 @@ func userInputsAttributes() map[string]schema.Attribute {
 	}
 }
 
-// validationsSchema is the `validations` list shared by the form and its steps.
-// The service accepts jq as the only engine, so the engine is not configurable.
 func validationsSchema(description string) schema.ListNestedAttribute {
 	return schema.ListNestedAttribute{
 		MarkdownDescription: description + " Up to 10 rules are allowed.",
@@ -272,8 +270,6 @@ func validationsSchema(description string) schema.ListNestedAttribute {
 			},
 		},
 		Validators: []validator.List{
-			// An empty list is rejected rather than sent, because the API drops
-			// it on read and the next plan would show a diff.
 			listvalidator.SizeAtLeast(1),
 			listvalidator.SizeAtMost(10),
 		},

--- a/port/workflow/schema.go
+++ b/port/workflow/schema.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/consts"
-	"github.com/port-labs/terraform-provider-port-labs/v2/port/action"
 )
 
 // CURSOR_AGENT is intentionally absent: it is still a live member of the service
@@ -169,17 +168,7 @@ func respondersBlock(description string) schema.Block {
 
 func userInputsAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
-		"user_properties": schema.SingleNestedAttribute{
-			MarkdownDescription: "The user inputs the form collects.",
-			Optional:            true,
-			Attributes: map[string]schema.Attribute{
-				"string_props":  action.StringPropertySchema(),
-				"number_props":  action.NumberPropertySchema(),
-				"boolean_props": action.BooleanPropertySchema(),
-				"object_props":  action.ObjectPropertySchema(),
-				"array_props":   action.ArrayPropertySchema(),
-			},
-		},
+		"user_properties": userPropertiesSchema(),
 		"titles": schema.MapNestedAttribute{
 			MarkdownDescription: "Static titles rendered between the inputs of the form.",
 			Optional:            true,
@@ -244,11 +233,49 @@ func userInputsAttributes() map[string]schema.Attribute {
 							stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("visible")),
 						},
 					},
+					"validations": validationsSchema("Validation rules evaluated when the step is submitted."),
 				},
 			},
 			Validators: []validator.List{
-				listvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("order_properties")),
+				listvalidator.ConflictsWith(
+					path.MatchRelative().AtParent().AtName("order_properties"),
+					path.MatchRelative().AtParent().AtName("validations"),
+				),
 			},
+		},
+		"validations": validationsSchema(
+			"Validation rules evaluated against the whole form when it is submitted. " +
+				"Cannot be combined with `steps`, add the rules to the individual steps instead.",
+		),
+	}
+}
+
+// validationsSchema is the `validations` list shared by the form and its steps.
+// The service accepts jq as the only engine, so the engine is not configurable.
+func validationsSchema(description string) schema.ListNestedAttribute {
+	return schema.ListNestedAttribute{
+		MarkdownDescription: description + " Up to 10 rules are allowed.",
+		Optional:            true,
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"constraint": schema.StringAttribute{
+					MarkdownDescription: "A jq expression that has to evaluate to `true` for the form to be valid.",
+					Required:            true,
+				},
+				"message": schema.StringAttribute{
+					MarkdownDescription: "The error message shown when the constraint evaluates to `false` (max 100 characters).",
+					Required:            true,
+					Validators: []validator.String{
+						stringvalidator.LengthAtMost(100),
+					},
+				},
+			},
+		},
+		Validators: []validator.List{
+			// An empty list is rejected rather than sent, because the API drops
+			// it on read and the next plan would show a diff.
+			listvalidator.SizeAtLeast(1),
+			listvalidator.SizeAtMost(10),
 		},
 	}
 }

--- a/port/workflow/userPropertiesModel.go
+++ b/port/workflow/userPropertiesModel.go
@@ -2,12 +2,6 @@ package workflow
 
 import "github.com/hashicorp/terraform-plugin-framework/types"
 
-// The models below intentionally do not reuse the ones from the action package.
-// Workflow forms and action forms look alike but are validated by different
-// services: workflow inputs additionally support `read_only`, give `disabled` a
-// different meaning, and reject attributes such as encryption or boolean array
-// items that actions accept.
-
 type UserPropertiesModel struct {
 	StringProps  map[string]StringPropModel  `tfsdk:"string_props"`
 	NumberProps  map[string]NumberPropModel  `tfsdk:"number_props"`
@@ -160,12 +154,11 @@ type DatasetModel struct {
 }
 
 type DatasetRuleModel struct {
-	Blueprint types.String `tfsdk:"blueprint"`
-	Property  types.String `tfsdk:"property"`
-	Operator  types.String `tfsdk:"operator"`
-	Value     *ValueModel  `tfsdk:"value"`
-	ValueJson types.String `tfsdk:"value_json"`
-	// Group rules carry a combinator and nested rules instead of an operator.
+	Blueprint  types.String       `tfsdk:"blueprint"`
+	Property   types.String       `tfsdk:"property"`
+	Operator   types.String       `tfsdk:"operator"`
+	Value      *ValueModel        `tfsdk:"value"`
+	ValueJson  types.String       `tfsdk:"value_json"`
 	Combinator types.String       `tfsdk:"combinator"`
 	Rules      []DatasetRuleModel `tfsdk:"rules"`
 }
@@ -174,10 +167,6 @@ type ValueModel struct {
 	JqQuery types.String `tfsdk:"jq_query"`
 }
 
-// propCommon points at the attributes every input type shares so the mappers can
-// read and write them once instead of switching on the property type. The
-// framework needs a flat struct per property, so the fields cannot simply be
-// embedded.
 type propCommon struct {
 	Title           *types.String
 	Icon            *types.String

--- a/port/workflow/userPropertiesModel.go
+++ b/port/workflow/userPropertiesModel.go
@@ -1,0 +1,238 @@
+package workflow
+
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
+// The models below intentionally do not reuse the ones from the action package.
+// Workflow forms and action forms look alike but are validated by different
+// services: workflow inputs additionally support `read_only`, give `disabled` a
+// different meaning, and reject attributes such as encryption or boolean array
+// items that actions accept.
+
+type UserPropertiesModel struct {
+	StringProps  map[string]StringPropModel  `tfsdk:"string_props"`
+	NumberProps  map[string]NumberPropModel  `tfsdk:"number_props"`
+	BooleanProps map[string]BooleanPropModel `tfsdk:"boolean_props"`
+	ArrayProps   map[string]ArrayPropModel   `tfsdk:"array_props"`
+	ObjectProps  map[string]ObjectPropModel  `tfsdk:"object_props"`
+}
+
+type StringPropModel struct {
+	Title           types.String `tfsdk:"title"`
+	Icon            types.String `tfsdk:"icon"`
+	Description     types.String `tfsdk:"description"`
+	Required        types.Bool   `tfsdk:"required"`
+	DependsOn       types.List   `tfsdk:"depends_on"`
+	Visible         types.Bool   `tfsdk:"visible"`
+	VisibleJqQuery  types.String `tfsdk:"visible_jq_query"`
+	ReadOnly        types.Bool   `tfsdk:"read_only"`
+	ReadOnlyJqQuery types.String `tfsdk:"read_only_jq_query"`
+	Disabled        types.Bool   `tfsdk:"disabled"`
+	DisabledJqQuery types.String `tfsdk:"disabled_jq_query"`
+
+	Default        types.String       `tfsdk:"default"`
+	DefaultJqQuery types.String       `tfsdk:"default_jq_query"`
+	Format         types.String       `tfsdk:"format"`
+	Blueprint      types.String       `tfsdk:"blueprint"`
+	Dataset        *DatasetModel      `tfsdk:"dataset"`
+	Sort           *EntitiesSortModel `tfsdk:"sort"`
+	MinLength      types.Int64        `tfsdk:"min_length"`
+	MaxLength      types.Int64        `tfsdk:"max_length"`
+	Pattern        types.String       `tfsdk:"pattern"`
+	PatternJqQuery types.String       `tfsdk:"pattern_jq_query"`
+	Enum           types.List         `tfsdk:"enum"`
+	EnumColors     types.Map          `tfsdk:"enum_colors"`
+	EnumJqQuery    types.String       `tfsdk:"enum_jq_query"`
+}
+
+type NumberPropModel struct {
+	Title           types.String `tfsdk:"title"`
+	Icon            types.String `tfsdk:"icon"`
+	Description     types.String `tfsdk:"description"`
+	Required        types.Bool   `tfsdk:"required"`
+	DependsOn       types.List   `tfsdk:"depends_on"`
+	Visible         types.Bool   `tfsdk:"visible"`
+	VisibleJqQuery  types.String `tfsdk:"visible_jq_query"`
+	ReadOnly        types.Bool   `tfsdk:"read_only"`
+	ReadOnlyJqQuery types.String `tfsdk:"read_only_jq_query"`
+	Disabled        types.Bool   `tfsdk:"disabled"`
+	DisabledJqQuery types.String `tfsdk:"disabled_jq_query"`
+
+	Default          types.Float64 `tfsdk:"default"`
+	DefaultJqQuery   types.String  `tfsdk:"default_jq_query"`
+	Minimum          types.Float64 `tfsdk:"minimum"`
+	Maximum          types.Float64 `tfsdk:"maximum"`
+	ExclusiveMinimum types.Float64 `tfsdk:"exclusive_minimum"`
+	ExclusiveMaximum types.Float64 `tfsdk:"exclusive_maximum"`
+	Enum             types.List    `tfsdk:"enum"`
+	EnumJqQuery      types.String  `tfsdk:"enum_jq_query"`
+}
+
+type BooleanPropModel struct {
+	Title           types.String `tfsdk:"title"`
+	Icon            types.String `tfsdk:"icon"`
+	Description     types.String `tfsdk:"description"`
+	Required        types.Bool   `tfsdk:"required"`
+	DependsOn       types.List   `tfsdk:"depends_on"`
+	Visible         types.Bool   `tfsdk:"visible"`
+	VisibleJqQuery  types.String `tfsdk:"visible_jq_query"`
+	ReadOnly        types.Bool   `tfsdk:"read_only"`
+	ReadOnlyJqQuery types.String `tfsdk:"read_only_jq_query"`
+	Disabled        types.Bool   `tfsdk:"disabled"`
+	DisabledJqQuery types.String `tfsdk:"disabled_jq_query"`
+
+	Default        types.Bool   `tfsdk:"default"`
+	DefaultJqQuery types.String `tfsdk:"default_jq_query"`
+}
+
+type ObjectPropModel struct {
+	Title           types.String `tfsdk:"title"`
+	Icon            types.String `tfsdk:"icon"`
+	Description     types.String `tfsdk:"description"`
+	Required        types.Bool   `tfsdk:"required"`
+	DependsOn       types.List   `tfsdk:"depends_on"`
+	Visible         types.Bool   `tfsdk:"visible"`
+	VisibleJqQuery  types.String `tfsdk:"visible_jq_query"`
+	ReadOnly        types.Bool   `tfsdk:"read_only"`
+	ReadOnlyJqQuery types.String `tfsdk:"read_only_jq_query"`
+	Disabled        types.Bool   `tfsdk:"disabled"`
+	DisabledJqQuery types.String `tfsdk:"disabled_jq_query"`
+
+	Default        types.String `tfsdk:"default"`
+	DefaultJqQuery types.String `tfsdk:"default_jq_query"`
+	Format         types.String `tfsdk:"format"`
+}
+
+type ArrayPropModel struct {
+	Title           types.String `tfsdk:"title"`
+	Icon            types.String `tfsdk:"icon"`
+	Description     types.String `tfsdk:"description"`
+	Required        types.Bool   `tfsdk:"required"`
+	DependsOn       types.List   `tfsdk:"depends_on"`
+	Visible         types.Bool   `tfsdk:"visible"`
+	VisibleJqQuery  types.String `tfsdk:"visible_jq_query"`
+	ReadOnly        types.Bool   `tfsdk:"read_only"`
+	ReadOnlyJqQuery types.String `tfsdk:"read_only_jq_query"`
+	Disabled        types.Bool   `tfsdk:"disabled"`
+	DisabledJqQuery types.String `tfsdk:"disabled_jq_query"`
+
+	DefaultJqQuery  types.String       `tfsdk:"default_jq_query"`
+	MinItems        types.Int64        `tfsdk:"min_items"`
+	MinItemsJqQuery types.String       `tfsdk:"min_items_jq_query"`
+	MaxItems        types.Int64        `tfsdk:"max_items"`
+	MaxItemsJqQuery types.String       `tfsdk:"max_items_jq_query"`
+	UniqueItems     types.Bool         `tfsdk:"unique_items"`
+	StringItems     *StringItemsModel  `tfsdk:"string_items"`
+	NumberItems     *NumberItemsModel  `tfsdk:"number_items"`
+	ObjectItems     *ObjectItemsModel  `tfsdk:"object_items"`
+	Sort            *EntitiesSortModel `tfsdk:"sort"`
+}
+
+type StringItemsModel struct {
+	Format      types.String `tfsdk:"format"`
+	Blueprint   types.String `tfsdk:"blueprint"`
+	Default     types.List   `tfsdk:"default"`
+	Enum        types.List   `tfsdk:"enum"`
+	EnumJqQuery types.String `tfsdk:"enum_jq_query"`
+	EnumColors  types.Map    `tfsdk:"enum_colors"`
+	Dataset     types.String `tfsdk:"dataset"`
+}
+
+type NumberItemsModel struct {
+	Default     types.List   `tfsdk:"default"`
+	Enum        types.List   `tfsdk:"enum"`
+	EnumJqQuery types.String `tfsdk:"enum_jq_query"`
+	EnumColors  types.Map    `tfsdk:"enum_colors"`
+}
+
+type ObjectItemsModel struct {
+	Format  types.String `tfsdk:"format"`
+	Default types.List   `tfsdk:"default"`
+}
+
+type EntitiesSortModel struct {
+	Property types.String `tfsdk:"property"`
+	Order    types.String `tfsdk:"order"`
+}
+
+type DatasetModel struct {
+	Combinator types.String       `tfsdk:"combinator"`
+	Rules      []DatasetRuleModel `tfsdk:"rules"`
+}
+
+type DatasetRuleModel struct {
+	Blueprint types.String `tfsdk:"blueprint"`
+	Property  types.String `tfsdk:"property"`
+	Operator  types.String `tfsdk:"operator"`
+	Value     *ValueModel  `tfsdk:"value"`
+	ValueJson types.String `tfsdk:"value_json"`
+	// Group rules carry a combinator and nested rules instead of an operator.
+	Combinator types.String       `tfsdk:"combinator"`
+	Rules      []DatasetRuleModel `tfsdk:"rules"`
+}
+
+type ValueModel struct {
+	JqQuery types.String `tfsdk:"jq_query"`
+}
+
+// propCommon points at the attributes every input type shares so the mappers can
+// read and write them once instead of switching on the property type. The
+// framework needs a flat struct per property, so the fields cannot simply be
+// embedded.
+type propCommon struct {
+	Title           *types.String
+	Icon            *types.String
+	Description     *types.String
+	Required        *types.Bool
+	DependsOn       *types.List
+	Visible         *types.Bool
+	VisibleJqQuery  *types.String
+	ReadOnly        *types.Bool
+	ReadOnlyJqQuery *types.String
+	Disabled        *types.Bool
+	DisabledJqQuery *types.String
+}
+
+func (p *StringPropModel) common() propCommon {
+	return propCommon{
+		Title: &p.Title, Icon: &p.Icon, Description: &p.Description, Required: &p.Required, DependsOn: &p.DependsOn,
+		Visible: &p.Visible, VisibleJqQuery: &p.VisibleJqQuery,
+		ReadOnly: &p.ReadOnly, ReadOnlyJqQuery: &p.ReadOnlyJqQuery,
+		Disabled: &p.Disabled, DisabledJqQuery: &p.DisabledJqQuery,
+	}
+}
+
+func (p *NumberPropModel) common() propCommon {
+	return propCommon{
+		Title: &p.Title, Icon: &p.Icon, Description: &p.Description, Required: &p.Required, DependsOn: &p.DependsOn,
+		Visible: &p.Visible, VisibleJqQuery: &p.VisibleJqQuery,
+		ReadOnly: &p.ReadOnly, ReadOnlyJqQuery: &p.ReadOnlyJqQuery,
+		Disabled: &p.Disabled, DisabledJqQuery: &p.DisabledJqQuery,
+	}
+}
+
+func (p *BooleanPropModel) common() propCommon {
+	return propCommon{
+		Title: &p.Title, Icon: &p.Icon, Description: &p.Description, Required: &p.Required, DependsOn: &p.DependsOn,
+		Visible: &p.Visible, VisibleJqQuery: &p.VisibleJqQuery,
+		ReadOnly: &p.ReadOnly, ReadOnlyJqQuery: &p.ReadOnlyJqQuery,
+		Disabled: &p.Disabled, DisabledJqQuery: &p.DisabledJqQuery,
+	}
+}
+
+func (p *ObjectPropModel) common() propCommon {
+	return propCommon{
+		Title: &p.Title, Icon: &p.Icon, Description: &p.Description, Required: &p.Required, DependsOn: &p.DependsOn,
+		Visible: &p.Visible, VisibleJqQuery: &p.VisibleJqQuery,
+		ReadOnly: &p.ReadOnly, ReadOnlyJqQuery: &p.ReadOnlyJqQuery,
+		Disabled: &p.Disabled, DisabledJqQuery: &p.DisabledJqQuery,
+	}
+}
+
+func (p *ArrayPropModel) common() propCommon {
+	return propCommon{
+		Title: &p.Title, Icon: &p.Icon, Description: &p.Description, Required: &p.Required, DependsOn: &p.DependsOn,
+		Visible: &p.Visible, VisibleJqQuery: &p.VisibleJqQuery,
+		ReadOnly: &p.ReadOnly, ReadOnlyJqQuery: &p.ReadOnlyJqQuery,
+		Disabled: &p.Disabled, DisabledJqQuery: &p.DisabledJqQuery,
+	}
+}

--- a/port/workflow/userPropertiesSchema.go
+++ b/port/workflow/userPropertiesSchema.go
@@ -14,16 +14,11 @@ import (
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/utils"
 )
 
-// The formats the workflow service accepts per input type. There is no `none`
-// format: the service compiles the form into a JSON schema and rejects any
-// format it does not know, so an unformatted input leaves `format` out.
 var (
 	stringPropertyFormats = []string{
 		"multi-line", "date-time", "email", "entity", "team", "user", "url", "markdown", "yaml", "proto",
 	}
 	stringItemFormats = []string{"entity", "team", "user", "date-time", "email", "url", "yaml"}
-	// An object carries no `format` beyond `labeled-url`, because the JSON
-	// schema `format` keyword only applies to strings and numbers.
 	objectFormats     = []string{"labeled-url"}
 	objectItemFormats = []string{"labeled-url"}
 )
@@ -42,7 +37,6 @@ func userPropertiesSchema() schema.Attribute {
 	}
 }
 
-// propertyMetadataSchema holds the attributes shared by every input type.
 func propertyMetadataSchema(propertyType string) map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"title": schema.StringAttribute{
@@ -68,9 +62,6 @@ func propertyMetadataSchema(propertyType string) map[string]schema.Attribute {
 			Optional:            true,
 			Validators: []validator.Bool{
 				isTrueValidator{},
-				// Hops from `required` up to the user inputs block that owns
-				// required_jq_query: the property, the property map, and
-				// user_properties.
 				boolvalidator.ConflictsWith(
 					path.MatchRelative().AtParent().AtParent().AtParent().AtParent().AtName("required_jq_query"),
 				),
@@ -501,8 +492,6 @@ func datasetSchema() schema.Attribute {
 				MarkdownDescription: "The rules of the dataset. A rule either filters on a property or groups nested rules under a combinator.",
 				Required:            true,
 				NestedObject: schema.NestedAttributeObject{
-					// 10 levels of nesting, past which the schema stops
-					// recursing while the Go model keeps accepting rules.
 					Attributes: datasetRuleSchema(10),
 				},
 			},

--- a/port/workflow/userPropertiesSchema.go
+++ b/port/workflow/userPropertiesSchema.go
@@ -1,0 +1,561 @@
+package workflow
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework-validators/boolvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/utils"
+)
+
+// The formats the workflow service accepts per input type. There is no `none`
+// format: the service compiles the form into a JSON schema and rejects any
+// format it does not know, so an unformatted input leaves `format` out.
+var (
+	stringPropertyFormats = []string{
+		"multi-line", "date-time", "email", "entity", "team", "user", "url", "markdown", "yaml", "proto",
+	}
+	stringItemFormats = []string{"entity", "team", "user", "date-time", "email", "url", "yaml"}
+	// An object carries no `format` beyond `labeled-url`, because the JSON
+	// schema `format` keyword only applies to strings and numbers.
+	objectFormats     = []string{"labeled-url"}
+	objectItemFormats = []string{"labeled-url"}
+)
+
+func userPropertiesSchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		MarkdownDescription: "The user inputs the form collects.",
+		Optional:            true,
+		Attributes: map[string]schema.Attribute{
+			"string_props":  stringPropertySchema(),
+			"number_props":  numberPropertySchema(),
+			"boolean_props": booleanPropertySchema(),
+			"object_props":  objectPropertySchema(),
+			"array_props":   arrayPropertySchema(),
+		},
+	}
+}
+
+// propertyMetadataSchema holds the attributes shared by every input type.
+func propertyMetadataSchema(propertyType string) map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"title": schema.StringAttribute{
+			MarkdownDescription: "The title of the " + propertyType + " input.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.LengthAtMost(140),
+			},
+		},
+		"icon": schema.StringAttribute{
+			MarkdownDescription: "The icon of the " + propertyType + " input.",
+			Optional:            true,
+		},
+		"description": schema.StringAttribute{
+			MarkdownDescription: "The description of the " + propertyType + " input.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.LengthAtMost(1000),
+			},
+		},
+		"required": schema.BoolAttribute{
+			MarkdownDescription: "Whether the input has to be filled in. Only `true` is accepted, and it cannot be combined with `required_jq_query`.",
+			Optional:            true,
+			Validators: []validator.Bool{
+				isTrueValidator{},
+				// Hops from `required` up to the user inputs block that owns
+				// required_jq_query: the property, the property map, and
+				// user_properties.
+				boolvalidator.ConflictsWith(
+					path.MatchRelative().AtParent().AtParent().AtParent().AtParent().AtName("required_jq_query"),
+				),
+			},
+		},
+		"depends_on": schema.ListAttribute{
+			MarkdownDescription: "The inputs this input depends on.",
+			Optional:            true,
+			ElementType:         types.StringType,
+		},
+		"visible": schema.BoolAttribute{
+			MarkdownDescription: "The visibility of the " + propertyType + " input.",
+			Optional:            true,
+		},
+		"visible_jq_query": schema.StringAttribute{
+			MarkdownDescription: "The visibility condition jq query of the " + propertyType + " input.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("visible")),
+			},
+		},
+		"read_only": schema.BoolAttribute{
+			MarkdownDescription: "Shows the value of the " + propertyType + " input without letting the user change it. " +
+				"The value is still submitted with the form, unlike `disabled`.",
+			Optional: true,
+		},
+		"read_only_jq_query": schema.StringAttribute{
+			MarkdownDescription: "The read only condition jq query of the " + propertyType + " input.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("read_only")),
+			},
+		},
+		"disabled": schema.BoolAttribute{
+			MarkdownDescription: "Greys out the " + propertyType + " input. A disabled input is excluded from the submitted " +
+				"data and from `required` validation, which makes it a way to drop an input from the form based on the other answers. " +
+				"Use `read_only` to keep the value in the submission.",
+			Optional: true,
+		},
+		"disabled_jq_query": schema.StringAttribute{
+			MarkdownDescription: "The disabled condition jq query of the " + propertyType + " input.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("disabled")),
+			},
+		},
+	}
+}
+
+func stringPropertySchema() schema.Attribute {
+	properties := map[string]schema.Attribute{
+		"default": schema.StringAttribute{
+			MarkdownDescription: "The default of the string input.",
+			Optional:            true,
+		},
+		"default_jq_query": schema.StringAttribute{
+			MarkdownDescription: "The default jq query of the string input.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("default")),
+			},
+		},
+		"format": schema.StringAttribute{
+			MarkdownDescription: "The format of the string input.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.OneOf(stringPropertyFormats...),
+			},
+		},
+		"blueprint": schema.StringAttribute{
+			MarkdownDescription: "The blueprint the entities are taken from. Required when `format` is `entity`.",
+			Optional:            true,
+		},
+		"dataset": datasetSchema(),
+		"sort":    entitiesSortSchema(),
+		"min_length": schema.Int64Attribute{
+			MarkdownDescription: "The min length of the string input.",
+			Optional:            true,
+			Validators: []validator.Int64{
+				int64validator.AtLeast(1),
+			},
+		},
+		"max_length": schema.Int64Attribute{
+			MarkdownDescription: "The max length of the string input.",
+			Optional:            true,
+			Validators: []validator.Int64{
+				int64validator.AtLeast(1),
+			},
+		},
+		"pattern": schema.StringAttribute{
+			MarkdownDescription: "The regex pattern the value has to match.",
+			Optional:            true,
+		},
+		"pattern_jq_query": schema.StringAttribute{
+			MarkdownDescription: "A jq query resolving the pattern of the string input, either a regex string or a list of allowed values.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("pattern")),
+				stringvalidator.LengthAtLeast(1),
+			},
+		},
+		"enum": schema.ListAttribute{
+			MarkdownDescription: "The values the user can pick from.",
+			Optional:            true,
+			ElementType:         types.StringType,
+			Validators: []validator.List{
+				listvalidator.UniqueValues(),
+				listvalidator.SizeAtLeast(1),
+			},
+		},
+		"enum_jq_query": schema.StringAttribute{
+			MarkdownDescription: "A jq query resolving the values the user can pick from.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("enum")),
+			},
+		},
+		"enum_colors": schema.MapAttribute{
+			MarkdownDescription: "The colors of the enum values.",
+			Optional:            true,
+			ElementType:         types.StringType,
+		},
+	}
+
+	utils.CopyMaps(properties, propertyMetadataSchema("string"))
+	return schema.MapNestedAttribute{
+		MarkdownDescription: "The string inputs of the form.",
+		Optional:            true,
+		NestedObject:        schema.NestedAttributeObject{Attributes: properties},
+	}
+}
+
+func numberPropertySchema() schema.Attribute {
+	properties := map[string]schema.Attribute{
+		"default": schema.Float64Attribute{
+			MarkdownDescription: "The default of the number input.",
+			Optional:            true,
+		},
+		"default_jq_query": schema.StringAttribute{
+			MarkdownDescription: "The default jq query of the number input.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("default")),
+			},
+		},
+		"minimum": schema.Float64Attribute{
+			MarkdownDescription: "The smallest value the input accepts.",
+			Optional:            true,
+		},
+		"maximum": schema.Float64Attribute{
+			MarkdownDescription: "The largest value the input accepts.",
+			Optional:            true,
+		},
+		"exclusive_minimum": schema.Float64Attribute{
+			MarkdownDescription: "The value the input has to be strictly greater than.",
+			Optional:            true,
+		},
+		"exclusive_maximum": schema.Float64Attribute{
+			MarkdownDescription: "The value the input has to be strictly smaller than.",
+			Optional:            true,
+		},
+		"enum": schema.ListAttribute{
+			MarkdownDescription: "The values the user can pick from.",
+			Optional:            true,
+			ElementType:         types.Float64Type,
+			Validators: []validator.List{
+				listvalidator.UniqueValues(),
+				listvalidator.SizeAtLeast(1),
+			},
+		},
+		"enum_jq_query": schema.StringAttribute{
+			MarkdownDescription: "A jq query resolving the values the user can pick from.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("enum")),
+			},
+		},
+	}
+
+	utils.CopyMaps(properties, propertyMetadataSchema("number"))
+	return schema.MapNestedAttribute{
+		MarkdownDescription: "The number inputs of the form.",
+		Optional:            true,
+		NestedObject:        schema.NestedAttributeObject{Attributes: properties},
+	}
+}
+
+func booleanPropertySchema() schema.Attribute {
+	properties := map[string]schema.Attribute{
+		"default": schema.BoolAttribute{
+			MarkdownDescription: "The default of the boolean input.",
+			Optional:            true,
+		},
+		"default_jq_query": schema.StringAttribute{
+			MarkdownDescription: "The default jq query of the boolean input.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("default")),
+			},
+		},
+	}
+
+	utils.CopyMaps(properties, propertyMetadataSchema("boolean"))
+	return schema.MapNestedAttribute{
+		MarkdownDescription: "The boolean inputs of the form.",
+		Optional:            true,
+		NestedObject:        schema.NestedAttributeObject{Attributes: properties},
+	}
+}
+
+func objectPropertySchema() schema.Attribute {
+	properties := map[string]schema.Attribute{
+		"default": schema.StringAttribute{
+			MarkdownDescription: "The default of the object input, as a JSON encoded string.",
+			Optional:            true,
+		},
+		"default_jq_query": schema.StringAttribute{
+			MarkdownDescription: "The default jq query of the object input.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("default")),
+			},
+		},
+		"format": schema.StringAttribute{
+			MarkdownDescription: "The format of the object input. `labeled-url` renders a url with a display text. " +
+				"Leave it out for a free form object.",
+			Optional: true,
+			Validators: []validator.String{
+				stringvalidator.OneOf(objectFormats...),
+			},
+		},
+	}
+
+	utils.CopyMaps(properties, propertyMetadataSchema("object"))
+	return schema.MapNestedAttribute{
+		MarkdownDescription: "The object inputs of the form.",
+		Optional:            true,
+		NestedObject:        schema.NestedAttributeObject{Attributes: properties},
+	}
+}
+
+func arrayPropertySchema() schema.Attribute {
+	properties := map[string]schema.Attribute{
+		"default_jq_query": schema.StringAttribute{
+			MarkdownDescription: "The default jq query of the array input.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("string_items").AtName("default")),
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("number_items").AtName("default")),
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("object_items").AtName("default")),
+			},
+		},
+		"min_items": schema.Int64Attribute{
+			MarkdownDescription: "The min items of the array input.",
+			Optional:            true,
+			Validators: []validator.Int64{
+				int64validator.AtLeast(0),
+			},
+		},
+		"min_items_jq_query": schema.StringAttribute{
+			MarkdownDescription: "The min items jq query of the array input.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("min_items")),
+			},
+		},
+		"max_items": schema.Int64Attribute{
+			MarkdownDescription: "The max items of the array input.",
+			Optional:            true,
+			Validators: []validator.Int64{
+				int64validator.AtLeast(0),
+			},
+		},
+		"max_items_jq_query": schema.StringAttribute{
+			MarkdownDescription: "The max items jq query of the array input.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("max_items")),
+			},
+		},
+		"unique_items": schema.BoolAttribute{
+			MarkdownDescription: "Whether the values of the array have to be unique.",
+			Optional:            true,
+		},
+		"string_items": schema.SingleNestedAttribute{
+			MarkdownDescription: "The string items of the array input.",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"format": schema.StringAttribute{
+					MarkdownDescription: "The format of each item.",
+					Optional:            true,
+					Validators: []validator.String{
+						stringvalidator.OneOf(stringItemFormats...),
+					},
+				},
+				"blueprint": schema.StringAttribute{
+					MarkdownDescription: "The blueprint the entities are taken from. Required when `format` is `entity`.",
+					Optional:            true,
+				},
+				"default": schema.ListAttribute{
+					MarkdownDescription: "The default value of the items.",
+					Optional:            true,
+					ElementType:         types.StringType,
+				},
+				"enum": schema.ListAttribute{
+					MarkdownDescription: "The values the user can pick from.",
+					Optional:            true,
+					ElementType:         types.StringType,
+					Validators: []validator.List{
+						listvalidator.UniqueValues(),
+						listvalidator.SizeAtLeast(1),
+					},
+				},
+				"enum_jq_query": schema.StringAttribute{
+					MarkdownDescription: "A jq query resolving the values the user can pick from.",
+					Optional:            true,
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("enum")),
+					},
+				},
+				"enum_colors": schema.MapAttribute{
+					MarkdownDescription: "The colors of the enum values.",
+					Optional:            true,
+					ElementType:         types.StringType,
+				},
+				"dataset": schema.StringAttribute{
+					MarkdownDescription: "The dataset filtering the entities of the items, as a JSON encoded string.",
+					Optional:            true,
+				},
+			},
+		},
+		"number_items": schema.SingleNestedAttribute{
+			MarkdownDescription: "The number items of the array input.",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"default": schema.ListAttribute{
+					MarkdownDescription: "The default value of the items.",
+					Optional:            true,
+					ElementType:         types.Float64Type,
+				},
+				"enum": schema.ListAttribute{
+					MarkdownDescription: "The values the user can pick from.",
+					Optional:            true,
+					ElementType:         types.Float64Type,
+					Validators: []validator.List{
+						listvalidator.UniqueValues(),
+						listvalidator.SizeAtLeast(1),
+					},
+				},
+				"enum_jq_query": schema.StringAttribute{
+					MarkdownDescription: "A jq query resolving the values the user can pick from.",
+					Optional:            true,
+					Validators: []validator.String{
+						stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("enum")),
+					},
+				},
+				"enum_colors": schema.MapAttribute{
+					MarkdownDescription: "The colors of the enum values.",
+					Optional:            true,
+					ElementType:         types.StringType,
+				},
+			},
+		},
+		"object_items": schema.SingleNestedAttribute{
+			MarkdownDescription: "The object items of the array input.",
+			Optional:            true,
+			Attributes: map[string]schema.Attribute{
+				"format": schema.StringAttribute{
+					MarkdownDescription: "The format of each item.",
+					Optional:            true,
+					Validators: []validator.String{
+						stringvalidator.OneOf(objectItemFormats...),
+					},
+				},
+				"default": schema.ListAttribute{
+					MarkdownDescription: "The default value of the items.",
+					Optional:            true,
+					ElementType:         types.MapType{ElemType: types.StringType},
+				},
+			},
+		},
+		"sort": entitiesSortSchema(),
+	}
+
+	utils.CopyMaps(properties, propertyMetadataSchema("array"))
+	return schema.MapNestedAttribute{
+		MarkdownDescription: "The array inputs of the form.",
+		Optional:            true,
+		NestedObject:        schema.NestedAttributeObject{Attributes: properties},
+	}
+}
+
+func entitiesSortSchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		MarkdownDescription: "How the entities are sorted in the form.",
+		Optional:            true,
+		Attributes: map[string]schema.Attribute{
+			"property": schema.StringAttribute{
+				MarkdownDescription: "The property to sort the entities by.",
+				Required:            true,
+			},
+			"order": schema.StringAttribute{
+				MarkdownDescription: "The order to sort the entities in.",
+				Computed:            true,
+				Optional:            true,
+				Default:             stringdefault.StaticString("ASC"),
+				Validators: []validator.String{
+					stringvalidator.OneOf("ASC", "DESC"),
+				},
+			},
+		},
+	}
+}
+
+func datasetSchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		MarkdownDescription: "The dataset filtering the entities the user can pick from.",
+		Optional:            true,
+		Attributes: map[string]schema.Attribute{
+			"combinator": schema.StringAttribute{
+				MarkdownDescription: "How the rules are combined.",
+				Required:            true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("and", "or"),
+				},
+			},
+			"rules": schema.ListNestedAttribute{
+				MarkdownDescription: "The rules of the dataset. A rule either filters on a property or groups nested rules under a combinator.",
+				Required:            true,
+				NestedObject: schema.NestedAttributeObject{
+					// 10 levels of nesting, past which the schema stops
+					// recursing while the Go model keeps accepting rules.
+					Attributes: datasetRuleSchema(10),
+				},
+			},
+		},
+	}
+}
+
+func datasetRuleSchema(depth int) map[string]schema.Attribute {
+	attributes := map[string]schema.Attribute{
+		"blueprint": schema.StringAttribute{
+			MarkdownDescription: "The blueprint identifier of the rule.",
+			Optional:            true,
+		},
+		"property": schema.StringAttribute{
+			MarkdownDescription: "The property identifier of the rule.",
+			Optional:            true,
+		},
+		"operator": schema.StringAttribute{
+			MarkdownDescription: "The operator of the rule. Set on filtering rules and left out on group rules.",
+			Optional:            true,
+		},
+		"value": schema.ObjectAttribute{
+			MarkdownDescription: "A value resolved from the form or the trigger when the form is rendered.",
+			Optional:            true,
+			AttributeTypes: map[string]attr.Type{
+				"jq_query": types.StringType,
+			},
+		},
+		"value_json": schema.StringAttribute{
+			MarkdownDescription: "A fixed value, as a JSON encoded string. Use `value` for a value resolved by a jq query.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.ConflictsWith(path.MatchRelative().AtParent().AtName("value")),
+			},
+		},
+		"combinator": schema.StringAttribute{
+			MarkdownDescription: "How the nested rules of a group rule are combined.",
+			Optional:            true,
+			Validators: []validator.String{
+				stringvalidator.OneOf("and", "or"),
+			},
+		},
+	}
+
+	if depth > 0 {
+		attributes["rules"] = schema.ListNestedAttribute{
+			MarkdownDescription: "The nested rules of a group rule.",
+			Optional:            true,
+			NestedObject: schema.NestedAttributeObject{
+				Attributes: datasetRuleSchema(depth - 1),
+			},
+		}
+	}
+
+	return attributes
+}

--- a/port/workflow/userPropertiesToBody.go
+++ b/port/workflow/userPropertiesToBody.go
@@ -1,0 +1,462 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/utils"
+)
+
+// userPropertiesToBody converts the declared inputs into the request payload and
+// collects the identifiers of the inputs marked as required.
+func userPropertiesToBody(ctx context.Context, model *UserPropertiesModel) (map[string]cli.WorkflowInputProperty, []string, error) {
+	properties := map[string]cli.WorkflowInputProperty{}
+	var required []string
+
+	if model == nil {
+		return properties, nil, nil
+	}
+
+	for identifier, prop := range model.StringProps {
+		property, err := stringPropToBody(ctx, prop)
+		if err != nil {
+			return nil, nil, fmt.Errorf("string input %q: %w", identifier, err)
+		}
+		properties[identifier] = *property
+		required = appendIfRequired(required, identifier, prop.Required)
+	}
+
+	for identifier, prop := range model.NumberProps {
+		property, err := numberPropToBody(ctx, prop)
+		if err != nil {
+			return nil, nil, fmt.Errorf("number input %q: %w", identifier, err)
+		}
+		properties[identifier] = *property
+		required = appendIfRequired(required, identifier, prop.Required)
+	}
+
+	for identifier, prop := range model.BooleanProps {
+		property, err := booleanPropToBody(ctx, prop)
+		if err != nil {
+			return nil, nil, fmt.Errorf("boolean input %q: %w", identifier, err)
+		}
+		properties[identifier] = *property
+		required = appendIfRequired(required, identifier, prop.Required)
+	}
+
+	for identifier, prop := range model.ObjectProps {
+		property, err := objectPropToBody(ctx, prop)
+		if err != nil {
+			return nil, nil, fmt.Errorf("object input %q: %w", identifier, err)
+		}
+		properties[identifier] = *property
+		required = appendIfRequired(required, identifier, prop.Required)
+	}
+
+	for identifier, prop := range model.ArrayProps {
+		property, err := arrayPropToBody(ctx, prop)
+		if err != nil {
+			return nil, nil, fmt.Errorf("array input %q: %w", identifier, err)
+		}
+		properties[identifier] = *property
+		required = appendIfRequired(required, identifier, prop.Required)
+	}
+
+	// Map iteration order is random, so the list is sorted to keep the payload
+	// stable between plans.
+	sort.Strings(required)
+
+	return properties, required, nil
+}
+
+func appendIfRequired(required []string, identifier string, value types.Bool) []string {
+	if value.ValueBool() {
+		return append(required, identifier)
+	}
+	return required
+}
+
+// commonPropToBody writes the attributes shared by every input type.
+func commonPropToBody(ctx context.Context, property *cli.WorkflowInputProperty, common propCommon) error {
+	property.Title = common.Title.ValueStringPointer()
+	property.Icon = common.Icon.ValueStringPointer()
+	property.Description = common.Description.ValueStringPointer()
+
+	if !common.DependsOn.IsNull() {
+		dependsOn, err := utils.TerraformListToGoArray(ctx, *common.DependsOn, "string")
+		if err != nil {
+			return err
+		}
+		property.DependsOn = utils.InterfaceToStringArray(dependsOn)
+	}
+
+	property.Visible = boolOrJqToBody(*common.Visible, *common.VisibleJqQuery)
+	property.ReadOnly = boolOrJqToBody(*common.ReadOnly, *common.ReadOnlyJqQuery)
+	property.Disabled = boolOrJqToBody(*common.Disabled, *common.DisabledJqQuery)
+
+	return nil
+}
+
+func boolOrJqToBody(value types.Bool, jqQuery types.String) any {
+	if !jqQuery.IsNull() {
+		return jqQueryBody(jqQuery)
+	}
+	if !value.IsNull() {
+		return value.ValueBool()
+	}
+	return nil
+}
+
+func jqQueryBody(jqQuery types.String) map[string]string {
+	return map[string]string{"jqQuery": jqQuery.ValueString()}
+}
+
+func stringPropToBody(ctx context.Context, prop StringPropModel) (*cli.WorkflowInputProperty, error) {
+	property := &cli.WorkflowInputProperty{Type: "string"}
+	if err := commonPropToBody(ctx, property, prop.common()); err != nil {
+		return nil, err
+	}
+
+	property.Format = prop.Format.ValueStringPointer()
+	property.Blueprint = prop.Blueprint.ValueStringPointer()
+
+	if !prop.DefaultJqQuery.IsNull() {
+		property.Default = jqQueryBody(prop.DefaultJqQuery)
+	} else if !prop.Default.IsNull() {
+		property.Default = prop.Default.ValueString()
+	}
+
+	if !prop.MinLength.IsNull() {
+		minLength := int(prop.MinLength.ValueInt64())
+		property.MinLength = &minLength
+	}
+
+	if !prop.MaxLength.IsNull() {
+		maxLength := int(prop.MaxLength.ValueInt64())
+		property.MaxLength = &maxLength
+	}
+
+	if !prop.PatternJqQuery.IsNull() {
+		property.Pattern = jqQueryBody(prop.PatternJqQuery)
+	} else if !prop.Pattern.IsNull() {
+		property.Pattern = prop.Pattern.ValueString()
+	}
+
+	enum, err := enumToBody(ctx, prop.Enum, prop.EnumJqQuery, "string")
+	if err != nil {
+		return nil, err
+	}
+	property.Enum = enum
+
+	enumColors, err := enumColorsToBody(ctx, prop.EnumColors)
+	if err != nil {
+		return nil, err
+	}
+	property.EnumColors = enumColors
+
+	dataset, err := datasetToBody(prop.Dataset)
+	if err != nil {
+		return nil, err
+	}
+	property.Dataset = dataset
+	property.Sort = sortToBody(prop.Sort)
+
+	return property, nil
+}
+
+func numberPropToBody(ctx context.Context, prop NumberPropModel) (*cli.WorkflowInputProperty, error) {
+	property := &cli.WorkflowInputProperty{Type: "number"}
+	if err := commonPropToBody(ctx, property, prop.common()); err != nil {
+		return nil, err
+	}
+
+	if !prop.DefaultJqQuery.IsNull() {
+		property.Default = jqQueryBody(prop.DefaultJqQuery)
+	} else if !prop.Default.IsNull() {
+		property.Default = prop.Default.ValueFloat64()
+	}
+
+	property.Minimum = prop.Minimum.ValueFloat64Pointer()
+	property.Maximum = prop.Maximum.ValueFloat64Pointer()
+	property.ExclusiveMinimum = prop.ExclusiveMinimum.ValueFloat64Pointer()
+	property.ExclusiveMaximum = prop.ExclusiveMaximum.ValueFloat64Pointer()
+
+	enum, err := enumToBody(ctx, prop.Enum, prop.EnumJqQuery, "float64")
+	if err != nil {
+		return nil, err
+	}
+	property.Enum = enum
+
+	return property, nil
+}
+
+func booleanPropToBody(ctx context.Context, prop BooleanPropModel) (*cli.WorkflowInputProperty, error) {
+	property := &cli.WorkflowInputProperty{Type: "boolean"}
+	if err := commonPropToBody(ctx, property, prop.common()); err != nil {
+		return nil, err
+	}
+
+	if !prop.DefaultJqQuery.IsNull() {
+		property.Default = jqQueryBody(prop.DefaultJqQuery)
+	} else if !prop.Default.IsNull() {
+		property.Default = prop.Default.ValueBool()
+	}
+
+	return property, nil
+}
+
+func objectPropToBody(ctx context.Context, prop ObjectPropModel) (*cli.WorkflowInputProperty, error) {
+	property := &cli.WorkflowInputProperty{Type: "object"}
+	if err := commonPropToBody(ctx, property, prop.common()); err != nil {
+		return nil, err
+	}
+
+	property.Format = prop.Format.ValueStringPointer()
+
+	if !prop.DefaultJqQuery.IsNull() {
+		property.Default = jqQueryBody(prop.DefaultJqQuery)
+	} else if !prop.Default.IsNull() {
+		defaultValue := map[string]any{}
+		if err := json.Unmarshal([]byte(prop.Default.ValueString()), &defaultValue); err != nil {
+			return nil, fmt.Errorf("`default` must be a JSON object: %w", err)
+		}
+		property.Default = defaultValue
+	}
+
+	return property, nil
+}
+
+func arrayPropToBody(ctx context.Context, prop ArrayPropModel) (*cli.WorkflowInputProperty, error) {
+	property := &cli.WorkflowInputProperty{Type: "array"}
+	if err := commonPropToBody(ctx, property, prop.common()); err != nil {
+		return nil, err
+	}
+
+	if !prop.DefaultJqQuery.IsNull() {
+		property.Default = jqQueryBody(prop.DefaultJqQuery)
+	}
+
+	if !prop.MinItemsJqQuery.IsNull() {
+		property.MinItems = jqQueryBody(prop.MinItemsJqQuery)
+	} else if !prop.MinItems.IsNull() {
+		property.MinItems = int(prop.MinItems.ValueInt64())
+	}
+
+	if !prop.MaxItemsJqQuery.IsNull() {
+		property.MaxItems = jqQueryBody(prop.MaxItemsJqQuery)
+	} else if !prop.MaxItems.IsNull() {
+		property.MaxItems = int(prop.MaxItems.ValueInt64())
+	}
+
+	property.UniqueItems = prop.UniqueItems.ValueBoolPointer()
+	property.Sort = sortToBody(prop.Sort)
+
+	if err := arrayItemsToBody(ctx, property, prop); err != nil {
+		return nil, err
+	}
+
+	return property, nil
+}
+
+func arrayItemsToBody(ctx context.Context, property *cli.WorkflowInputProperty, prop ArrayPropModel) error {
+	switch {
+	case prop.StringItems != nil:
+		items := map[string]any{"type": "string"}
+		if !prop.StringItems.Format.IsNull() {
+			items["format"] = prop.StringItems.Format.ValueString()
+		}
+		if !prop.StringItems.Blueprint.IsNull() {
+			items["blueprint"] = prop.StringItems.Blueprint.ValueString()
+		}
+		if !prop.StringItems.Dataset.IsNull() {
+			dataset, err := utils.TerraformJsonStringToGoObject(prop.StringItems.Dataset.ValueStringPointer())
+			if err != nil {
+				return fmt.Errorf("`string_items.dataset` must be a JSON object: %w", err)
+			}
+			items["dataset"] = dataset
+		}
+
+		enum, err := enumToBody(ctx, prop.StringItems.Enum, prop.StringItems.EnumJqQuery, "string")
+		if err != nil {
+			return err
+		}
+		if enum != nil {
+			items["enum"] = enum
+		}
+
+		enumColors, err := enumColorsToBody(ctx, prop.StringItems.EnumColors)
+		if err != nil {
+			return err
+		}
+		if enumColors != nil {
+			items["enumColors"] = enumColors
+		}
+
+		// The service reads the array default off the property, not the items.
+		if !prop.StringItems.Default.IsNull() {
+			defaults, err := utils.TerraformListToGoArray(ctx, prop.StringItems.Default, "string")
+			if err != nil {
+				return err
+			}
+			property.Default = defaults
+		}
+
+		property.Items = items
+
+	case prop.NumberItems != nil:
+		items := map[string]any{"type": "number"}
+
+		enum, err := enumToBody(ctx, prop.NumberItems.Enum, prop.NumberItems.EnumJqQuery, "float64")
+		if err != nil {
+			return err
+		}
+		if enum != nil {
+			items["enum"] = enum
+		}
+
+		enumColors, err := enumColorsToBody(ctx, prop.NumberItems.EnumColors)
+		if err != nil {
+			return err
+		}
+		if enumColors != nil {
+			items["enumColors"] = enumColors
+		}
+
+		if !prop.NumberItems.Default.IsNull() {
+			defaults, err := utils.TerraformListToGoArray(ctx, prop.NumberItems.Default, "float64")
+			if err != nil {
+				return err
+			}
+			property.Default = defaults
+		}
+
+		property.Items = items
+
+	case prop.ObjectItems != nil:
+		items := map[string]any{"type": "object"}
+		if !prop.ObjectItems.Format.IsNull() {
+			items["format"] = prop.ObjectItems.Format.ValueString()
+		}
+
+		if !prop.ObjectItems.Default.IsNull() {
+			defaults := make([]map[string]any, 0, len(prop.ObjectItems.Default.Elements()))
+			for _, element := range prop.ObjectItems.Default.Elements() {
+				elementMap, ok := element.(types.Map)
+				if !ok {
+					return fmt.Errorf("`object_items.default` must hold maps, got %T", element)
+				}
+				value := map[string]any{}
+				for key, entry := range elementMap.Elements() {
+					entryString, ok := entry.(types.String)
+					if !ok {
+						return fmt.Errorf("`object_items.default` must hold string values, got %T", entry)
+					}
+					value[key] = entryString.ValueString()
+				}
+				defaults = append(defaults, value)
+			}
+			property.Default = defaults
+		}
+
+		property.Items = items
+	}
+
+	return nil
+}
+
+func enumToBody(ctx context.Context, enum types.List, enumJqQuery types.String, elementType string) (any, error) {
+	if !enumJqQuery.IsNull() {
+		return jqQueryBody(enumJqQuery), nil
+	}
+	if enum.IsNull() {
+		return nil, nil
+	}
+
+	values, err := utils.TerraformListToGoArray(ctx, enum, elementType)
+	if err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
+func enumColorsToBody(ctx context.Context, enumColors types.Map) (map[string]string, error) {
+	if enumColors.IsNull() {
+		return nil, nil
+	}
+
+	colors := map[string]string{}
+	for key, value := range enumColors.Elements() {
+		valueString, ok := value.(types.String)
+		if !ok {
+			return nil, fmt.Errorf("`enum_colors` must hold strings, got %T", value)
+		}
+		colors[key] = valueString.ValueString()
+	}
+	return colors, nil
+}
+
+func sortToBody(model *EntitiesSortModel) *cli.EntitiesSortModel {
+	if model == nil {
+		return nil
+	}
+	return &cli.EntitiesSortModel{
+		Property: model.Property.ValueString(),
+		Order:    model.Order.ValueString(),
+	}
+}
+
+func datasetToBody(model *DatasetModel) (*cli.WorkflowDataset, error) {
+	if model == nil {
+		return nil, nil
+	}
+
+	dataset := &cli.WorkflowDataset{Combinator: model.Combinator.ValueString()}
+	dataset.Rules = make([]cli.WorkflowDatasetRule, 0, len(model.Rules))
+	for _, rule := range model.Rules {
+		converted, err := datasetRuleToBody(rule)
+		if err != nil {
+			return nil, err
+		}
+		dataset.Rules = append(dataset.Rules, converted)
+	}
+	return dataset, nil
+}
+
+func datasetRuleToBody(model DatasetRuleModel) (cli.WorkflowDatasetRule, error) {
+	rule := cli.WorkflowDatasetRule{}
+
+	if !model.Combinator.IsNull() && model.Combinator.ValueString() != "" {
+		combinator := model.Combinator.ValueString()
+		rule.Combinator = &combinator
+		rule.Rules = make([]cli.WorkflowDatasetRule, 0, len(model.Rules))
+		for _, nested := range model.Rules {
+			converted, err := datasetRuleToBody(nested)
+			if err != nil {
+				return rule, err
+			}
+			rule.Rules = append(rule.Rules, converted)
+		}
+		return rule, nil
+	}
+
+	rule.Operator = model.Operator.ValueString()
+	rule.Blueprint = model.Blueprint.ValueStringPointer()
+	rule.Property = model.Property.ValueStringPointer()
+
+	switch {
+	case model.Value != nil && !model.Value.JqQuery.IsNull():
+		rule.Value = map[string]string{"jqQuery": model.Value.JqQuery.ValueString()}
+	case !model.ValueJson.IsNull():
+		var value any
+		if err := json.Unmarshal([]byte(model.ValueJson.ValueString()), &value); err != nil {
+			return rule, fmt.Errorf("`dataset` rule `value_json` must be valid JSON: %w", err)
+		}
+		rule.Value = value
+	}
+
+	return rule, nil
+}

--- a/port/workflow/userPropertiesToBody.go
+++ b/port/workflow/userPropertiesToBody.go
@@ -11,8 +11,6 @@ import (
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/utils"
 )
 
-// userPropertiesToBody converts the declared inputs into the request payload and
-// collects the identifiers of the inputs marked as required.
 func userPropertiesToBody(ctx context.Context, model *UserPropertiesModel) (map[string]cli.WorkflowInputProperty, []string, error) {
 	properties := map[string]cli.WorkflowInputProperty{}
 	var required []string
@@ -66,8 +64,6 @@ func userPropertiesToBody(ctx context.Context, model *UserPropertiesModel) (map[
 		required = appendIfRequired(required, identifier, prop.Required)
 	}
 
-	// Map iteration order is random, so the list is sorted to keep the payload
-	// stable between plans.
 	sort.Strings(required)
 
 	return properties, required, nil
@@ -80,7 +76,6 @@ func appendIfRequired(required []string, identifier string, value types.Bool) []
 	return required
 }
 
-// commonPropToBody writes the attributes shared by every input type.
 func commonPropToBody(ctx context.Context, property *cli.WorkflowInputProperty, common propCommon) error {
 	property.Title = common.Title.ValueStringPointer()
 	property.Icon = common.Icon.ValueStringPointer()
@@ -296,7 +291,6 @@ func arrayItemsToBody(ctx context.Context, property *cli.WorkflowInputProperty, 
 			items["enumColors"] = enumColors
 		}
 
-		// The service reads the array default off the property, not the items.
 		if !prop.StringItems.Default.IsNull() {
 			defaults, err := utils.TerraformListToGoArray(ctx, prop.StringItems.Default, "string")
 			if err != nil {

--- a/port/workflow/userPropertiesToState.go
+++ b/port/workflow/userPropertiesToState.go
@@ -12,9 +12,6 @@ import (
 	"github.com/samber/lo"
 )
 
-// userPropertiesToState rebuilds the declared inputs from the API response.
-// configured reports whether a user_properties block was declared, which decides
-// whether a form without inputs becomes an empty block or no block at all.
 func (r *WorkflowResource) userPropertiesToState(ctx context.Context, userInputs *cli.WorkflowUserInputs, configured bool) (*UserPropertiesModel, error) {
 	model := &UserPropertiesModel{}
 	_, required := requiredToState(userInputs.Required)
@@ -116,7 +113,6 @@ func boolOrJqToState(value any) (types.Bool, types.String) {
 	return types.BoolNull(), types.StringNull()
 }
 
-// jqQueryToState reports the jq query of a `{jqQuery}` envelope.
 func jqQueryToState(value any) (string, bool) {
 	switch value := value.(type) {
 	case map[string]any:
@@ -283,8 +279,6 @@ func arrayPropToState(ctx context.Context, property cli.WorkflowInputProperty, j
 		return prop, nil
 	}
 
-	// The default of an array lives on the property while the rest of the item
-	// configuration lives on items, so it is only read when it is not a jq query.
 	defaults, _ := property.Default.([]any)
 	if !prop.DefaultJqQuery.IsNull() {
 		defaults = nil

--- a/port/workflow/userPropertiesToState.go
+++ b/port/workflow/userPropertiesToState.go
@@ -1,0 +1,511 @@
+package workflow
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/flex"
+	"github.com/port-labs/terraform-provider-port-labs/v2/internal/utils"
+	"github.com/samber/lo"
+)
+
+// userPropertiesToState rebuilds the declared inputs from the API response.
+// configured reports whether a user_properties block was declared, which decides
+// whether a form without inputs becomes an empty block or no block at all.
+func (r *WorkflowResource) userPropertiesToState(ctx context.Context, userInputs *cli.WorkflowUserInputs, configured bool) (*UserPropertiesModel, error) {
+	model := &UserPropertiesModel{}
+	_, required := requiredToState(userInputs.Required)
+
+	for identifier, property := range userInputs.Properties {
+		isRequired := lo.Contains(required, identifier)
+
+		switch property.Type {
+		case "string":
+			prop, err := stringPropToState(ctx, property, r.portClient.JSONEscapeHTML)
+			if err != nil {
+				return nil, fmt.Errorf("string input %q: %w", identifier, err)
+			}
+			commonPropToState(ctx, property, prop.common(), isRequired)
+			if model.StringProps == nil {
+				model.StringProps = map[string]StringPropModel{}
+			}
+			model.StringProps[identifier] = *prop
+
+		case "number":
+			prop, err := numberPropToState(ctx, property)
+			if err != nil {
+				return nil, fmt.Errorf("number input %q: %w", identifier, err)
+			}
+			commonPropToState(ctx, property, prop.common(), isRequired)
+			if model.NumberProps == nil {
+				model.NumberProps = map[string]NumberPropModel{}
+			}
+			model.NumberProps[identifier] = *prop
+
+		case "boolean":
+			prop := booleanPropToState(property)
+			commonPropToState(ctx, property, prop.common(), isRequired)
+			if model.BooleanProps == nil {
+				model.BooleanProps = map[string]BooleanPropModel{}
+			}
+			model.BooleanProps[identifier] = *prop
+
+		case "object":
+			prop, err := objectPropToState(property, r.portClient.JSONEscapeHTML)
+			if err != nil {
+				return nil, fmt.Errorf("object input %q: %w", identifier, err)
+			}
+			commonPropToState(ctx, property, prop.common(), isRequired)
+			if model.ObjectProps == nil {
+				model.ObjectProps = map[string]ObjectPropModel{}
+			}
+			model.ObjectProps[identifier] = *prop
+
+		case "array":
+			prop, err := arrayPropToState(ctx, property, r.portClient.JSONEscapeHTML)
+			if err != nil {
+				return nil, fmt.Errorf("array input %q: %w", identifier, err)
+			}
+			commonPropToState(ctx, property, prop.common(), isRequired)
+			if model.ArrayProps == nil {
+				model.ArrayProps = map[string]ArrayPropModel{}
+			}
+			model.ArrayProps[identifier] = *prop
+		}
+	}
+
+	if model.StringProps == nil && model.NumberProps == nil && model.BooleanProps == nil &&
+		model.ObjectProps == nil && model.ArrayProps == nil && !configured {
+		return nil, nil
+	}
+
+	return model, nil
+}
+
+func commonPropToState(ctx context.Context, property cli.WorkflowInputProperty, common propCommon, required bool) {
+	*common.Title = flex.GoStringToFramework(property.Title)
+	*common.Icon = flex.GoStringToFramework(property.Icon)
+	*common.Description = flex.GoStringToFramework(property.Description)
+	*common.DependsOn = flex.GoArrayStringToTerraformList(ctx, property.DependsOn)
+
+	if required {
+		*common.Required = types.BoolValue(true)
+	}
+
+	*common.Visible, *common.VisibleJqQuery = boolOrJqToState(property.Visible)
+	*common.ReadOnly, *common.ReadOnlyJqQuery = boolOrJqToState(property.ReadOnly)
+	*common.Disabled, *common.DisabledJqQuery = boolOrJqToState(property.Disabled)
+}
+
+func boolOrJqToState(value any) (types.Bool, types.String) {
+	switch value := value.(type) {
+	case bool:
+		return types.BoolValue(value), types.StringNull()
+	case map[string]any:
+		if jqQuery, ok := value["jqQuery"].(string); ok {
+			return types.BoolNull(), types.StringValue(jqQuery)
+		}
+	case map[string]string:
+		if jqQuery, ok := value["jqQuery"]; ok {
+			return types.BoolNull(), types.StringValue(jqQuery)
+		}
+	}
+	return types.BoolNull(), types.StringNull()
+}
+
+// jqQueryToState reports the jq query of a `{jqQuery}` envelope.
+func jqQueryToState(value any) (string, bool) {
+	switch value := value.(type) {
+	case map[string]any:
+		jqQuery, ok := value["jqQuery"].(string)
+		return jqQuery, ok
+	case map[string]string:
+		jqQuery, ok := value["jqQuery"]
+		return jqQuery, ok
+	}
+	return "", false
+}
+
+func requiredToState(required any) (types.String, []string) {
+	switch required := required.(type) {
+	case []any:
+		values := make([]string, 0, len(required))
+		for _, value := range required {
+			if valueString, ok := value.(string); ok {
+				values = append(values, valueString)
+			}
+		}
+		return types.StringNull(), values
+	case []string:
+		return types.StringNull(), required
+	case map[string]any:
+		if jqQuery, ok := required["jqQuery"].(string); ok {
+			return types.StringValue(jqQuery), nil
+		}
+	}
+	return types.StringNull(), nil
+}
+
+func stringPropToState(ctx context.Context, property cli.WorkflowInputProperty, jsonEscapeHTML bool) (*StringPropModel, error) {
+	prop := &StringPropModel{
+		Format:     flex.GoStringToFramework(property.Format),
+		Blueprint:  flex.GoStringToFramework(property.Blueprint),
+		MinLength:  flex.GoInt64ToFramework(property.MinLength),
+		MaxLength:  flex.GoInt64ToFramework(property.MaxLength),
+		Default:    types.StringNull(),
+		Pattern:    types.StringNull(),
+		Enum:       types.ListNull(types.StringType),
+		EnumColors: types.MapNull(types.StringType),
+	}
+
+	if jqQuery, ok := jqQueryToState(property.Default); ok {
+		prop.DefaultJqQuery = types.StringValue(jqQuery)
+	} else if value, ok := property.Default.(string); ok {
+		prop.Default = types.StringValue(value)
+	}
+
+	if jqQuery, ok := jqQueryToState(property.Pattern); ok {
+		prop.PatternJqQuery = types.StringValue(jqQuery)
+	} else if value, ok := property.Pattern.(string); ok && value != "" {
+		prop.Pattern = types.StringValue(value)
+	}
+
+	enum, enumJqQuery, err := enumToState(property.Enum, types.StringType, func(value any) (attr.Value, error) {
+		valueString, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected a string enum value, got %T", value)
+		}
+		return types.StringValue(valueString), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	prop.Enum, prop.EnumJqQuery = enum, enumJqQuery
+
+	if property.EnumColors != nil {
+		prop.EnumColors, _ = types.MapValueFrom(ctx, types.StringType, property.EnumColors)
+	}
+
+	prop.Dataset = datasetToState(property.Dataset, jsonEscapeHTML)
+	prop.Sort = sortToState(property.Sort)
+
+	return prop, nil
+}
+
+func numberPropToState(_ context.Context, property cli.WorkflowInputProperty) (*NumberPropModel, error) {
+	prop := &NumberPropModel{
+		Default:          types.Float64Null(),
+		Minimum:          flex.GoFloat64ToFramework(property.Minimum),
+		Maximum:          flex.GoFloat64ToFramework(property.Maximum),
+		ExclusiveMinimum: flex.GoFloat64ToFramework(property.ExclusiveMinimum),
+		ExclusiveMaximum: flex.GoFloat64ToFramework(property.ExclusiveMaximum),
+		Enum:             types.ListNull(types.Float64Type),
+	}
+
+	if jqQuery, ok := jqQueryToState(property.Default); ok {
+		prop.DefaultJqQuery = types.StringValue(jqQuery)
+	} else if value, ok := property.Default.(float64); ok {
+		prop.Default = types.Float64Value(value)
+	}
+
+	enum, enumJqQuery, err := enumToState(property.Enum, types.Float64Type, func(value any) (attr.Value, error) {
+		valueFloat, ok := value.(float64)
+		if !ok {
+			return nil, fmt.Errorf("expected a number enum value, got %T", value)
+		}
+		return types.Float64Value(valueFloat), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	prop.Enum, prop.EnumJqQuery = enum, enumJqQuery
+
+	return prop, nil
+}
+
+func booleanPropToState(property cli.WorkflowInputProperty) *BooleanPropModel {
+	prop := &BooleanPropModel{Default: types.BoolNull()}
+
+	if jqQuery, ok := jqQueryToState(property.Default); ok {
+		prop.DefaultJqQuery = types.StringValue(jqQuery)
+	} else if value, ok := property.Default.(bool); ok {
+		prop.Default = types.BoolValue(value)
+	}
+
+	return prop
+}
+
+func objectPropToState(property cli.WorkflowInputProperty, jsonEscapeHTML bool) (*ObjectPropModel, error) {
+	prop := &ObjectPropModel{
+		Format:  flex.GoStringToFramework(property.Format),
+		Default: types.StringNull(),
+	}
+
+	if jqQuery, ok := jqQueryToState(property.Default); ok {
+		prop.DefaultJqQuery = types.StringValue(jqQuery)
+	} else if property.Default != nil {
+		defaultValue, err := utils.GoObjectToTerraformString(property.Default, jsonEscapeHTML)
+		if err != nil {
+			return nil, fmt.Errorf("converting `default` to a string: %w", err)
+		}
+		prop.Default = defaultValue
+	}
+
+	return prop, nil
+}
+
+func arrayPropToState(ctx context.Context, property cli.WorkflowInputProperty, jsonEscapeHTML bool) (*ArrayPropModel, error) {
+	prop := &ArrayPropModel{
+		UniqueItems: flex.GoBoolToFramework(property.UniqueItems),
+		Sort:        sortToState(property.Sort),
+	}
+
+	minItems, minItemsJqQuery, err := intOrJqToState(property.MinItems, "minItems")
+	if err != nil {
+		return nil, err
+	}
+	prop.MinItems, prop.MinItemsJqQuery = minItems, minItemsJqQuery
+
+	maxItems, maxItemsJqQuery, err := intOrJqToState(property.MaxItems, "maxItems")
+	if err != nil {
+		return nil, err
+	}
+	prop.MaxItems, prop.MaxItemsJqQuery = maxItems, maxItemsJqQuery
+
+	if jqQuery, ok := jqQueryToState(property.Default); ok {
+		prop.DefaultJqQuery = types.StringValue(jqQuery)
+	}
+
+	if property.Items == nil {
+		return prop, nil
+	}
+
+	// The default of an array lives on the property while the rest of the item
+	// configuration lives on items, so it is only read when it is not a jq query.
+	defaults, _ := property.Default.([]any)
+	if !prop.DefaultJqQuery.IsNull() {
+		defaults = nil
+	}
+
+	switch property.Items["type"] {
+	case "string":
+		items := &StringItemsModel{
+			Default:    types.ListNull(types.StringType),
+			Enum:       types.ListNull(types.StringType),
+			EnumColors: types.MapNull(types.StringType),
+		}
+
+		if value, ok := property.Items["format"].(string); ok {
+			items.Format = types.StringValue(value)
+		}
+		if value, ok := property.Items["blueprint"].(string); ok {
+			items.Blueprint = types.StringValue(value)
+		}
+		if value, ok := property.Items["dataset"]; ok && value != nil {
+			dataset, err := utils.GoObjectToTerraformString(value, jsonEscapeHTML)
+			if err != nil {
+				return nil, fmt.Errorf("converting `string_items.dataset` to a string: %w", err)
+			}
+			items.Dataset = dataset
+		}
+
+		enum, enumJqQuery, err := enumToState(property.Items["enum"], types.StringType, func(value any) (attr.Value, error) {
+			valueString, ok := value.(string)
+			if !ok {
+				return nil, fmt.Errorf("expected a string enum value, got %T", value)
+			}
+			return types.StringValue(valueString), nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		items.Enum, items.EnumJqQuery = enum, enumJqQuery
+
+		if colors, ok := property.Items["enumColors"].(map[string]any); ok {
+			items.EnumColors, _ = types.MapValueFrom(ctx, types.StringType, toStringMap(colors))
+		}
+
+		if defaults != nil {
+			values := make([]attr.Value, 0, len(defaults))
+			for _, value := range defaults {
+				valueString, ok := value.(string)
+				if !ok {
+					return nil, fmt.Errorf("expected a string default item, got %T", value)
+				}
+				values = append(values, types.StringValue(valueString))
+			}
+			items.Default, _ = types.ListValue(types.StringType, values)
+		}
+
+		prop.StringItems = items
+
+	case "number":
+		items := &NumberItemsModel{
+			Default:    types.ListNull(types.Float64Type),
+			Enum:       types.ListNull(types.Float64Type),
+			EnumColors: types.MapNull(types.StringType),
+		}
+
+		enum, enumJqQuery, err := enumToState(property.Items["enum"], types.Float64Type, func(value any) (attr.Value, error) {
+			valueFloat, ok := value.(float64)
+			if !ok {
+				return nil, fmt.Errorf("expected a number enum value, got %T", value)
+			}
+			return types.Float64Value(valueFloat), nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		items.Enum, items.EnumJqQuery = enum, enumJqQuery
+
+		if colors, ok := property.Items["enumColors"].(map[string]any); ok {
+			items.EnumColors, _ = types.MapValueFrom(ctx, types.StringType, toStringMap(colors))
+		}
+
+		if defaults != nil {
+			values := make([]attr.Value, 0, len(defaults))
+			for _, value := range defaults {
+				valueFloat, ok := value.(float64)
+				if !ok {
+					return nil, fmt.Errorf("expected a number default item, got %T", value)
+				}
+				values = append(values, types.Float64Value(valueFloat))
+			}
+			items.Default, _ = types.ListValue(types.Float64Type, values)
+		}
+
+		prop.NumberItems = items
+
+	case "object":
+		items := &ObjectItemsModel{
+			Default: types.ListNull(types.MapType{ElemType: types.StringType}),
+		}
+
+		if value, ok := property.Items["format"].(string); ok {
+			items.Format = types.StringValue(value)
+		}
+
+		if defaults != nil {
+			values := make([]attr.Value, 0, len(defaults))
+			for _, value := range defaults {
+				valueMap, ok := value.(map[string]any)
+				if !ok {
+					return nil, fmt.Errorf("expected an object default item, got %T", value)
+				}
+				entries := map[string]attr.Value{}
+				for key, entry := range valueMap {
+					entries[key] = types.StringValue(fmt.Sprintf("%v", entry))
+				}
+				mapValue, _ := types.MapValue(types.StringType, entries)
+				values = append(values, mapValue)
+			}
+			items.Default, _ = types.ListValue(types.MapType{ElemType: types.StringType}, values)
+		}
+
+		prop.ObjectItems = items
+	}
+
+	return prop, nil
+}
+
+func intOrJqToState(value any, name string) (types.Int64, types.String, error) {
+	switch value := value.(type) {
+	case nil:
+		return types.Int64Null(), types.StringNull(), nil
+	case float64:
+		return types.Int64Value(int64(value)), types.StringNull(), nil
+	case int:
+		return types.Int64Value(int64(value)), types.StringNull(), nil
+	case map[string]any:
+		if jqQuery, ok := value["jqQuery"].(string); ok {
+			return types.Int64Null(), types.StringValue(jqQuery), nil
+		}
+	}
+	return types.Int64Null(), types.StringNull(), fmt.Errorf("`%s` must be a number or a jq query, got %T", name, value)
+}
+
+func enumToState(value any, elementType attr.Type, convert func(any) (attr.Value, error)) (types.List, types.String, error) {
+	switch value := value.(type) {
+	case nil:
+		return types.ListNull(elementType), types.StringNull(), nil
+	case []any:
+		values := make([]attr.Value, 0, len(value))
+		for _, entry := range value {
+			converted, err := convert(entry)
+			if err != nil {
+				return types.ListNull(elementType), types.StringNull(), err
+			}
+			values = append(values, converted)
+		}
+		list, diags := types.ListValue(elementType, values)
+		if diags.HasError() {
+			return types.ListNull(elementType), types.StringNull(), fmt.Errorf("building the enum list: %v", diags.Errors())
+		}
+		return list, types.StringNull(), nil
+	}
+
+	if jqQuery, ok := jqQueryToState(value); ok {
+		return types.ListNull(elementType), types.StringValue(jqQuery), nil
+	}
+
+	return types.ListNull(elementType), types.StringNull(), nil
+}
+
+func toStringMap(value map[string]any) map[string]string {
+	result := make(map[string]string, len(value))
+	for key, entry := range value {
+		result[key] = fmt.Sprintf("%v", entry)
+	}
+	return result
+}
+
+func sortToState(sort *cli.EntitiesSortModel) *EntitiesSortModel {
+	if sort == nil {
+		return nil
+	}
+	return &EntitiesSortModel{
+		Property: types.StringValue(sort.Property),
+		Order:    types.StringValue(sort.Order),
+	}
+}
+
+func datasetToState(dataset *cli.WorkflowDataset, jsonEscapeHTML bool) *DatasetModel {
+	if dataset == nil {
+		return nil
+	}
+
+	model := &DatasetModel{Combinator: types.StringValue(dataset.Combinator)}
+	for _, rule := range dataset.Rules {
+		model.Rules = append(model.Rules, datasetRuleToState(rule, jsonEscapeHTML))
+	}
+	return model
+}
+
+func datasetRuleToState(rule cli.WorkflowDatasetRule, jsonEscapeHTML bool) DatasetRuleModel {
+	model := DatasetRuleModel{}
+
+	if rule.Combinator != nil && *rule.Combinator != "" {
+		model.Combinator = types.StringValue(*rule.Combinator)
+		for _, nested := range rule.Rules {
+			model.Rules = append(model.Rules, datasetRuleToState(nested, jsonEscapeHTML))
+		}
+		return model
+	}
+
+	model.Blueprint = flex.GoStringToFramework(rule.Blueprint)
+	model.Property = flex.GoStringToFramework(rule.Property)
+	model.Operator = flex.GoStringToFramework(&rule.Operator)
+
+	if jqQuery, ok := jqQueryToState(rule.Value); ok {
+		model.Value = &ValueModel{JqQuery: types.StringValue(jqQuery)}
+	} else if rule.Value != nil {
+		if value, err := utils.GoObjectToTerraformString(rule.Value, jsonEscapeHTML); err == nil {
+			model.ValueJson = value
+		}
+	}
+
+	return model
+}

--- a/port/workflow/validators.go
+++ b/port/workflow/validators.go
@@ -29,9 +29,6 @@ func (v stringValidator) ValidateString(_ context.Context, req validator.StringR
 	}
 }
 
-// isTrueValidator rejects `required = false`. Leaving an input out of the
-// required list is how it is marked optional, so an explicit false would be
-// silently dropped.
 type isTrueValidator struct{}
 
 var _ validator.Bool = isTrueValidator{}

--- a/port/workflow/validators.go
+++ b/port/workflow/validators.go
@@ -29,6 +29,28 @@ func (v stringValidator) ValidateString(_ context.Context, req validator.StringR
 	}
 }
 
+// isTrueValidator rejects `required = false`. Leaving an input out of the
+// required list is how it is marked optional, so an explicit false would be
+// silently dropped.
+type isTrueValidator struct{}
+
+var _ validator.Bool = isTrueValidator{}
+
+func (v isTrueValidator) Description(context.Context) string { return "value must be true" }
+
+func (v isTrueValidator) MarkdownDescription(ctx context.Context) string { return v.Description(ctx) }
+
+func (v isTrueValidator) ValidateBool(_ context.Context, req validator.BoolRequest, resp *validator.BoolResponse) {
+	if req.ConfigValue.IsNull() || req.ConfigValue.IsUnknown() || req.ConfigValue.ValueBool() {
+		return
+	}
+	resp.Diagnostics.AddAttributeError(
+		req.Path,
+		"Invalid required value",
+		"Only `true` is accepted. Leave `required` out to make the input optional.",
+	)
+}
+
 func decodeJSONObject(value string) (map[string]any, error) {
 	var decoded any
 	if err := json.Unmarshal([]byte(value), &decoded); err != nil {

--- a/port/workflow/workflowStateToPortBody.go
+++ b/port/workflow/workflowStateToPortBody.go
@@ -8,7 +8,6 @@ import (
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/cli"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/consts"
 	"github.com/port-labs/terraform-provider-port-labs/v2/internal/utils"
-	"github.com/port-labs/terraform-provider-port-labs/v2/port/action"
 )
 
 func workflowStateToPortBody(ctx context.Context, state *WorkflowModel) (*cli.Workflow, error) {
@@ -285,53 +284,25 @@ func nodeConfigToPortBody(ctx context.Context, n WorkflowNodeModel) (*cli.Workfl
 }
 
 func selfServeUserInputsToPortBody(ctx context.Context, model *SelfServeUserInputsModel) (*cli.WorkflowUserInputs, error) {
-	properties, required, err := action.UserPropertiesToBody(ctx, model.UserProperties, model.RequiredJqQuery)
+	userInputs, err := userInputsToPortBody(ctx, model.UserProperties, model.Titles, model.RequiredJqQuery, model.OrderProperties)
 	if err != nil {
 		return nil, err
 	}
 
-	titles, err := action.UserInputTitlesToBody(ctx, model.Titles)
-	if err != nil {
-		return nil, err
-	}
+	userInputs.Steps = userInputStepsToPortBody(model.Steps)
+	userInputs.Validations = validationsToPortBody(model.Validations)
 
-	order, err := action.UserInputsOrderToBody(ctx, model.OrderProperties)
-	if err != nil {
-		return nil, err
-	}
-
-	return &cli.WorkflowUserInputs{
-		Properties: properties,
-		Required:   required,
-		Titles:     titles,
-		Order:      order,
-		Steps:      action.UserInputStepsToBody(model.Steps),
-	}, nil
+	return userInputs, nil
 }
 
 func inputUserInputsToPortBody(ctx context.Context, model *InputUserInputsModel) (*cli.WorkflowUserInputs, error) {
-	properties, required, err := action.UserPropertiesToBody(ctx, model.UserProperties, model.RequiredJqQuery)
+	userInputs, err := userInputsToPortBody(ctx, model.UserProperties, model.Titles, model.RequiredJqQuery, model.OrderProperties)
 	if err != nil {
 		return nil, err
 	}
 
-	titles, err := action.UserInputTitlesToBody(ctx, model.Titles)
-	if err != nil {
-		return nil, err
-	}
-
-	order, err := action.UserInputsOrderToBody(ctx, model.OrderProperties)
-	if err != nil {
-		return nil, err
-	}
-
-	userInputs := &cli.WorkflowUserInputs{
-		Properties: properties,
-		Required:   required,
-		Titles:     titles,
-		Order:      order,
-		Steps:      action.UserInputStepsToBody(model.Steps),
-	}
+	userInputs.Steps = userInputStepsToPortBody(model.Steps)
+	userInputs.Validations = validationsToPortBody(model.Validations)
 
 	buttons := make([]cli.WorkflowInputButton, 0, len(model.Buttons))
 	for _, b := range model.Buttons {
@@ -345,6 +316,112 @@ func inputUserInputsToPortBody(ctx context.Context, model *InputUserInputsModel)
 	userInputs.Buttons = &buttons
 
 	return userInputs, nil
+}
+
+// userInputsToPortBody builds the parts of the payload a self serve trigger form
+// and an input node form have in common.
+func userInputsToPortBody(
+	ctx context.Context,
+	userProperties *UserPropertiesModel,
+	titles map[string]UserInputText,
+	requiredJqQuery types.String,
+	orderProperties types.List,
+) (*cli.WorkflowUserInputs, error) {
+	properties, required, err := userPropertiesToBody(ctx, userProperties)
+	if err != nil {
+		return nil, err
+	}
+
+	userInputs := &cli.WorkflowUserInputs{
+		Properties: properties,
+		Titles:     userInputTitlesToPortBody(titles),
+	}
+
+	if !requiredJqQuery.IsNull() {
+		userInputs.Required = map[string]string{"jqQuery": requiredJqQuery.ValueString()}
+	} else if len(required) > 0 {
+		userInputs.Required = required
+	}
+
+	if !orderProperties.IsNull() {
+		order, err := terraformListToStrings(ctx, orderProperties)
+		if err != nil {
+			return nil, err
+		}
+		userInputs.Order = order
+	}
+
+	return userInputs, nil
+}
+
+func userInputTitlesToPortBody(titles map[string]UserInputText) map[string]cli.ActionTitle {
+	if titles == nil {
+		return nil
+	}
+
+	result := make(map[string]cli.ActionTitle, len(titles))
+	for identifier, title := range titles {
+		converted := cli.ActionTitle{
+			Title:       title.Title.ValueString(),
+			Description: title.Description.ValueStringPointer(),
+		}
+
+		if !title.VisibleJqQuery.IsNull() {
+			converted.Visible = map[string]string{"jqQuery": title.VisibleJqQuery.ValueString()}
+		} else if !title.Visible.IsNull() {
+			converted.Visible = title.Visible.ValueBool()
+		}
+
+		result[identifier] = converted
+	}
+
+	return result
+}
+
+func userInputStepsToPortBody(steps []UserInputsStepModel) []cli.WorkflowUserInputsStep {
+	if steps == nil {
+		return nil
+	}
+
+	result := make([]cli.WorkflowUserInputsStep, 0, len(steps))
+	for _, s := range steps {
+		order := make([]string, 0, len(s.Order))
+		for _, p := range s.Order {
+			order = append(order, p.ValueString())
+		}
+
+		step := cli.WorkflowUserInputsStep{
+			Title:       s.Title.ValueString(),
+			Order:       order,
+			Validations: validationsToPortBody(s.Validations),
+		}
+
+		if !s.VisibleJqQuery.IsNull() {
+			step.Visible = map[string]string{"jqQuery": s.VisibleJqQuery.ValueString()}
+		} else if !s.Visible.IsNull() {
+			step.Visible = s.Visible.ValueBool()
+		}
+
+		result = append(result, step)
+	}
+
+	return result
+}
+
+func validationsToPortBody(validations []InputValidationModel) []cli.WorkflowInputValidation {
+	if validations == nil {
+		return nil
+	}
+
+	result := make([]cli.WorkflowInputValidation, 0, len(validations))
+	for _, v := range validations {
+		result = append(result, cli.WorkflowInputValidation{
+			Constraint: v.Constraint.ValueString(),
+			Message:    v.Message.ValueString(),
+		})
+	}
+
+	return result
 }
 
 func upsertMappingToPortBody(ctx context.Context, model *UpsertMappingModel) (*cli.WorkflowUpsertMapping, error) {

--- a/port/workflow/workflowStateToPortBody.go
+++ b/port/workflow/workflowStateToPortBody.go
@@ -318,8 +318,6 @@ func inputUserInputsToPortBody(ctx context.Context, model *InputUserInputsModel)
 	return userInputs, nil
 }
 
-// userInputsToPortBody builds the parts of the payload a self serve trigger form
-// and an input node form have in common.
 func userInputsToPortBody(
 	ctx context.Context,
 	userProperties *UserPropertiesModel,

--- a/port/workflow/workflow_internal_test.go
+++ b/port/workflow/workflow_internal_test.go
@@ -365,7 +365,7 @@ func TestRefreshWorkflowStateSelfServeTriggerUserInputs(t *testing.T) {
 					Type:      consts.SelfServeTrigger,
 					Published: boolPtr(true),
 					UserInputs: &cli.WorkflowUserInputs{
-						Properties: map[string]cli.ActionProperty{
+						Properties: map[string]cli.WorkflowInputProperty{
 							"service": {Type: "string", Title: strPtr("Service")},
 						},
 						Required: []any{"service"},
@@ -409,7 +409,7 @@ func TestSelfServeTriggerUserInputsRoundTrip(t *testing.T) {
 				Config: cli.WorkflowNodeConfig{
 					Type: consts.SelfServeTrigger,
 					UserInputs: &cli.WorkflowUserInputs{
-						Properties: map[string]cli.ActionProperty{
+						Properties: map[string]cli.WorkflowInputProperty{
 							"service":  {Type: "string", Title: strPtr("Service")},
 							"replicas": {Type: "number", Title: strPtr("Replicas")},
 						},
@@ -432,6 +432,222 @@ func TestSelfServeTriggerUserInputsRoundTrip(t *testing.T) {
 	assert.Equal(t, "string", userInputs.Properties["service"].Type)
 	assert.Equal(t, "number", userInputs.Properties["replicas"].Type)
 	assert.Equal(t, []string{"service"}, userInputs.Required)
+}
+
+// selfServeTriggerRoundTrip pushes a form through the API mapping in both
+// directions and hands back what the second write would send.
+func selfServeTriggerRoundTrip(t *testing.T, userInputs *cli.WorkflowUserInputs) *cli.WorkflowUserInputs {
+	t.Helper()
+
+	ctx := context.Background()
+	r := &WorkflowResource{portClient: &cli.PortClient{JSONEscapeHTML: true}}
+
+	state := &WorkflowModel{
+		Identifier: types.StringValue("wf"),
+		Nodes:      []WorkflowNodeModel{{Identifier: types.StringValue("trigger")}},
+	}
+
+	apiWorkflow := &cli.Workflow{
+		Identifier: "wf",
+		Nodes: []cli.WorkflowNode{
+			{
+				Identifier: "trigger",
+				Config: cli.WorkflowNodeConfig{
+					Type:       consts.SelfServeTrigger,
+					UserInputs: userInputs,
+				},
+			},
+		},
+	}
+
+	require.NoError(t, r.refreshWorkflowState(ctx, state, apiWorkflow))
+
+	body, err := workflowStateToPortBody(ctx, state)
+	require.NoError(t, err)
+
+	result := body.Nodes[0].Config.UserInputs
+	require.NotNil(t, result)
+	return result
+}
+
+func TestUserInputReadOnlyAndDisabledRoundTrip(t *testing.T) {
+	result := selfServeTriggerRoundTrip(t, &cli.WorkflowUserInputs{
+		Properties: map[string]cli.WorkflowInputProperty{
+			"requested_by": {
+				Type:     "string",
+				Format:   strPtr("user"),
+				ReadOnly: true,
+				Default:  map[string]any{"jqQuery": ".trigger.by.user.email"},
+			},
+			"approver": {
+				Type:     "string",
+				Format:   strPtr("user"),
+				Disabled: map[string]any{"jqQuery": ".form.tier != \"production\""},
+			},
+			"notes": {
+				Type:     "string",
+				ReadOnly: map[string]any{"jqQuery": ".form.locked"},
+			},
+		},
+	})
+
+	assert.Equal(t, true, result.Properties["requested_by"].ReadOnly)
+	assert.Equal(t, map[string]string{"jqQuery": ".trigger.by.user.email"}, result.Properties["requested_by"].Default)
+	assert.Equal(t, map[string]string{"jqQuery": ".form.tier != \"production\""}, result.Properties["approver"].Disabled)
+	assert.Equal(t, map[string]string{"jqQuery": ".form.locked"}, result.Properties["notes"].ReadOnly)
+
+	// read_only and disabled are independent, so neither leaks into the other.
+	assert.Nil(t, result.Properties["requested_by"].Disabled)
+	assert.Nil(t, result.Properties["approver"].ReadOnly)
+}
+
+func TestUserInputValidationsRoundTrip(t *testing.T) {
+	result := selfServeTriggerRoundTrip(t, &cli.WorkflowUserInputs{
+		Properties: map[string]cli.WorkflowInputProperty{
+			"min_replicas": {Type: "number"},
+			"max_replicas": {Type: "number"},
+		},
+		Validations: []cli.WorkflowInputValidation{
+			{Constraint: ".form.max_replicas >= .form.min_replicas", Message: "max must be at least min"},
+		},
+	})
+
+	require.Len(t, result.Validations, 1)
+	assert.Equal(t, ".form.max_replicas >= .form.min_replicas", result.Validations[0].Constraint)
+	assert.Equal(t, "max must be at least min", result.Validations[0].Message)
+}
+
+func TestUserInputStepValidationsRoundTrip(t *testing.T) {
+	result := selfServeTriggerRoundTrip(t, &cli.WorkflowUserInputs{
+		Properties: map[string]cli.WorkflowInputProperty{
+			"cpu": {Type: "number"},
+		},
+		Steps: []cli.WorkflowUserInputsStep{
+			{
+				Title:   "Limits",
+				Order:   []string{"cpu"},
+				Visible: map[string]any{"jqQuery": ".form.advanced"},
+				Validations: []cli.WorkflowInputValidation{
+					{Constraint: ".form.cpu <= 8", Message: "CPU limit cannot exceed 8 cores"},
+				},
+			},
+		},
+	})
+
+	require.Len(t, result.Steps, 1)
+	assert.Equal(t, "Limits", result.Steps[0].Title)
+	assert.Equal(t, map[string]string{"jqQuery": ".form.advanced"}, result.Steps[0].Visible)
+	require.Len(t, result.Steps[0].Validations, 1)
+	assert.Equal(t, ".form.cpu <= 8", result.Steps[0].Validations[0].Constraint)
+	assert.Empty(t, result.Validations)
+}
+
+func TestUserInputDatasetRoundTrip(t *testing.T) {
+	result := selfServeTriggerRoundTrip(t, &cli.WorkflowUserInputs{
+		Properties: map[string]cli.WorkflowInputProperty{
+			"service": {
+				Type:      "string",
+				Format:    strPtr("entity"),
+				Blueprint: strPtr("service"),
+				Dataset: &cli.WorkflowDataset{
+					Combinator: "and",
+					Rules: []cli.WorkflowDatasetRule{
+						// A value resolved from the form while it is filled in.
+						{Property: strPtr("tier"), Operator: "=", Value: map[string]any{"jqQuery": ".form.tier"}},
+						// A fixed value.
+						{Property: strPtr("archived"), Operator: "=", Value: false},
+					},
+				},
+			},
+		},
+	})
+
+	dataset := result.Properties["service"].Dataset
+	require.NotNil(t, dataset)
+	assert.Equal(t, "and", dataset.Combinator)
+	require.Len(t, dataset.Rules, 2)
+	assert.Equal(t, map[string]string{"jqQuery": ".form.tier"}, dataset.Rules[0].Value)
+	assert.Equal(t, false, dataset.Rules[1].Value)
+}
+
+func TestUserInputNumberBoundsAndUniqueItemsRoundTrip(t *testing.T) {
+	minimum, maximum := 1.0, 10.0
+	result := selfServeTriggerRoundTrip(t, &cli.WorkflowUserInputs{
+		Properties: map[string]cli.WorkflowInputProperty{
+			"replicas": {
+				Type:             "number",
+				Minimum:          &minimum,
+				ExclusiveMaximum: &maximum,
+			},
+			"tags": {
+				Type:        "array",
+				UniqueItems: boolPtr(true),
+				Items:       map[string]any{"type": "string"},
+			},
+		},
+	})
+
+	assert.Equal(t, &minimum, result.Properties["replicas"].Minimum)
+	assert.Equal(t, &maximum, result.Properties["replicas"].ExclusiveMaximum)
+	assert.Nil(t, result.Properties["replicas"].Maximum)
+	assert.Equal(t, boolPtr(true), result.Properties["tags"].UniqueItems)
+}
+
+// An input node that only offers buttons declares no user_properties, so the
+// refreshed state must leave the block unset instead of filling in an empty one.
+func TestInputNodeWithoutUserPropertiesStaysUnset(t *testing.T) {
+	ctx := context.Background()
+	r := &WorkflowResource{portClient: &cli.PortClient{JSONEscapeHTML: true}}
+
+	state := &WorkflowModel{
+		Identifier: types.StringValue("wf"),
+		Nodes: []WorkflowNodeModel{{
+			Identifier: types.StringValue("approval"),
+			Input: &InputModel{
+				UserInputs: &InputUserInputsModel{
+					Buttons: []InputButtonModel{{
+						Identifier: types.StringValue("approve"),
+						Label:      types.StringValue("Approve"),
+						Variant:    types.StringValue("PRIMARY"),
+					}},
+				},
+			},
+		}},
+	}
+
+	apiWorkflow := &cli.Workflow{
+		Identifier: "wf",
+		Nodes: []cli.WorkflowNode{{
+			Identifier: "approval",
+			Config: cli.WorkflowNodeConfig{
+				Type: consts.InputNode,
+				UserInputs: &cli.WorkflowUserInputs{
+					Properties: map[string]cli.WorkflowInputProperty{},
+					Buttons: &[]cli.WorkflowInputButton{
+						{Identifier: "approve", Label: "Approve", Variant: "PRIMARY"},
+					},
+				},
+			},
+		}},
+	}
+
+	require.NoError(t, r.refreshWorkflowState(ctx, state, apiWorkflow))
+
+	userInputs := state.Nodes[0].Input.UserInputs
+	require.NotNil(t, userInputs)
+	assert.Nil(t, userInputs.UserProperties)
+	assert.Len(t, userInputs.Buttons, 1)
+}
+
+func TestUserInputRequiredJqQueryRoundTrip(t *testing.T) {
+	result := selfServeTriggerRoundTrip(t, &cli.WorkflowUserInputs{
+		Properties: map[string]cli.WorkflowInputProperty{
+			"service": {Type: "string"},
+		},
+		Required: map[string]any{"jqQuery": ".form.tier == \"production\""},
+	})
+
+	assert.Equal(t, map[string]string{"jqQuery": ".form.tier == \"production\""}, result.Required)
 }
 
 func validateNodes(nodes []WorkflowNodeModel, connections []ConnectionModel) diag.Diagnostics {

--- a/port/workflow/workflow_internal_test.go
+++ b/port/workflow/workflow_internal_test.go
@@ -434,8 +434,6 @@ func TestSelfServeTriggerUserInputsRoundTrip(t *testing.T) {
 	assert.Equal(t, []string{"service"}, userInputs.Required)
 }
 
-// selfServeTriggerRoundTrip pushes a form through the API mapping in both
-// directions and hands back what the second write would send.
 func selfServeTriggerRoundTrip(t *testing.T, userInputs *cli.WorkflowUserInputs) *cli.WorkflowUserInputs {
 	t.Helper()
 
@@ -496,7 +494,6 @@ func TestUserInputReadOnlyAndDisabledRoundTrip(t *testing.T) {
 	assert.Equal(t, map[string]string{"jqQuery": ".form.tier != \"production\""}, result.Properties["approver"].Disabled)
 	assert.Equal(t, map[string]string{"jqQuery": ".form.locked"}, result.Properties["notes"].ReadOnly)
 
-	// read_only and disabled are independent, so neither leaks into the other.
 	assert.Nil(t, result.Properties["requested_by"].Disabled)
 	assert.Nil(t, result.Properties["approver"].ReadOnly)
 }
@@ -552,9 +549,7 @@ func TestUserInputDatasetRoundTrip(t *testing.T) {
 				Dataset: &cli.WorkflowDataset{
 					Combinator: "and",
 					Rules: []cli.WorkflowDatasetRule{
-						// A value resolved from the form while it is filled in.
 						{Property: strPtr("tier"), Operator: "=", Value: map[string]any{"jqQuery": ".form.tier"}},
-						// A fixed value.
 						{Property: strPtr("archived"), Operator: "=", Value: false},
 					},
 				},
@@ -593,8 +588,6 @@ func TestUserInputNumberBoundsAndUniqueItemsRoundTrip(t *testing.T) {
 	assert.Equal(t, boolPtr(true), result.Properties["tags"].UniqueItems)
 }
 
-// An input node that only offers buttons declares no user_properties, so the
-// refreshed state must leave the block unset instead of filling in an empty one.
 func TestInputNodeWithoutUserPropertiesStaysUnset(t *testing.T) {
 	ctx := context.Background()
 	r := &WorkflowResource{portClient: &cli.PortClient{JSONEscapeHTML: true}}


### PR DESCRIPTION
# Description

## What

Adds the advanced self-service input features of the workflow service to `port_workflow`, and gives workflows their own user inputs schema instead of borrowing the one from `port_action`.

### Workflow owned user inputs

The workflow form contract differs from the action one in ways that could not be expressed while the schema was shared:

- `read_only` / `read_only_jq_query` show a value without letting the user change it, and still submit it.
- `disabled` / `disabled_jq_query` drop the input from the submitted data *and* from `required` validation, which makes it a way to remove an input based on the other answers. This is not the action meaning of `disabled`.
- `dataset` is a first class block whose rule values either resolve from the form as it is filled in (`value = { jq_query = ... }`) or are fixed (`value_json`), replacing the opaque JSON string.
- `exclusive_minimum` / `exclusive_maximum` on numbers and `unique_items` on arrays.
- Action-only attributes the service rejects (`encryption`, `client_side_encryption`, `boolean_items`) are gone.

### Form validations

`validations` is a list of `constraint` (jq that must evaluate to `true`) and `message` pairs, capped at 10 rules with a 100 character message, matching the service. It sits on the whole form, or on individual steps for a stepped form. The two are mutually exclusive and the provider rejects the combination at plan time.

### Format allowlists corrected

The service compiles the form into a JSON schema and validates it with ajv in strict mode, so the accepted formats are narrower than the client contract suggests:

- `none` is rejected everywhere (string props, string items, object props, object items). An unformatted input omits `format`.
- An object input only accepts `labeled-url`. `format` is a JSON schema keyword for strings and numbers, so `multi-line` on an object fails to compile; `labeled-url` survives only because the validator rewrites those subschemas first.

## Usage

```hcl
resource "port_workflow" "capacity" {
  identifier = "request-capacity"
  title      = "Request capacity"

  node {
    identifier = "trigger"

    self_serve_trigger {
      published = true

      user_inputs {
        user_properties = {
          string_props = {
            "tier" = {
              title    = "Tier"
              required = true
              enum     = ["production", "staging", "development"]
            }

            # Shown filled in, and still submitted.
            "requested_by" = {
              title            = "Requested by"
              format           = "user"
              default_jq_query = ".trigger.by.user.email"
              read_only        = true
            }

            # Greyed out and dropped from the submission outside production,
            # so `required` only applies when the input is enabled.
            "approver" = {
              title             = "Approver"
              format            = "user"
              required          = true
              disabled_jq_query = ".form.tier != \"production\""
            }

            "service" = {
              title     = "Service"
              format    = "entity"
              required  = true
              blueprint = port_blueprint.service.identifier

              # One rule resolved from the form, one fixed value.
              dataset = {
                combinator = "and"
                rules = [
                  {
                    blueprint = port_blueprint.service.identifier
                    property  = "tier"
                    operator  = "="
                    value     = { jq_query = ".form.tier" }
                  },
                  {
                    blueprint  = port_blueprint.service.identifier
                    property   = "archived"
                    operator   = "="
                    value_json = jsonencode(false)
                  },
                ]
              }
            }
          }

          number_props = {
            "min_replicas" = {
              title             = "Minimum replicas"
              default           = 1
              exclusive_minimum = 0
              maximum           = 20
            }
          }
        }

        # Checked on submit. Use step level `validations` for a stepped form.
        validations = [
          {
            constraint = "if .form.tier == \"production\" then .form.min_replicas >= 2 else true end"
            message    = "Production needs at least 2 replicas"
          },
        ]
      }
    }
  }
}
```

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)