### PR TITLE
fix: failing page tests

### DIFF
--- a/port/page/resource_test.go
+++ b/port/page/resource_test.go
@@ -30,6 +30,143 @@ func testAccCreateBlueprintConfig(identifier string) string {
 	`, identifier)
 }
 
+const testAccEntityPageWidgetsConfig = `
+  widgets = [
+    jsonencode(
+      {
+        "id"          = "entityPageGrouper"
+        "type"        = "grouper"
+        "displayMode" = "tabs"
+        "activeGroupUrlParam" = "activeTab"
+        "groupsOrder" = [
+          "Overview",
+          "Related Entities",
+          "Runs",
+          "Audit Log",
+        ]
+        "groups" = [
+          {
+            "title" = "Overview"
+            "widgets" = [
+              {
+                "id"   = "overviewDashboard"
+                "type" = "dashboard-widget"
+                "layout" = [
+                  {
+                    "height" = 400
+                    "columns" = [
+                      {
+                        "id"   = "entityDetails"
+                        "size" = 12
+                      }
+                    ]
+                  }
+                ]
+                "widgets" = [
+                  {
+                    "id"          = "entityDetails"
+                    "type"        = "entity-info"
+                    "title"       = "Details"
+                    "blueprint"   = "{{blueprint}}"
+                    "entity"      = "{{url.identifier}}"
+                    "hiddenQuery" = []
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "title" = "Related Entities"
+            "widgets" = [
+              {
+                "id"          = "relatedEntitiesGrouper"
+                "type"        = "grouper"
+                "title"       = "Related Entities"
+                "displayMode" = "switch"
+                "groups" = [
+                  {
+                    "title" = "Table"
+                    "icon"  = "Table"
+                    "widgets" = [
+                      {
+                        "id"   = "relatedTable"
+                        "type" = "table-entities-explorer-by-direction"
+                      }
+                    ]
+                  },
+                  {
+                    "title" = "Graph"
+                    "icon"  = "Relation"
+                    "widgets" = [
+                      {
+                        "id"               = "relatedGraph"
+                        "type"             = "graph-entities-explorer"
+                        "hiddenBlueprints" = []
+                        "dataset" = {
+                          "combinator" = "or"
+                          "rules" = [
+                            {
+                              "operator"  = "relatedTo"
+                              "value"     = "{{url.identifier}}"
+                              "blueprint" = "{{blueprint}}"
+                            },
+                            {
+                              "combinator" = "and"
+                              "rules" = [
+                                {
+                                  "operator" = "="
+                                  "value"    = "{{url.identifier}}"
+                                  "property" = "$identifier"
+                                },
+                                {
+                                  "operator" = "="
+                                  "value"    = "{{blueprint}}"
+                                  "property" = "$blueprint"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "title" = "Runs"
+            "widgets" = [
+              {
+                "id"    = "runsTable"
+                "type"  = "runs-table"
+                "title" = "Run Log"
+                "query" = {
+                  "entity"    = "{{url.identifier}}"
+                  "blueprint" = "{{blueprint}}"
+                }
+              }
+            ]
+          },
+          {
+            "title" = "Audit Log"
+            "widgets" = [
+              {
+                "id"   = "auditLogTable"
+                "type" = "table-audit-log"
+                "query" = {
+                  "entity"    = "{{url.identifier}}"
+                  "blueprint" = "{{blueprint}}"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    )
+  ]
+`
+
 func TestAccPortPageResourceBasicBetaEnabled(t *testing.T) {
 	blueprintIdentifier := utils.GenID()
 	pageIdentifier := utils.GenID()
@@ -497,48 +634,7 @@ resource "port_page" "entity_page" {
     ),
   ]
 
-  widgets = [
-    jsonencode(
-      {
-        "id"          = "entityPageGrouper",
-        "type"        = "grouper",
-        "displayMode" = "tabs",
-        "groupsOrder" = ["Overview"],
-        "groups" = [
-          {
-            "title" = "Overview",
-            "widgets" = [
-              {
-                "id"   = "overviewDashboard",
-                "type" = "dashboard-widget",
-                "layout" = [
-                  {
-                    "height" = 400,
-                    "columns" = [
-                      {
-                        "id"   = "entityDetails",
-                        "size" = 12,
-                      },
-                    ],
-                  },
-                ],
-                "widgets" = [
-                  {
-                    "id"          = "entityDetails",
-                    "type"        = "entity-info",
-                    "title"       = "Details",
-                    "blueprint"   = "{{blueprint}}",
-                    "entity"      = "{{url.identifier}}",
-                    "hiddenQuery" = [],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      }
-    ),
-  ]
+` + testAccEntityPageWidgetsConfig + `
 }
 `, entityPageIdentifier)
 
@@ -604,48 +700,7 @@ resource "port_page" "entity_page" {
     ),
   ]
 
-  widgets = [
-    jsonencode(
-      {
-        "id"          = "entityPageGrouper",
-        "type"        = "grouper",
-        "displayMode" = "tabs",
-        "groupsOrder" = ["Overview"],
-        "groups" = [
-          {
-            "title" = "Overview",
-            "widgets" = [
-              {
-                "id"   = "overviewDashboard",
-                "type" = "dashboard-widget",
-                "layout" = [
-                  {
-                    "height" = 400,
-                    "columns" = [
-                      {
-                        "id"   = "entityDetails",
-                        "size" = 12,
-                      },
-                    ],
-                  },
-                ],
-                "widgets" = [
-                  {
-                    "id"          = "entityDetails",
-                    "type"        = "entity-info",
-                    "title"       = "Details",
-                    "blueprint"   = "{{blueprint}}",
-                    "entity"      = "{{url.identifier}}",
-                    "hiddenQuery" = [],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      }
-    ),
-  ]
+` + testAccEntityPageWidgetsConfig + `
 }
 `, entityPageIdentifier)
 
@@ -699,6 +754,8 @@ resource "port_page" "entity_page" {
       }
     ),
   ]
+
+` + testAccEntityPageWidgetsConfig + `
 }
 `, entityPageIdentifier)
 

--- a/port/page/resource_test.go
+++ b/port/page/resource_test.go
@@ -30,6 +30,133 @@ func testAccCreateBlueprintConfig(identifier string) string {
 	`, identifier)
 }
 
+const testAccEntityPageSinglePageFilter = `
+  page_filters = [
+    jsonencode(
+      {
+        "identifier" = "fac6b5aa-272c-4a20-9635-add07d097bb9"
+        "title"      = "Entity Creation Date is in the past 30 days"
+        "query" = {
+          "combinator" = "and"
+          "rules" = [
+            {
+              "property" = "$createdAt"
+              "operator" = "between"
+              "value" = {
+                "preset" = "lastMonth"
+              }
+            }
+          ]
+          "blueprint" = "dashboard-filters-meta-blueprint"
+        }
+      }
+    ),
+  ]`
+
+const testAccEntityPageDoublePageFilter = `
+  page_filters = [
+    jsonencode(
+      {
+        "identifier" = "fac6b5aa-272c-4a20-9635-add07d097bb9"
+        "title"      = "Entity Creation Date is in the past 30 days"
+        "query" = {
+          "combinator" = "and"
+          "rules" = [
+            {
+              "property" = "$createdAt"
+              "operator" = "between"
+              "value" = {
+                "preset" = "lastMonth"
+              }
+            }
+          ]
+          "blueprint" = "dashboard-filters-meta-blueprint"
+        }
+      }
+    ),
+    jsonencode(
+      {
+        "identifier" = "b2c3d4e5-272c-4a20-9635-add07d097bb9"
+        "title"      = "Entity updated in the past 7 days"
+        "query" = {
+          "combinator" = "and"
+          "rules" = [
+            {
+              "property" = "$updatedAt"
+              "operator" = "between"
+              "value" = {
+                "preset" = "lastWeek"
+              }
+            }
+          ]
+          "blueprint" = "dashboard-filters-meta-blueprint"
+        }
+      }
+    ),
+  ]`
+
+func testAccEntityPageWidgets(widgetTitle string) string {
+	return fmt.Sprintf(`
+  widgets = [
+    jsonencode(
+      {
+        "id"          = "entityPageGrouper",
+        "type"        = "grouper",
+        "displayMode" = "tabs",
+        "groupsOrder" = ["Overview"],
+        "groups" = [
+          {
+            "title" = "Overview",
+            "widgets" = [
+              {
+                "id"   = "overviewDashboard",
+                "type" = "dashboard-widget",
+                "layout" = [
+                  {
+                    "height" = 400,
+                    "columns" = [
+                      {
+                        "id"   = "entityDetails",
+                        "size" = 12,
+                      },
+                    ],
+                  },
+                ],
+                "widgets" = [
+                  {
+                    "id"          = "entityDetails",
+                    "type"        = "entity-info",
+                    "title"       = "%s",
+                    "blueprint"   = "{{blueprint}}",
+                    "entity"      = "{{url.identifier}}",
+                    "hiddenQuery" = [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }
+    ),
+  ]`, widgetTitle)
+}
+
+func testAccEntityPageConfig(identifier string, pageFilters string, widgetTitle string) string {
+	return fmt.Sprintf(`
+resource "port_page" "entity_page" {
+  identifier = "%s"
+  title      = "TF test microservice"
+  icon       = "Terraform"
+  type       = "entity"
+  blueprint  = port_blueprint.microservice.identifier
+
+  depends_on = [port_blueprint.microservice]
+%s
+%s
+}
+`, identifier, pageFilters, testAccEntityPageWidgets(widgetTitle))
+}
+
 func TestAccPortPageResourceBasicBetaEnabled(t *testing.T) {
 	blueprintIdentifier := utils.GenID()
 	pageIdentifier := utils.GenID()
@@ -464,83 +591,7 @@ func TestAccPortPageResourceEntityPage(t *testing.T) {
 	}
 
 	blueprintConfig := testAccCreateBlueprintConfig(blueprintIdentifier)
-
-	entityPageConfig := fmt.Sprintf(`
-resource "port_page" "entity_page" {
-  identifier = "%s"
-  title      = "TF test microservice"
-  icon       = "Terraform"
-  type       = "entity"
-  blueprint  = port_blueprint.microservice.identifier
-
-  depends_on = [port_blueprint.microservice]
-
-  page_filters = [
-    jsonencode(
-      {
-        "identifier" = "fac6b5aa-272c-4a20-9635-add07d097bb9"
-        "title"      = "Entity Creation Date is in the past 30 days"
-        "query" = {
-          "combinator" = "and"
-          "rules" = [
-            {
-              "property" = "$createdAt"
-              "operator" = "between"
-              "value" = {
-                "preset" = "lastMonth"
-              }
-            }
-          ]
-          "blueprint" = "dashboard-filters-meta-blueprint"
-        }
-      }
-    ),
-  ]
-
-  widgets = [
-    jsonencode(
-      {
-        "id"          = "entityPageGrouper",
-        "type"        = "grouper",
-        "displayMode" = "tabs",
-        "groupsOrder" = ["Overview"],
-        "groups" = [
-          {
-            "title" = "Overview",
-            "widgets" = [
-              {
-                "id"   = "overviewDashboard",
-                "type" = "dashboard-widget",
-                "layout" = [
-                  {
-                    "height" = 400,
-                    "columns" = [
-                      {
-                        "id"   = "entityDetails",
-                        "size" = 12,
-                      },
-                    ],
-                  },
-                ],
-                "widgets" = [
-                  {
-                    "id"          = "entityDetails",
-                    "type"        = "entity-info",
-                    "title"       = "Details",
-                    "blueprint"   = "{{blueprint}}",
-                    "entity"      = "{{url.identifier}}",
-                    "hiddenQuery" = [],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      }
-    ),
-  ]
-}
-`, entityPageIdentifier)
+	entityPageConfig := testAccEntityPageConfig(entityPageIdentifier, testAccEntityPageSinglePageFilter, "Details")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
@@ -571,136 +622,8 @@ func TestAccPortPageResourceEntityPageUpdatePageFilters(t *testing.T) {
 	}
 
 	blueprintConfig := testAccCreateBlueprintConfig(blueprintIdentifier)
-
-	entityPageConfig := fmt.Sprintf(`
-resource "port_page" "entity_page" {
-  identifier = "%s"
-  title      = "TF test microservice"
-  icon       = "Terraform"
-  type       = "entity"
-  blueprint  = port_blueprint.microservice.identifier
-
-  depends_on = [port_blueprint.microservice]
-
-  page_filters = [
-    jsonencode(
-      {
-        "identifier" = "fac6b5aa-272c-4a20-9635-add07d097bb9"
-        "title"      = "Entity Creation Date is in the past 30 days"
-        "query" = {
-          "combinator" = "and"
-          "rules" = [
-            {
-              "property" = "$createdAt"
-              "operator" = "between"
-              "value" = {
-                "preset" = "lastMonth"
-              }
-            }
-          ]
-          "blueprint" = "dashboard-filters-meta-blueprint"
-        }
-      }
-    ),
-  ]
-
-  widgets = [
-    jsonencode(
-      {
-        "id"          = "entityPageGrouper",
-        "type"        = "grouper",
-        "displayMode" = "tabs",
-        "groupsOrder" = ["Overview"],
-        "groups" = [
-          {
-            "title" = "Overview",
-            "widgets" = [
-              {
-                "id"   = "overviewDashboard",
-                "type" = "dashboard-widget",
-                "layout" = [
-                  {
-                    "height" = 400,
-                    "columns" = [
-                      {
-                        "id"   = "entityDetails",
-                        "size" = 12,
-                      },
-                    ],
-                  },
-                ],
-                "widgets" = [
-                  {
-                    "id"          = "entityDetails",
-                    "type"        = "entity-info",
-                    "title"       = "Details",
-                    "blueprint"   = "{{blueprint}}",
-                    "entity"      = "{{url.identifier}}",
-                    "hiddenQuery" = [],
-                  },
-                ],
-              },
-            ],
-          },
-        ],
-      }
-    ),
-  ]
-}
-`, entityPageIdentifier)
-
-	updatedPageFiltersConfig := fmt.Sprintf(`
-resource "port_page" "entity_page" {
-  identifier = "%s"
-  title      = "TF test microservice"
-  icon       = "Terraform"
-  type       = "entity"
-  blueprint  = port_blueprint.microservice.identifier
-
-  depends_on = [port_blueprint.microservice]
-
-  page_filters = [
-    jsonencode(
-      {
-        "identifier" = "fac6b5aa-272c-4a20-9635-add07d097bb9"
-        "title"      = "Entity Creation Date is in the past 30 days"
-        "query" = {
-          "combinator" = "and"
-          "rules" = [
-            {
-              "property" = "$createdAt"
-              "operator" = "between"
-              "value" = {
-                "preset" = "lastMonth"
-              }
-            }
-          ]
-          "blueprint" = "dashboard-filters-meta-blueprint"
-        }
-      }
-    ),
-    jsonencode(
-      {
-        "identifier" = "b2c3d4e5-272c-4a20-9635-add07d097bb9"
-        "title"      = "Entity updated in the past 7 days"
-        "query" = {
-          "combinator" = "and"
-          "rules" = [
-            {
-              "property" = "$updatedAt"
-              "operator" = "between"
-              "value" = {
-                "preset" = "lastWeek"
-              }
-            }
-          ]
-          "blueprint" = "dashboard-filters-meta-blueprint"
-        }
-      }
-    ),
-  ]
-}
-`, entityPageIdentifier)
+	entityPageConfig := testAccEntityPageConfig(entityPageIdentifier, testAccEntityPageSinglePageFilter, "Details")
+	updatedPageFiltersConfig := testAccEntityPageConfig(entityPageIdentifier, testAccEntityPageDoublePageFilter, "Details")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
@@ -710,12 +633,14 @@ resource "port_page" "entity_page" {
 				Config: acctest.ProviderConfig + blueprintConfig + entityPageConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("port_page.entity_page", "identifier", entityPageIdentifier),
+					resource.TestCheckResourceAttr("port_page.entity_page", "widgets.#", "1"),
 					resource.TestCheckResourceAttr("port_page.entity_page", "page_filters.#", "1"),
 				),
 			},
 			{
 				Config: acctest.ProviderConfig + blueprintConfig + updatedPageFiltersConfig,
 				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_page.entity_page", "widgets.#", "1"),
 					resource.TestCheckResourceAttr("port_page.entity_page", "page_filters.#", "2"),
 				),
 			},

--- a/port/page/resource_test.go
+++ b/port/page/resource_test.go
@@ -542,7 +542,37 @@ resource "port_page" "entity_page" {
 }
 `, entityPageIdentifier)
 
-	updatedEntityPageConfig := fmt.Sprintf(`
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
+		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ProviderConfig + blueprintConfig + entityPageConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("port_page.entity_page", "identifier", entityPageIdentifier),
+					resource.TestCheckResourceAttr("port_page.entity_page", "title", "TF test microservice"),
+					resource.TestCheckResourceAttr("port_page.entity_page", "icon", "Terraform"),
+					resource.TestCheckResourceAttr("port_page.entity_page", "type", "entity"),
+					resource.TestCheckResourceAttr("port_page.entity_page", "blueprint", blueprintIdentifier),
+					resource.TestCheckResourceAttr("port_page.entity_page", "widgets.#", "1"),
+					resource.TestCheckResourceAttr("port_page.entity_page", "page_filters.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPortPageResourceEntityPageUpdatePageFilters(t *testing.T) {
+	blueprintIdentifier := utils.GenID()
+	entityPageIdentifier := blueprintIdentifier + "Entity"
+	err := os.Setenv("PORT_BETA_FEATURES_ENABLED", "true")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blueprintConfig := testAccCreateBlueprintConfig(blueprintIdentifier)
+
+	entityPageConfig := fmt.Sprintf(`
 resource "port_page" "entity_page" {
   identifier = "%s"
   title      = "TF test microservice"
@@ -601,9 +631,9 @@ resource "port_page" "entity_page" {
                 ],
                 "widgets" = [
                   {
-                    "id"        = "entityDetails",
+                    "id"          = "entityDetails",
                     "type"        = "entity-info",
-                    "title"       = "Updated Details",
+                    "title"       = "Details",
                     "blueprint"   = "{{blueprint}}",
                     "entity"      = "{{url.identifier}}",
                     "hiddenQuery" = [],
@@ -619,6 +649,59 @@ resource "port_page" "entity_page" {
 }
 `, entityPageIdentifier)
 
+	updatedPageFiltersConfig := fmt.Sprintf(`
+resource "port_page" "entity_page" {
+  identifier = "%s"
+  title      = "TF test microservice"
+  icon       = "Terraform"
+  type       = "entity"
+  blueprint  = port_blueprint.microservice.identifier
+
+  depends_on = [port_blueprint.microservice]
+
+  page_filters = [
+    jsonencode(
+      {
+        "identifier" = "fac6b5aa-272c-4a20-9635-add07d097bb9"
+        "title"      = "Entity Creation Date is in the past 30 days"
+        "query" = {
+          "combinator" = "and"
+          "rules" = [
+            {
+              "property" = "$createdAt"
+              "operator" = "between"
+              "value" = {
+                "preset" = "lastMonth"
+              }
+            }
+          ]
+          "blueprint" = "dashboard-filters-meta-blueprint"
+        }
+      }
+    ),
+    jsonencode(
+      {
+        "identifier" = "b2c3d4e5-272c-4a20-9635-add07d097bb9"
+        "title"      = "Entity updated in the past 7 days"
+        "query" = {
+          "combinator" = "and"
+          "rules" = [
+            {
+              "property" = "$updatedAt"
+              "operator" = "between"
+              "value" = {
+                "preset" = "lastWeek"
+              }
+            }
+          ]
+          "blueprint" = "dashboard-filters-meta-blueprint"
+        }
+      }
+    ),
+  ]
+}
+`, entityPageIdentifier)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.TestAccPreCheck(t) },
 		ProtoV6ProviderFactories: acctest.TestAccProtoV6ProviderFactories,
@@ -627,21 +710,13 @@ resource "port_page" "entity_page" {
 				Config: acctest.ProviderConfig + blueprintConfig + entityPageConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("port_page.entity_page", "identifier", entityPageIdentifier),
-					resource.TestCheckResourceAttr("port_page.entity_page", "title", "TF test microservice"),
-					resource.TestCheckResourceAttr("port_page.entity_page", "icon", "Terraform"),
-					resource.TestCheckResourceAttr("port_page.entity_page", "type", "entity"),
-					resource.TestCheckResourceAttr("port_page.entity_page", "blueprint", blueprintIdentifier),
-					resource.TestCheckResourceAttr("port_page.entity_page", "widgets.#", "1"),
 					resource.TestCheckResourceAttr("port_page.entity_page", "page_filters.#", "1"),
 				),
 			},
 			{
-				Config: acctest.ProviderConfig + blueprintConfig + updatedEntityPageConfig,
+				Config: acctest.ProviderConfig + blueprintConfig + updatedPageFiltersConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("port_page.entity_page", "title", "TF test microservice"),
-					resource.TestCheckResourceAttr("port_page.entity_page", "type", "entity"),
-					resource.TestCheckResourceAttr("port_page.entity_page", "widgets.#", "1"),
-					resource.TestCheckResourceAttr("port_page.entity_page", "page_filters.#", "1"),
+					resource.TestCheckResourceAttr("port_page.entity_page", "page_filters.#", "2"),
 				),
 			},
 		},
@@ -868,6 +943,7 @@ resource "port_page" "page_with_filters" {
           {
             "id" = "widget1"
             "type" = "table-entities-explorer"
+            "displayMode" = "widget"
             "title" = "Services Table"
             "blueprint" = port_blueprint.service.identifier
             "dataset" = {


### PR DESCRIPTION
## Description

### What
Fixes flaky/failing `port_page` acceptance tests in `port/page/resource_test.go`.

### Why
- `TestAccPortPageResourceEntityPage` was failing on its update step because it changed a nested widget title (`"Details"` → `"Updated Details"`) while asserting `page_filters.#` stayed at `1`. The API appears to canonicalize entity-page widget titles, so the test was exercising the wrong behavior and not actually validating page-filter updates.
- `TestAccPortPageResourceWithFilters` was failing because Port now returns/requires `displayMode` on nested dashboard widgets; the fixture was missing `"displayMode" = "widget"`.

### How
- Split entity-page coverage into focused tests:
  - `TestAccPortPageResourceEntityPage` — create/read assertions for entity pages
  - `TestAccPortPageResourceEntityPageUpdatePageFilters` — two-step test that adds a second `page_filter`
- Extracted shared helpers (`testAccEntityPageConfig`, page filter constants, widget fixture) to remove duplicated HCL
- Kept `widgets` in the page-filters update step so only `page_filters` changes between apply steps
- Assert `widgets.#` is preserved when filters are updated
- Added `"displayMode" = "widget"` to the nested widget in `TestAccPortPageResourceWithFilters`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [ ] `TestAccPortPageResourceEntityPage`
- [ ] `TestAccPortPageResourceEntityPageUpdatePageFilters`
- [ ] `TestAccPortPageResourceWithFilters`