### PR TITLE
fix: use unique installation IDs in integration acceptance tests

### DIFF
--- a/port/integration/integrationToPortBody_test.go
+++ b/port/integration/integrationToPortBody_test.go
@@ -1,0 +1,37 @@
+package integration
+
+import "testing"
+
+func TestInstallationIdPattern(t *testing.T) {
+	valid := []string{
+		"myintegration",
+		"my-integration",
+		"my-integration-123",
+		"integration1",
+		"123-integration",
+		"my-integration-",
+		"-my-integration",
+		"12345",
+		"---",
+	}
+
+	for _, id := range valid {
+		if !installationIdRegex.MatchString(id) {
+			t.Errorf("expected %q to match installation ID pattern", id)
+		}
+	}
+
+	invalid := []string{
+		"my integration with spaces",
+		"MyIntegration",
+		"my_integration",
+		"my-integration!",
+		"my@integration",
+	}
+
+	for _, id := range invalid {
+		if installationIdRegex.MatchString(id) {
+			t.Errorf("expected %q not to match installation ID pattern", id)
+		}
+	}
+}

--- a/port/integration/resource_test.go
+++ b/port/integration/resource_test.go
@@ -273,54 +273,23 @@ func TestPortIntegrationValidIdentifier(t *testing.T) {
 	installationAppType := "kafka"
 
 	testCases := []struct {
-		name       string
-		identifier string
+		name    string
+		buildID func(uniqueID string) string
 	}{
-		{
-			name:       "simple lowercase",
-			identifier: "myintegration",
-		},
-		{
-			name:       "with dashes",
-			identifier: "my-integration",
-		},
-		{
-			name:       "with numbers",
-			identifier: "my-integration-123",
-		},
-		{
-			name:       "starts with letter ends with number",
-			identifier: "integration1",
-		},
-		{
-			name:       "multiple dashes",
-			identifier: "my-custom-integration-v2",
-		},
-		{
-			name:       "starts with number",
-			identifier: "123-integration",
-		},
-		{
-			name:       "ends with dash",
-			identifier: "my-integration-",
-		},
-		{
-			name:       "starts with dash",
-			identifier: "-my-integration",
-		},
-		{
-			name:       "only numbers",
-			identifier: "12345",
-		},
-		{
-			name:       "only dashes",
-			identifier: "---",
-		},
+		{"simple lowercase", func(id string) string { return "myintegration-" + id }},
+		{"with dashes", func(id string) string { return "my-integration-" + id }},
+		{"with numbers", func(id string) string { return "my-integration-123-" + id }},
+		{"starts with letter ends with number", func(id string) string { return "integration1-" + id }},
+		{"multiple dashes", func(id string) string { return "my-custom-integration-v2-" + id }},
+		{"starts with number", func(id string) string { return "123-integration-" + id }},
+		{"ends with dash", func(id string) string { return "my-integration-" + id + "-" }},
+		{"starts with dash", func(id string) string { return "-" + id + "-my-integration" }},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			config := createIntegration(tc.identifier, installationAppType)
+			installationID := tc.buildID(utils.GenID())
+			config := createIntegration(installationID, installationAppType)
 			resource.Test(t, resource.TestCase{
 				PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 				ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
@@ -328,7 +297,7 @@ func TestPortIntegrationValidIdentifier(t *testing.T) {
 					{
 						Config: config,
 						Check: resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttr("port_integration.kafkush", "installation_id", tc.identifier),
+							resource.TestCheckResourceAttr("port_integration.kafkush", "installation_id", installationID),
 							resource.TestCheckResourceAttr("port_integration.kafkush", "installation_app_type", installationAppType),
 						),
 					},


### PR DESCRIPTION
# Description
Hardcoded `installation_id` values in `TestPortIntegrationValidIdentifier` collided in the shared CI org, causing `integration_installed` failures. Generate unique IDs per subtest and move regex edge-case checks to a unit test

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)