### PR TITLE
fix CODEOWNERS not requiring correct team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,5 @@
+* @port-labs/builder-team
+
 /port/action/ @port-labs/workflows-team
 /port/action-permissions/ @port-labs/workflows-team
 /port/workflow/ @port-labs/workflows-team
@@ -12,5 +14,3 @@
 /port/scorecard_group/ @port-labs/spotlight-team
 
 /port/webhook/ @port-labs/lighthouse-team
-
-* @port-labs/builder-team


### PR DESCRIPTION
## Description
Reorder CODEOWNERS so specific team paths override the catch-all * rule. Fixes integration (and other scoped) paths incorrectly requiring only builder-team.

## Type of change

Please leave one option from the following and delete the rest:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)