### PR TITLE
fix: add CODEOWNERS overrides for docs/resources

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,5 @@
+* @port-labs/builder-team
+
 /port/action/ @port-labs/workflows-team
 /port/action-permissions/ @port-labs/workflows-team
 /port/workflow/ @port-labs/workflows-team
@@ -12,5 +14,3 @@
 /port/scorecard_group/ @port-labs/spotlight-team
 
 /port/webhook/ @port-labs/lighthouse-team
-
-* @port-labs/builder-team

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,3 +14,19 @@
 /port/scorecard_group/ @port-labs/spotlight-team
 
 /port/webhook/ @port-labs/lighthouse-team
+
+/docs/resources/action.md @port-labs/workflows-team
+/docs/resources/action_permissions.md @port-labs/workflows-team
+/docs/resources/workflow.md @port-labs/workflows-team
+
+/docs/resources/organization.md @port-labs/buildops
+/docs/resources/organization_secret.md @port-labs/buildops
+
+/docs/resources/integration.md @port-labs/connect-team
+
+/docs/resources/page.md @port-labs/spotlight-team
+/docs/resources/page_permissions.md @port-labs/spotlight-team
+/docs/resources/scorecard.md @port-labs/spotlight-team
+/docs/resources/scorecard_group.md @port-labs/spotlight-team
+
+/docs/resources/webhook.md @port-labs/lighthouse-team


### PR DESCRIPTION
# Description
Add docs/resources/ code owner rules matching the existing port/ team mappings so generated docs PRs request the right team reviews.

## Type of change

Please leave one option from the following and delete the rest:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Non-breaking change (fix of existing functionality that will not change current behavior)
- [ ] Documentation (added/updated documentation)