### PR TITLE
feat: support items on array calculation properties (internal mirror of #442)

### DIFF
--- a/docs/resources/blueprint.md
+++ b/docs/resources/blueprint.md
@@ -321,9 +321,19 @@ Optional:
 - `description` (String) The description of the calculation property
 - `format` (String) The format of the calculation property
 - `icon` (String) The icon of the calculation property
+- `items` (Attributes) The items of an `array` calculation property (see [below for nested schema](#nestedatt--calculation_properties--items))
 - `spec` (String) The spec of the calculation property
 - `spec_authentication` (Attributes) The spec authentication of the calculation property (see [below for nested schema](#nestedatt--calculation_properties--spec_authentication))
 - `title` (String) The title of the calculation property
+
+<a id="nestedatt--calculation_properties--items"></a>
+### Nested Schema for `calculation_properties.items`
+
+Optional:
+
+- `format` (String) The format of the items
+- `type` (String) The type of the items
+
 
 <a id="nestedatt--calculation_properties--spec_authentication"></a>
 ### Nested Schema for `calculation_properties.spec_authentication`

--- a/docs/resources/system_blueprint.md
+++ b/docs/resources/system_blueprint.md
@@ -47,9 +47,19 @@ Optional:
 - `description` (String) The description of the calculation property
 - `format` (String) The format of the calculation property
 - `icon` (String) The icon of the calculation property
+- `items` (Attributes) The items of an `array` calculation property (see [below for nested schema](#nestedatt--calculation_properties--items))
 - `spec` (String) The spec of the calculation property
 - `spec_authentication` (Attributes) The spec authentication of the calculation property (see [below for nested schema](#nestedatt--calculation_properties--spec_authentication))
 - `title` (String) The title of the calculation property
+
+<a id="nestedatt--calculation_properties--items"></a>
+### Nested Schema for `calculation_properties.items`
+
+Optional:
+
+- `format` (String) The format of the items
+- `type` (String) The type of the items
+
 
 <a id="nestedatt--calculation_properties--spec_authentication"></a>
 ### Nested Schema for `calculation_properties.spec_authentication`

--- a/internal/cli/models.go
+++ b/internal/cli/models.go
@@ -195,19 +195,25 @@ func (dv DatasetValue) MarshalJSON() ([]byte, error) {
 
 type (
 	BlueprintCalculationProperty struct {
-		Type               string              `json:"type,omitempty"`
-		Title              *string             `json:"title,omitempty"`
-		Identifier         string              `json:"identifier,omitempty"`
-		Calculation        string              `json:"calculation,omitempty"`
-		Default            any                 `json:"default,omitempty"`
-		Icon               *string             `json:"icon,omitempty"`
-		Format             *string             `json:"format,omitempty"`
-		DateFormat         *string             `json:"dateFormat,omitempty"`
-		Description        *string             `json:"description,omitempty"`
-		Colorized          *bool               `json:"colorized,omitempty"`
-		Colors             map[string]string   `json:"colors,omitempty"`
-		Spec               *string             `json:"spec,omitempty"`
-		SpecAuthentication *SpecAuthentication `json:"specAuthentication,omitempty"`
+		Type               string                             `json:"type,omitempty"`
+		Title              *string                            `json:"title,omitempty"`
+		Identifier         string                             `json:"identifier,omitempty"`
+		Calculation        string                             `json:"calculation,omitempty"`
+		Items              *BlueprintCalculationPropertyItems `json:"items,omitempty"`
+		Default            any                                `json:"default,omitempty"`
+		Icon               *string                            `json:"icon,omitempty"`
+		Format             *string                            `json:"format,omitempty"`
+		DateFormat         *string                            `json:"dateFormat,omitempty"`
+		Description        *string                            `json:"description,omitempty"`
+		Colorized          *bool                              `json:"colorized,omitempty"`
+		Colors             map[string]string                  `json:"colors,omitempty"`
+		Spec               *string                            `json:"spec,omitempty"`
+		SpecAuthentication *SpecAuthentication                `json:"specAuthentication,omitempty"`
+	}
+
+	BlueprintCalculationPropertyItems struct {
+		Type   *string `json:"type,omitempty"`
+		Format *string `json:"format,omitempty"`
 	}
 
 	BlueprintAggregationProperty struct {

--- a/port/blueprint/model.go
+++ b/port/blueprint/model.go
@@ -126,6 +126,11 @@ type MirrorPropertyModel struct {
 	Path  types.String `tfsdk:"path"`
 }
 
+type CalculationItems struct {
+	Type   types.String `tfsdk:"type"`
+	Format types.String `tfsdk:"format"`
+}
+
 type CalculationPropertyModel struct {
 	Calculation        types.String             `tfsdk:"calculation"`
 	Title              types.String             `tfsdk:"title"`
@@ -138,6 +143,7 @@ type CalculationPropertyModel struct {
 	Colors             types.Map                `tfsdk:"colors"`
 	Spec               types.String             `tfsdk:"spec"`
 	SpecAuthentication *SpecAuthenticationModel `tfsdk:"spec_authentication"`
+	Items              *CalculationItems        `tfsdk:"items"`
 }
 
 type AverageEntitiesModel struct {

--- a/port/blueprint/readStateToPortBody.go
+++ b/port/blueprint/readStateToPortBody.go
@@ -158,6 +158,19 @@ func CalculationPropertiesToBody(ctx context.Context, state map[string]Calculati
 			calculationProp.SpecAuthentication = specAuth
 		}
 
+		if prop.Items != nil {
+			items := &cli.BlueprintCalculationPropertyItems{}
+			if !prop.Items.Type.IsNull() {
+				itemType := prop.Items.Type.ValueString()
+				items.Type = &itemType
+			}
+			if !prop.Items.Format.IsNull() {
+				itemFormat := prop.Items.Format.ValueString()
+				items.Format = &itemFormat
+			}
+			calculationProp.Items = items
+		}
+
 		calculationProperties[identifier] = calculationProp
 	}
 

--- a/port/blueprint/resource_test.go
+++ b/port/blueprint/resource_test.go
@@ -882,6 +882,15 @@ func TestAccPortBlueprintWithCalculationProperty(t *testing.T) {
 					"test4" = "yellow"
 				}
 			}
+			"links-for-microservice1" = {
+				title = "Links for microservice1"
+				calculation = "[.properties.text]"
+				type = "array"
+				items = {
+					type = "string"
+					format = "url"
+				}
+			}
 		}
 	}`, identifier1)
 
@@ -896,6 +905,9 @@ func TestAccPortBlueprintWithCalculationProperty(t *testing.T) {
 					resource.TestCheckResourceAttr("port_blueprint.microservice1", "calculation_properties.calculation-for-microservice1.calculation", "test-rel.$identifier"),
 					resource.TestCheckResourceAttr("port_blueprint.microservice1", "calculation_properties.calculation-for-microservice1.icon", "Terraform"),
 					resource.TestCheckResourceAttr("port_blueprint.microservice1", "calculation_properties.calculation-for-microservice1.colors.test2", "blue"),
+					resource.TestCheckResourceAttr("port_blueprint.microservice1", "calculation_properties.links-for-microservice1.type", "array"),
+					resource.TestCheckResourceAttr("port_blueprint.microservice1", "calculation_properties.links-for-microservice1.items.type", "string"),
+					resource.TestCheckResourceAttr("port_blueprint.microservice1", "calculation_properties.links-for-microservice1.items.format", "url"),
 				),
 			},
 		},

--- a/port/blueprint/schema.go
+++ b/port/blueprint/schema.go
@@ -537,6 +537,20 @@ func BlueprintSchema() map[string]schema.Attribute {
 							},
 						},
 					},
+					"items": schema.SingleNestedAttribute{
+						MarkdownDescription: "The items of an `array` calculation property",
+						Optional:            true,
+						Attributes: map[string]schema.Attribute{
+							"type": schema.StringAttribute{
+								MarkdownDescription: "The type of the items",
+								Optional:            true,
+							},
+							"format": schema.StringAttribute{
+								MarkdownDescription: "The format of the items",
+								Optional:            true,
+							},
+						},
+					},
 				},
 			},
 		},

--- a/port/blueprint/updatePropertiesToState.go
+++ b/port/blueprint/updatePropertiesToState.go
@@ -257,6 +257,13 @@ func addCalculationPropertiesToState(ctx context.Context, b *cli.Blueprint, bm *
 			}
 		}
 
+		if v.Items != nil {
+			calculationPropertyModel.Items = &CalculationItems{
+				Type:   flex.GoStringToFramework(v.Items.Type),
+				Format: flex.GoStringToFramework(v.Items.Format),
+			}
+		}
+
 		bm.CalculationProperties[k] = *calculationPropertyModel
 
 	}


### PR DESCRIPTION
Internal mirror of #442 (https://github.com/port-labs/terraform-provider-port-labs/pull/442) by @jorcar, opened from a repo branch (not a fork) so CI acceptance tests run with org secrets and give a real signal.

Original PR description:

## What

Adds the optional `items` block to `port_blueprint` calculation properties.

## Why

Port's API documents `items` on calculation properties, but the provider modelled 11 of the object's 12 keys. Since `PUT /v1/blueprints/{identifier}` replaces the whole document, applying a Terraform-managed blueprint silently deletes an existing `items` — an array of URLs stops rendering as links, with no error and a clean plan.

This branch contains the exact same feature commit (8186f99) cherry-picked as-is, with original authorship preserved. If CI passes here, merge #442 (or fast-forward main from this branch) and close this one.

Made with [Cursor](https://cursor.com)